### PR TITLE
fixes to the PTP1B pipeline notebook

### DIFF
--- a/notebooks/pipeline.ipynb
+++ b/notebooks/pipeline.ipynb
@@ -23,12 +23,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "545740fa-2eeb-46e3-b7bf-395ec6ee30d7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/n/hekstra_lab/people/dhekstra/conda_envs/valdo-gpu/lib/python3.10/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.17.3 and <1.25.0 is required for this version of SciPy (detected version 1.25.2\n",
+      "  warnings.warn(f\"A NumPy version >={np_minversion} and <{np_maxversion}\"\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "done with imports.\n"
+     ]
+    }
+   ],
    "source": [
-    "#this may take 20-30 seconds\n",
+    "#this may take a minute\n",
     "import torch\n",
     "import glob\n",
     "import re\n",
@@ -56,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "ca04ea52-52d3-4cd6-9cde-984566c97493",
    "metadata": {},
    "outputs": [],
@@ -66,10 +82,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "cf2f6e18-0fb8-41ba-8c01-558585d91b86",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We will use GPU for torch operations (esp. VAE training).\n",
+      "There are 24 CPUs available.\n",
+      "For multiprocessing, we will use 23 CPUs.\n"
+     ]
+    }
+   ],
    "source": [
     "bGPU, ncpu=valdo.helper.configure_session()"
    ]
@@ -84,48 +110,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "05aa7480-58eb-45d6-bf37-79f03c2d3491",
    "metadata": {},
    "outputs": [],
    "source": [
     "random_seed       = 11231        # random seed for PyTorch and subsampling data (if any) \n",
-    "run_prefix        = \"run_20_\" + str(random_seed) + \"_\"\n",
+    "run_prefix        = \"run_23_\" + str(random_seed) + \"_\"\n",
     "\n",
     "# filtering input to MTZ\n",
     "ref_mtz           = '0001'       # use a high-quality dataset as reference\n",
     "mtzs_to_ignore    = []           # MTZs to disregard\n",
     "filter_by_Rfree   = True         # whether to filter out datasets for which refinement was poor (before scaling)\n",
-    "max_R_factor      = 0.4          # Worst apo refinement Rfree-factor to keep. otherwise discarded.\n",
+    "max_R_factor      = 0.45         # Worst apo refinement Rfree-factor to keep. otherwise discarded.\n",
     "filter_by_cc      = True         # whether to filter out datasets fwith poor correlation with the reference (after scaling)\n",
-    "min_cc_ref        = 0.6          # minimum correlation with the reference\n",
+    "min_cc_ref        = 0.55         # minimum correlation with the reference\n",
     "\n",
     "# for sorting out indexing ambiguity\n",
     "cc_min_dif        = 0.2          # min correlation difference to determine better reindex operation. otherwise carry through both solutions\n",
     "\n",
+    "# enable numerical optimization of scales\n",
+    "num_opt_scales    = True\n",
+    "\n",
     "# VAE (most settings hardcoded below)\n",
     "fraction          = 1.0          # fraction of datasets to work with (default: 1.0)\n",
-    "train_fraction    = 0.9          # fraction of working datasets used for training (sensible default: 0.8)\n",
+    "train_fraction    = 0.8          # fraction of working datasets used for training (sensible default: 0.8)\n",
     "latent_dim        = 7            # VAE latent space dimension (sensible default: 7)\n",
-    "epochs            = 300          # Number of VAE training epochs (sensible default: 500)\n",
+    "epochs            = 500          # Number of VAE training epochs (sensible default: 500)\n",
     "include_errors    = True         # whether to use SIGFs in the VAE loss function (sensible default: True)\n",
     "stdof             = 128          # DOF for student t (None -> normal dist); only used when include_errors=True\n",
     "eps               = 0.02         # the smaller eps (>=0), the more strongly estimated errors are taken into account (sensible default: 0.01)\n",
     "\n",
     "# difference maps\n",
-    "ml_recon          = True        # Whether to use the ML reconstruction from the VAE rather than a sample (default: False)\n",
+    "ml_recon          = True         # Whether to use the ML reconstruction from the VAE rather than samples (default: False)\n",
     "vae_samples       = 1            # number of samples to draw from the VAE during reconstruction (sensible default: 1), the variation is usually negligible\n",
     "w_pcts            = (95.0,99.99) # percentiles on sigDF and DelDF used in weights calc (sensible default: 95.00, 99.99)\n",
     "low_res_cutoff    = 1000.        # cutoff in A specifying what low-res reflections to keep (prob not helpful! sensible def: 1000.0)\n",
     "\n",
     "# blob finding\n",
     "blob_sig_cutoff   = 3.5          # cutoff for blob search (our default: 3.5)\n",
-    "radius_in_A       = 4.0          # radius (in A) of the gaussian smoothing kernel; 3x the sigma (default: 5)"
+    "radius_in_A       = 4.0          # radius (in A) of the gaussian smoothing kernel; 3x the sigma (default: 5)\n",
+    "\n",
+    "settings = {\"random_seed\": random_seed, \"run_prefix\": run_prefix, \"ref_mtz\": ref_mtz, \"mtzs_to_ignore\": mtzs_to_ignore, \\\n",
+    "            \"filter_by_Rfree\":filter_by_Rfree, \"max_R_factor\":max_R_factor, \"filter_by_cc\":filter_by_cc, \"min_cc_ref\":min_cc_ref,\"cc_min_dif\":cc_min_dif,\\\n",
+    "            \"fraction\":fraction, \"train_fraction\":train_fraction, \"latent_dim\":latent_dim, \"epochs\":epochs, \"include_errors\":include_errors,\\\n",
+    "            \"stdof\":stdof, \"eps\":eps,\"ml_recon\":ml_recon, \"vae_samples\":vae_samples, \"w_pcts\":w_pcts, \"low_res_cutoff\":low_res_cutoff,\\\n",
+    "            \"blob_sig_cutoff\":blob_sig_cutoff,\"radius_in_A\":radius_in_A}\n",
+    "\n",
+    "with open(run_prefix+'settings.pickle', 'wb') as handle:\n",
+    "    pickle.dump(settings, handle, protocol=pickle.HIGHEST_PROTOCOL)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "63960f66-3a1f-445f-8553-931157ad1144",
    "metadata": {},
    "outputs": [],
@@ -148,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "b3303685-7006-4327-a960-eee685d21202",
    "metadata": {},
    "outputs": [],
@@ -159,19 +197,22 @@
     "\n",
     "# keep the logs and pdb files in the same directory, e.g. with names xxxx.pdb, xxxx.mtz, and xxxx.log\n",
     "refinement_paths=[\"/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline_run16/vae/reconstructed/full_recon/refine/short_names/\",\n",
-    "                  \"/n/holyscratch01/hekstra_lab/dhekstra/phyllis/PTP1B_DK/pandda_input_models_refined_waters/short/\", \n",
+    "                  \"/n/holyscratch01/hekstra_lab/dhekstra/phyllis/PTP1B_DK/pandda_input_models_refined_waters/short/\", # we have these refinements, but not the \"short\" versions (lost on scratch)\n",
     "                  \"/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/\", # contains refinements for both indexing solutions\n",
-    "                  \"/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/refine/dimple_round_1/\"]\n",
+    "                  \"/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/refine/dimple_round_1/\",\n",
+    "                 \"/net/holy-nfsisilon/ifs/rc_labs/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refine_v2/refine_output/\"]\n",
     "\n",
     "refinement_phases = [(\"PH2FOFCWT\",\"PHFOFCWT\"),\\\n",
     "                     (\"PHIF-model\",\"PHFOFCWT\"),\\\n",
-    "                     (\"PH2FOFCWT\",\"PHFOFCWT\"),\\\n",
-    "                     (\"PHIC_ALL\",\"PHDELWT\")\\\n",
+    "                     (\"PHIF-model\",\"PHFOFCWT\"),\\\n",
+    "                     (\"PHIC_ALL\",\"PHDELWT\"),\\\n",
+    "                     (\"PHIF-model\",\"PHFOFCWT\")\\\n",
     "                        ]\n",
     "# PHENIX phase options: PHIF-model, PHFC, PH2FOFCWT, PHFOFCWT (0,1)\n",
     "# dimple phase options: PHIC, PHIC_ALL, PHWT, PHIC_ALL_LS (3)\n",
+    "# note: refinement_paths[4] is probably NOT suitable for re-indexing datasets.\n",
     "\n",
-    "def apo_phases_parser_default(file): # for 0,2\n",
+    "def apo_phases_parser_default(file): # for 0,2,4\n",
     "    return os.path.basename(file)\n",
     "\n",
     "def apo_phases_parser_4digit(file): # for 1\n",
@@ -180,22 +221,33 @@
     "def apo_phases_parser_dimple(file): # for 3\n",
     "    return \"dimple_\"+os.path.basename(file)[0:4]+\"/final.mtz\"\n",
     "\n",
+    "def apo_phases_parser_mhl(file):\n",
+    "    # will prompt loader to try to load either indexing solution\n",
+    "    mtz_list = [\"refine_\" + os.path.basename(file)[0:4] + \"_0_001.mtz\", \n",
+    "                \"refine_\" + os.path.basename(file)[0:4] + \"_1_001.mtz\"]\n",
+    "    return mtz_list\n",
+    "    \n",
+    "apo_phases_parser = apo_phases_parser_default\n",
     "\n",
-    "apo_phases_parser = apo_phases_parser_dimple\n",
-    "\n",
-    "which_phases = 3\n",
-    "refined_path = refinement_paths[ 2] # keep at 2; used for indexing disambiguation; \n",
+    "which_phases = 2                              # using 2 provides the simplest example of indexing disamb\n",
+    "refined_path = refinement_paths[ 2]           # keep at 2\n",
     "phasing_path = refinement_paths[which_phases] # used for phasing of difference maps; could be the same as refined_path\n",
     "\n",
     "phase_2FOFC_col_in  = refinement_phases[which_phases][0]\n",
     "phase_FOFC_col_in   = refinement_phases[which_phases][1]\n",
     "phase_2FOFC_col_out = 'refine_PH2FOFCWT'\n",
-    "phase_FOFC_col_out  = 'refine_PHFOFCWT'"
+    "phase_FOFC_col_out  = 'refine_PHFOFCWT'\n",
+    "\n",
+    "pdb_settings = {\"refined_path\": refined_path, \"phasing_path\": phasing_path, \\\n",
+    "                \"phase_2FOFC_col_in\": phase_2FOFC_col_in, \"phase_FOFC_col_in\": phase_FOFC_col_in}\n",
+    "\n",
+    "with open(run_prefix+'phases_settings.pickle', 'wb') as handle:\n",
+    "    pickle.dump(settings, handle, protocol=pickle.HIGHEST_PROTOCOL)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a3ccfb47-528c-4fa1-b63a-0c23bfcb9376",
    "metadata": {},
    "outputs": [],
@@ -224,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "f812a13a-8f28-4be4-b0ec-c6cdd0c46525",
    "metadata": {},
    "outputs": [],
@@ -253,10 +305,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "fde0b36a-5565-4a48-860f-9752aa10b8c9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/                           already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/                      already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_origin/          already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/         already exists\n",
+      "/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/      already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_scaled/          already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/                       already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/reconstructed/         already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/reconstructed_w_phases/      already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/blobs/                 already exists\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/bound_models_reindexed/      already exists\n"
+     ]
+    }
+   ],
    "source": [
     "# Make paths\n",
     "dir_hierarchy=[basepath, data_path, input_mtz_path, reindexed_path, refined_path, scaled_path, vae_path, vae_reconstructed_path, \\\n",
@@ -273,7 +343,6 @@
    "cell_type": "markdown",
    "id": "7e101699-3d69-4bca-9033-1736845da4f7",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -307,8 +376,6 @@
     "\n",
     "2. Organize the datasets with sequential numerical names (e.g., `0001.mtz`, `0002.mtz`, etc.). You can do so using the following cell.\n",
     "\n",
-    "3. If you have bound-state models already and you want to benchmark against those in Step 9 below, also run the cell `Application to bound state models (for Step 9)`. \n",
-    "\n",
     "Following this naming convention will allow datasets to be ready for further processing."
    ]
   },
@@ -337,24 +404,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "c2574860-1cb6-4935-b0d9-1433a20e8852",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Copying & renaming 1679 MTZ files from /n/hekstra_lab/people/minhuan/projects/drug/phyllis_backup/pipeline/data/original_data/ to /n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_origin/\n",
+      "\n",
+      "Created 1679 standardized MTZ files using the following pattern:.*(\\d{4}).*.mtz.\n",
+      "CPU times: user 30.3 ms, sys: 112 ms, total: 143 ms\n",
+      "Wall time: 22.7 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "new_mtzs=valdo.helper.standardize_input_mtzs(source_path=original_data_path, \n",
     "                       destination_path=input_mtz_path, \n",
     "                       mtz_file_pattern=mtz_file_pattern, \n",
     "                       ncpu=ncpu)\n",
-    "print(\"\\nCreated \" + str(len(new_mtzs)) + \" standardized MTZ files.\")"
+    "print(\"\\nCreated \" + str(len(new_mtzs)) + \" standardized MTZ files using the following pattern:\" + mtz_file_pattern + \".\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "abd88a92-9666-43e3-a1dc-e685bba103a2",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -366,7 +444,7 @@
    "id": "039e036e-c6c0-4283-a5f6-eef58a8dd678",
    "metadata": {},
    "source": [
-    "This step focuses on reindexing, automatic refinement and scaling a list of input MTZ files to a reference MTZ file using gemmi. "
+    "This step focuses on reindexing of the diffraction data in the input MTZs, automatic refinement of models against the data, and scaling of the input MTZ files to a reference MTZ file using gemmi. "
    ]
   },
   {
@@ -374,11 +452,13 @@
    "id": "0945eb2d-c9a7-481a-b162-712d1cafbd09",
    "metadata": {},
    "source": [
-    "**Reindexing:** The datasets provided may include samples indexed using different settings to describe the same crystal lattice. To ensure comparability, we reindex each sample to a common indexing scheme by applying reindexing operators. To set the common indexing scheme, we compare each dataset to a common reference dataset. This can be one of the better datasets in the screen. In certain datasets, we may observe minimal disparity in correlation coefficients across various reindexing operations. These instances will be identified and subsequently, we will employ the R-factor from the subsequent autorefinement as an additional criterion.\n",
+    "**Reindexing:** The datasets provided may include samples indexed using different settings to describe the same crystal lattice. If this is the case, we need to ensure comparability by reindexing each sample to a common indexing scheme by applying reindexing operators. To set the common indexing scheme, we compare each dataset to a common reference dataset. This can be one of the better datasets in the screen. Generally, one and only one reindexing operation will yield high correlation with the reference dataset. However, in some datasets there may be minimal disparity in correlation coefficients across various reindexing operations. These instances will be identified and marked. We will employ the R-factor from the subsequent autorefinement as an additional criterion.\n",
+    "\n",
+    "Note that datasets which poorly correlate with the reference may do so for several reasons, and is worth investigating which of these apply: (1) very poor data quality, (2) previous merging of inconsistently indexed wedges of diffraction data, or (3) large conformational changes.\n",
     "\n",
     "**Automatic Refinement:** After reindexing datasets (ambiguous datasets will be duplicated using all available reindexing operations), we subject them to automatic refinement against the **apo model**. This serves two distinct purposes: firstly, we utilize refinement R-factors to screen out problematic datasets for downstream tasks; secondly, we will employ the phases obtained from the apo refinement in step 7.\n",
     "\n",
-    "**Scaling:** The samples are scaled to a reference dataset using a global anisotropic scaling factor by an analytical scaling method that determines the Debye-Waller Factor. The scaling process ensures that structure factor amplitudes are comparable across different datasets, accounting for variabilities such as differences in lattice orientations."
+    "**Scaling:** The samples are scaled to a reference dataset using a global anisotropic scaling factor by an analytical scaling method. The scaling process ensures that structure factor amplitudes are comparable across different datasets, accounting for lattice imperfections and radiation damage."
    ]
   },
   {
@@ -397,17 +477,10 @@
    "id": "6d08a5d0-92aa-4f96-8e03-2476910481b6",
    "metadata": {},
    "source": [
-    "1. Import the required library, `valdo`.\n",
+    "1. Import `valdo`.\n",
     "\n",
     "2. Call the `reindex_files()` function from `valdo.reindex`. The `reindex_files()` function will enumerate possible reindexing operations for any space group and apply them to each input MTZ file. It will select the operation with the highest correlation with the reference dataset. The reindexed files will be saved in the specified output folder, following `####_i.mtz` naming convention: `####` is the same file idx as before and `i` is the id of the best reindex operations, `0` means identical operation. \n",
     "\n",
-    "    This function can be called with the following parameters:\n",
-    "    - `input_files`: List of paths to input MTZ files to be reindexed.\n",
-    "    - `reference_file`: Path to the reference MTZ file.\n",
-    "    - `output_folder`: Path to the folder where the reindexed MTZ files will be saved.\n",
-    "    - `columns`: A list containing the names of the columns in the dataset that represent the amplitude and the error column.\n",
-    "\n",
-    "  \n",
     "3. You have the option to perform automatic refinement using either PHENIX or your preferred refinement software, such as dimple. In valdo, we provide a **command-line tool** specifically designed for automatic refinement using PHENIX. Our tests have shown that initiating the process with a lone apo model produces adequate phases and models for subsequent real-space maps in step 7. An example configuration file named `refine_drug.eff` can be located in the `notebook/` directory.\n",
     "\n",
     "    *Code Example:* `valdo.refine --pdbpath \"xxx/xxx_apo.pdb\" --mtzpath \"xxx/*.mtz\" --output \"yyy/\" --eff \"xxx/refine_drug.eff\"`\n",
@@ -421,7 +494,7 @@
     "   - `refine_####_001.log`: Log file during the refinement, containing the R-factors before and after refinement\n",
     "   - `refine_####_001.eff`: Complete configuration file of the refinement \n",
     "\n",
-    "   Generate a list of problematic datasets based on the R-factors, screen out for downstreaming tasks.\n",
+    "4. Generate a list of problematic datasets based on the R-factors, screen out for downstreaming tasks.\n",
     "\n",
     "5. Create a `Scaler` object by providing the path to the reference MTZ file.\n",
     "\n",
@@ -448,10 +521,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "0de3e185-789c-4768-adfd-25632d3baeb3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Working with 1679 MTZ files.\n"
+     ]
+    }
+   ],
    "source": [
     "# List of files to be reindexed\n",
     "file_list = glob.glob(input_mtz_path + \"*mtz\")\n",
@@ -475,10 +556,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "63a1cab5-8e5f-46b9-92b5-99a77cff5f73",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1679/1679 [00:36<00:00, 45.98it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reindex statistics record has been saved at:\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/reindex_record.pkl\n",
+      "CPU times: user 712 ms, sys: 230 ms, total: 942 ms\n",
+      "Wall time: 52.6 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time \n",
     "# Reindexes a list of input MTZ files to a reference MTZ file using gemmi, took ~1 min\n",
@@ -507,12 +606,112 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "be47577c-22d9-4f14-a63d-d88bcd366229",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_idx</th>\n",
+       "      <th>best_symop</th>\n",
+       "      <th>num_duplicates</th>\n",
+       "      <th>reindexed_file</th>\n",
+       "      <th>CC_symop0</th>\n",
+       "      <th>CC_symop1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0001</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.125</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0002</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.097</td>\n",
+       "      <td>0.797</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0004</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.666</td>\n",
+       "      <td>0.089</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0006</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.947</td>\n",
+       "      <td>0.117</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0009</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.126</td>\n",
+       "      <td>0.956</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  file_idx  best_symop  num_duplicates  \\\n",
+       "0     0001           0               1   \n",
+       "1     0002           1               1   \n",
+       "2     0004           0               1   \n",
+       "3     0006           0               1   \n",
+       "4     0009           1               1   \n",
+       "\n",
+       "                                      reindexed_file  CC_symop0  CC_symop1  \n",
+       "0  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      1.000      0.125  \n",
+       "1  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.097      0.797  \n",
+       "2  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.666      0.089  \n",
+       "3  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.947      0.117  \n",
+       "4  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.126      0.956  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "reindexing_record.describe()"
+    "reindexing_record.head()"
    ]
   },
   {
@@ -525,10 +724,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "5df9d95c-b960-4d26-959d-26461380d524",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYMAAAD/CAYAAAAT87ocAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAvyElEQVR4nO3de1hU5do/8O8IwzDoQKXIgOIZNcFM8YSW8lagZmZ5pZVmdvBQmoZapJk5thPFtkip6dbMbPdS7u2hw9YU3lJK0URFU1AsJcMDm1IUEhsR7t8f/lgxzgAzOAdm/H6ui4tZz3rmWfd6Zs3csw6zHpWICIiI6JbWwNUBEBGR6zEZEBERkwERETEZEBERmAyIiAhMBkREBCYDIiIC4O3qAOqDiooKnD17FjqdDiqVytXhEBHdNBFBSUkJQkJC0KBB7d/7mQwAnD17FqGhoa4Og4jI7vLz89G8efNa6zEZANDpdACud5pWq0VqaipiY2OhVqtdHFn9VlZWxr6yAvvJOuwn61nTV8XFxQgNDVU+32rDZAAoh4b8/f2h1Wrh5+cHf39/bpC1KCsrY19Zgf1kHfaT9WzpK2sPffMEMhERMRkQERGTARERgcmAiIjAZEBERGAyICIi8NJSp2o1Y7Py+JcFg10YCRGRKe4ZEBERkwERETEZEBERmAyIiAguTgbfffcdhgwZgpCQEKhUKnz++ecm80UEBoMBISEh0Gq1iI6ORnZ2tkkdo9GIyZMno0mTJmjYsCEefvhhnD592olrQUTk/lyaDC5fvowuXbpg6dKlFucvXLgQSUlJWLp0KTIzM6HX6xETE4OSkhKlTlxcHDZt2oTPPvsMO3fuxB9//IGHHnoI5eXlzloNIiK359JLSwcNGoRBgwZZnCciSE5OxqxZszBs2DAAwNq1axEUFISUlBRMmDABly5dwurVq/HPf/4TDzzwAADgk08+QWhoKP7v//4PAwYMcNq6EBG5s3r7O4O8vDwUFBQgNjZWKdNoNOjfvz8yMjIwYcIE7N+/H2VlZSZ1QkJCEBERgYyMjGqTgdFohNFoVKaLi4sBXL8trLe3t/LY3jReojx2RPvOVrkOnrAujsR+sg77yXrW9JWt/Vhvk0FBQQEAICgoyKQ8KCgIp06dUur4+Pjg9ttvN6tT+XxL5s+fj7lz55qVp6amws/PDwCQlpZ2U/FbsrDnX4+3bNli9/ZdxRF95YnYT9ZhP1mvpr4qLS21qa16mwwq3Tgwg4jUOlhDbXVmzpyJadOmKdOVIwLFxsZCq9UiLS0NMTExdh9gI8KwTXl8xOD+h7DKysoc1leehP1kHfaT9azpq8ojHtaqt8lAr9cDuP7tPzg4WCkvLCxU9hb0ej2uXr2KoqIik72DwsJC9OnTp9q2NRoNNBqNWblarVY6tupjezGW/5WgPGljd0RfeSL2k3XYT9arqa9s7cN6+zuD1q1bQ6/Xm+wGXb16Fenp6coHfWRkJNRqtUmdc+fO4ciRIzUmAyIiMuXSPYM//vgDP//8szKdl5eHgwcP4o477kCLFi0QFxeHhIQEhIWFISwsDAkJCfDz88PIkSMBAAEBAXj++ecxffp0NG7cGHfccQdeeeUVdO7cWbm6iIiIaufSZLBv3z78z//8jzJdeRx/zJgx+OijjxAfH48rV65g4sSJKCoqQq9evZCamgqdTqc8Z/HixfD29saIESNw5coV3H///fjoo4/g5eXl9PUhInJXLk0G0dHREJFq56tUKhgMBhgMhmrr+Pr6YsmSJViyZIkDIiQiujXU23MGRETkPEwGRETEZEBEREwGREQEJgMiIgKTARERgcmAiIjAZEBERGAyICIiMBkQERGYDIiICEwGRESEejy4DRGRO2k1Y7Py+JcFg10YSd1wz4CIiJgMiIiIyYCIiMBkQEREYDIgIiIwGRAREZgMiIgITAZERAT+6IyIyO7c8Qdo3DMgIiImAyIiqufJ4Nq1a3jjjTfQunVraLVatGnTBm+99RYqKiqUOiICg8GAkJAQaLVaREdHIzs724VRExG5n3qdDBITE7FixQosXboUR48excKFC/HOO+9gyZIlSp2FCxciKSkJS5cuRWZmJvR6PWJiYlBSUuLCyImI3Eu9Tga7d+/G0KFDMXjwYLRq1QqPPfYYYmNjsW/fPgDX9wqSk5Mxa9YsDBs2DBEREVi7di1KS0uRkpLi4uiJiNxHvb6a6J577sGKFStw/PhxtG/fHocOHcLOnTuRnJwMAMjLy0NBQQFiY2OV52g0GvTv3x8ZGRmYMGGCxXaNRiOMRqMyXVxcDAAoKyuDt7e38tjeNF6iPHZE+85WuQ6esC6OxH6yjrv3U9X3d1WOWB9r+srW5apExPIa1ODixYvYu3cvCgsLTY7fA8DTTz9ta3PVEhG8/vrrSExMhJeXF8rLyzFv3jzMnDkTAJCRkYG+ffvizJkzCAkJUZ43fvx4nDp1Ctu2bbPYrsFgwNy5c83KU1JS4OfnZ7f4iYhcpbS0FCNHjsSlS5fg7+9fa32b9wy++uorjBo1CpcvX4ZOp4NKpVLmqVQquyaDdevW4ZNPPkFKSgrCw8Nx8OBBxMXFISQkBGPGjDFZblUiYlZW1cyZMzFt2jRluri4GKGhoYiNjYVWq0VaWhpiYmKgVqvtti4AEGH4KzkdMQywa9uuUFZW5rC+8iTsJ+u4ez9VfX9X5Yj3ujV9VXnEw1o2J4Pp06fjueeeQ0JCgsO/Rb/66quYMWMGnnjiCQBA586dcerUKcyfPx9jxoyBXq8HABQUFCA4OFh5XmFhIYKCgqptV6PRQKPRmJWr1WqlY6s+thdj+V8Jyh039uo4oq88EfvJOu7UT1V/XAZY/gLqyHWpqa9sXa7NJ5DPnDmDKVOmOOVwSmlpKRo0MA3Ry8tLOTTVunVr6PV6pKWlKfOvXr2K9PR09OnTx+HxERF5Cpv3DAYMGIB9+/ahTZs2jojHxJAhQzBv3jy0aNEC4eHhyMrKQlJSEp577jkA1w8PxcXFISEhAWFhYQgLC1P2WEaOHOnw+IiIPIXNyWDw4MF49dVXkZOTg86dO5vtijz88MN2C27JkiWYPXs2Jk6ciMLCQoSEhGDChAl48803lTrx8fG4cuUKJk6ciKKiIvTq1QupqanQ6XR2i4OIyNPZnAzGjRsHAHjrrbfM5qlUKpSXl998VP+fTqdDcnKycimpJSqVCgaDAQaDwW7LJSK61dicDG68lJSIiNxfvf4FMhEROYdVewbvvfcexo8fD19fX7z33ns11p0yZYpdAvN07ni/cyLyXFYlg8WLF2PUqFHw9fXF4sWLq62nUqmYDIiI3JBVySAvL8/iYyIi8gw3dc5ARFCHWxsREVE9U6dksHr1akRERMDX1xe+vr6IiIjABx98YO/YiIjISWy+tHT27NlYvHgxJk+ejKioKADXxx2YOnUqfvnlF7z99tt2D/JWwhPLROQKNieD5cuXY9WqVXjyySeVsocffhh33XUXJk+ezGRAROSGbD5MVF5eju7du5uVR0ZG4tq1a3YJioiInMvmZPDUU09h+fLlZuUrV67EqFGj7BIUERE5l1WHiaoOBKNSqfDBBx8gNTUVvXv3BgDs2bMH+fn5dh3YhoiInMeqZJCVlWUyHRkZCQA4ceIEACAwMBCBgYHIzs62c3hERO7NXS4KsSoZbN++3dFxEBGRC/FGdURExGRARERMBkREBCYDIiKCjcmgrKwMzz77LE6ePOmoeIiIyAVsSgZqtRqbNm1yVCxEROQiNh8mevTRR/H55587IBQiInIVm29U165dO/ztb39DRkYGIiMj0bBhQ5P5HOmMiMj92JwMPvjgA9x2223Yv38/9u/fbzKPw14SEbknm5MBh70kIvI8db609OrVq8jNzXX4bavPnDmDp556Co0bN4afnx/uvvtukz0SEYHBYEBISAi0Wi2io6N5jyQiIhvZnAxKS0vx/PPPw8/PD+Hh4fj1118BXD9XsGDBArsGV1RUhL59+0KtVuPrr79GTk4OFi1ahNtuu02ps3DhQiQlJWHp0qXIzMyEXq9HTEwMSkpK7BoLEZEnszkZzJw5E4cOHcKOHTvg6+urlD/wwANYt26dXYNLTExEaGgo1qxZg549e6JVq1a4//770bZtWwDX9wqSk5Mxa9YsDBs2DBEREVi7di1KS0uRkpJi11iIiDyZzecMPv/8c6xbtw69e/eGSqVSyjt16qTc0tpevvzySwwYMADDhw9Heno6mjVrhokTJ2LcuHEArp+/KCgoQGxsrPIcjUaD/v37IyMjAxMmTLDYrtFohNFoVKaLi4sBXP9Rnbe3t/LY3jReYrG86rKq1nFEDPZUGV99j9PV2E/Wccd+qu49XR17rZs1fWXrslQiYtPa+Pn54ciRI2jTpg10Oh0OHTqENm3a4NChQ+jXrx8uXbpkUwA1qdzzmDZtGoYPH469e/ciLi4O//jHP/D0008jIyMDffv2xZkzZxASEqI8b/z48Th16hS2bdtmsV2DwYC5c+ealaekpMDPz89u8RMRuUppaSlGjhyJS5cuwd/fv9b6Nu8Z9OjRA5s3b8bkyZMBQNk7WLVqFaKiomxtrkYVFRXo3r07EhISAABdu3ZFdnY2li9fbjKqWtU9FOD64aMby6qaOXOmyehtxcXFCA0NRWxsLLRaLdLS0hATEwO1Wm3X9YkwWE5ORwwDLNapWl4flZWVOayvPAn7yTru2E/VvaerY6/3tDV9VXnEw1o2J4P58+dj4MCByMnJwbVr1/Duu+8iOzsbu3fvRnp6uq3N1Sg4OBidOnUyKbvzzjuxYcMGAIBerwcAFBQUIDg4WKlTWFiIoKCgatvVaDTQaDRm5Wq1WunYqo/txVhuOUFVXU7VOu7yhnBEX3ki9pN13KmfqntPV8fe61VTX9m6LJuTQZ8+fbBr1y78/e9/R9u2bZGamopu3bph9+7d6Ny5s63N1ahv377Izc01KTt+/DhatmwJAGjdujX0ej3S0tLQtWtXANcveU1PT0diYqJdY6mrqkPe3UwdIiJHsjkZAEDnzp2xdu1ae8diZurUqejTpw8SEhIwYsQI7N27FytXrsTKlSsBXD88FBcXh4SEBISFhSEsLAwJCQnw8/PDyJEjHR4fEZGnqFMyKC8vx6ZNm3D06FGoVCrceeedGDp0qHIljr306NEDmzZtwsyZM/HWW2+hdevWSE5OxqhRo5Q68fHxuHLlCiZOnIiioiL06tULqamp0Ol0do2FiMiT2fzpfeTIEQwdOhQFBQXo0KEDgOuHbgIDA/Hll1/a/VDRQw89hIceeqja+SqVCgaDAQaDwa7LJSK6ldj8o7OxY8ciPDwcp0+fxoEDB3DgwAHk5+fjrrvuwvjx4x0RIxEROZjNewaHDh3Cvn37cPvttytlt99+O+bNm4cePXrYNTgiInIOm/cMOnTogP/+979m5YWFhWjXrp1dgiIiIueyORkkJCRgypQpWL9+PU6fPo3Tp09j/fr1iIuLQ2JiIoqLi5U/IiJyDzYfJqo8mTtixAjlV76Vd7QYMmSIMq1SqVBeXm6vOImIyIFsTgbbt293RBxERORCNieD/v37OyIOIiJyoTqPdEZERJ6DyYCIiJgMiIiIyYCIiFCHZHDffffh4sWLZuXFxcW477777BETERE5mc3JYMeOHbh69apZ+Z9//onvv//eLkEREZFzWX1p6Y8//qg8zsnJQUFBgTJdXl6OrVu3olmzZvaNjoiInMLqZHD33XdDpVJBpVJZPByk1WqxZMkSuwZHRETOYXUyyMvLg4igTZs22Lt3LwIDA5V5Pj4+aNq0Kby8vBwSJBEROZbVyaBy3OGKigqHBUNERK5Rp3Eqjx8/jh07dqCwsNAsObz55pt2CYyAVjM2AwB+WTDYxZEQ3Zoq34OA578PbU4Gq1atwosvvogmTZpAr9crdy4Frg9ByWRAROR+bE4Gb7/9NubNm4fXXnvNEfEQEZEL2Pw7g6KiIgwfPtwRsRARkYvYnAyGDx+O1NRUR8RCROQSrWZsVv5uVTYfJmrXrh1mz56NPXv2oHPnzlCr1Sbzp0yZYrfgiIjIOWxOBitXrkSjRo2Qnp6O9PR0k3kqlYrJgIg8kqdfWWRzMsjLy3NEHFaZP38+Xn/9dbz88stITk4GcH285blz52LlypUoKipCr169sGzZMoSHh7ssTnvz9I2QqD6x5lCRJx5OcptbWGdmZmLlypW46667TMoXLlyIpKQkLF26FJmZmdDr9YiJiUFJSYmLIiUicj827xk899xzNc7/8MMP6xxMdf744w+MGjUKq1atwttvv62UiwiSk5Mxa9YsDBs2DACwdu1aBAUFISUlBRMmTLB7LEREnsjmZFBUVGQyXVZWhiNHjuDixYsOG89g0qRJGDx4MB544AGTZJCXl4eCggLExsYqZRqNBv3790dGRka1ycBoNMJoNCrTxcXFyrp4e3srj+1B4yV2aaeSveKyh8pY6lNM9RH7yTqu7Cd7v0+rY691s6avbF2Wzclg06ZNZmUVFRWYOHEi2rRpY2tztfrss89w4MABZGZmms2rvI12UFCQSXlQUBBOnTpVbZvz58/H3LlzzcpTU1Ph5+cHAEhLS7uZsBULe9qlGcWWLVvs26Ad2KuvPB37yTqu6Cd7v0+rY+/3b019VVpaalNbdbo30Y0aNGiAqVOnIjo6GvHx8fZoEgCQn5+Pl19+GampqfD19a22XtVbYgDXDx/dWFbVzJkzMW3aNGW6uLgYoaGhiI2NhVarRVpaGmJiYswum62LCMO2m26jqiOGAXZt72aUlZXZta88FfvJOq7sJ3u/T6tjr/evNX1VecTDWnZJBgBw4sQJXLt2zV7NAQD279+PwsJCREZGKmXl5eX47rvvsHTpUuTm5gK4vocQHBys1CksLDTbW6hKo9FAo9GYlavVaqVjqz6+Gcby6pNSXdTHDxN79ZWnYz9ZxxX9ZO/3aXXsvV419ZWty7I5GVT9Rg1c/xZ+7tw5bN68GWPGjLG1uRrdf//9OHz4sEnZs88+i44dO+K1115DmzZtoNfrkZaWhq5duwIArl69ivT0dCQmJto1lvqCl5kSkSPYnAyysrJMphs0aIDAwEAsWrSo1iuNbKXT6RAREWFS1rBhQzRu3Fgpj4uLQ0JCAsLCwhAWFoaEhAT4+flh5MiRdo2FiMiT2ZwMtm/f7og46iw+Ph5XrlzBxIkTlR+dpaamQqfTuTo0IiK3UedzBr/99htyc3OhUqnQvn17k2EwHWnHjh0m0yqVCgaDAQaDwSnLJyLyRDYng8uXL2Py5Mn4+OOPlVHOvLy88PTTT2PJkiXKpZnkOhwhjah+qs/n/Gy+HcW0adOQnp6Or776ChcvXsTFixfxxRdfID09HdOnT3dEjERE5GA27xls2LAB69evR3R0tFL24IMPQqvVYsSIEVi+fLk94yMichhPvOFcXdmcDEpLSy1ew9+0aVObf/FG9sONmohuhs2HiaKiojBnzhz8+eefStmVK1cwd+5cREVF2TU4IiJyDpv3DN59910MHDgQzZs3R5cuXaBSqXDw4EH4+vpi2zbn/KSbiMgW9fnEbX1hczKIiIjATz/9hE8++QTHjh2DiOCJJ57AqFGjoNVqHREjERE5WJ1+Z6DVajFu3Dh7x0I24nkCIrIXm88ZzJ8/3+IANh9++KHH3g+IiMjT2ZwM/vGPf6Bjx45m5eHh4VixYoVdgiIicpRWMzYrf/QXmw8T3Xi76EqBgYE4d+6cXYLyBNzQiMid2LxnEBoail27dpmV79q1CyEhIXYJioiInMvmPYOxY8ciLi4OZWVlypjH33zzDeLj43k7CiIiN2VzMoiPj8eFCxcwceJEXL16FQDg6+uL1157DTNnzrR7gERE5Hg2JwOVSoXExETMnj0bR48ehVarRVhYmMVhJKn+4I9uiKgmdR7PoFGjRujRo4c9YyEiIhepczIgIqrPeEWfbWy+moiIiDwPkwEREfEwkSfjbjIRWYt7BkRExGRARERMBkREBJ4zICIPwvNkdVev9wzmz5+PHj16QKfToWnTpnjkkUeQm5trUkdEYDAYEBISAq1Wi+joaGRnZ7soYiIi91Svk0F6ejomTZqEPXv2IC0tDdeuXUNsbCwuX76s1Fm4cCGSkpKwdOlSZGZmQq/XIyYmBiUlJS6MnIjIvdTrw0Rbt241mV6zZg2aNm2K/fv3o1+/fhARJCcnY9asWRg2bBgAYO3atQgKCkJKSgomTJjgirDrPd6niIhuVK+TwY0uXboEALjjjjsAAHl5eSgoKEBsbKxSR6PRoH///sjIyKg2GRiNRhiNRmW6uLgYAFBWVgZvb2/l8c3QeMlNPd9ZbmY9K597s33l6dhP1rFHP7nL+w5w/HvP1vZVIuIWvSciGDp0KIqKivD9998DADIyMtC3b1+cOXPGZGCd8ePH49SpU9i2bZvFtgwGA+bOnWtWnpKSAj8/P8esABGRE5WWlmLkyJG4dOkS/P39a63vNnsGL730En788Ufs3LnTbJ5KpTKZFhGzsqpmzpyJadOmKdPFxcUIDQ1FbGwstFot0tLSEBMTA7VaXed4IwyWE1F9c8QwoM7PLSsrs0tfeTr2k3Xs0U/u8r4DHP/eqzziYS23SAaTJ0/Gl19+ie+++w7NmzdXyvV6PQDzcZkLCwsRFBRUbXsajcbi+AtqtVrp2KqP68JYXn0yqk/s8eF0s311q2A/Wedm+sld3neA4997trZfr5OBiGDy5MnYtGkTduzYgdatW5vMb926NfR6PdLS0tC1a1cAwNWrV5Geno7ExERXhExETsbfFthHvU4GkyZNQkpKCr744gvodDoUFBQAAAICAqDVaqFSqRAXF4eEhASEhYUhLCwMCQkJ8PPzw8iRI10cPRGR+6jXyWD58uUAgOjoaJPyNWvW4JlnngFwfUzmK1euYOLEiSgqKkKvXr2QmpoKnU7n5GjdHy85JXfCPQL7qtfJwJoLnVQqFQwGAwwGg+MDIiLyUPU6GZDj8dsVEQH1/HYURETkHEwGRETEZEBEREwGREQEJgMiIpdoNWNzvbqAg8mAiIh4aak91acsT0RkC+4ZEBERkwEREfEwERHVExGGbVjY8/r/3HkPWazDQ7GOwz0DIiLingHVTasZm6HxEizs6epIiMgeuGdARETcM7hZnnoMs3K9OK4B0a2BewZERMQ9A7Kep+4FUf3DUfecj8mAasQEYB0eViN3x8NERETEPQNyDzxsQORY3DMgIiLuGdDNizBsg7FcBeCvb+3VnWuo+q2e3/ZvXba89jxv5RxMBmRXdX3jMjE4X1373NJrXN3zrVlGZR2Nl9UheJT6su3zMBEREXnOnsH777+Pd955B+fOnUN4eDiSk5Nx7733ujosuoE1ew61XabpjG9StnyjtfV5N1PfWW3Z2p4tryvVTx6xZ7Bu3TrExcVh1qxZyMrKwr333otBgwbh119/dXVoRERuwSP2DJKSkvD8889j7NixAIDk5GRs27YNy5cvx/z5810cHdWVrd82azt5XZUzjs3+dSxclPv0V55or6m+PfYobmYPhVzHmgsvHMXtk8HVq1exf/9+zJgxw6Q8NjYWGRkZFp9jNBphNBqV6UuXLgEALly4AF9fX5SWluL8+fNQq9W1Lt/72uWbiN69eVcISksr4F3WAOUV1X/IOcv58+cBWPeaVNatTtU2qqtr7Wtvaz/VFlt18VUXz83Gf2Mbjtrm69v2VJ/c+BqWlZXV+jlVUlICABAR6xYibu7MmTMCQHbt2mVSPm/ePGnfvr3F58yZM0cA8I9//OOfx//l5+db9Vnq9nsGlVQq028SImJWVmnmzJmYNm2aMl1RUYELFy6gcePGKCkpQWhoKPLz8+Hv7+/QmN1dcXEx+8oK7CfrsJ+sZ01fiQhKSkoQEhJiVZtunwyaNGkCLy8vFBQUmJQXFhYiKCjI4nM0Gg00Go1J2W233Qbgr6Ti7+/PDdJK7CvrsJ+sw36yXm19FRAQYHVbbn81kY+PDyIjI5GWlmZSnpaWhj59+rgoKiIi9+L2ewYAMG3aNIwePRrdu3dHVFQUVq5ciV9//RUvvPCCq0MjInILHpEMHn/8cZw/fx5vvfUWzp07h4iICGzZsgUtW7a0uS2NRoM5c+aYHUYic+wr67CfrMN+sp4j+kolYu11R0RE5Knc/pwBERHdPCYDIiJiMiAiIiYDIiICkwEAYN68eejTpw/8/PyUH5/VRkRgMBgQEhICrVaL6OhoZGdnOzZQFysqKsLo0aMREBCAgIAAjB49GhcvXqzxOc888wxUKpXJX+/evZ0TsBO9//77aN26NXx9fREZGYnvv/++xvrp6emIjIyEr68v2rRpgxUrVjgpUteypZ927Nhhtu2oVCocO3bMiRE733fffYchQ4YgJCQEKpUKn3/+ea3Pscf2xGSA6ze7Gz58OF588UWrn7Nw4UIkJSVh6dKlyMzMhF6vR0xMjHJzKE80cuRIHDx4EFu3bsXWrVtx8OBBjB49utbnDRw4EOfOnVP+tmzZ4oRoncfWW6jn5eXhwQcfxL333ousrCy8/vrrmDJlCjZs2ODkyJ2rrreaz83NNdl+wsLCnBSxa1y+fBldunTB0qVLrapvt+3pZm4S52nWrFkjAQEBtdarqKgQvV4vCxYsUMr+/PNPCQgIkBUrVjgwQtfJyckRALJnzx6lbPfu3QJAjh07Vu3zxowZI0OHDnVChK7Ts2dPeeGFF0zKOnbsKDNmzLBYPz4+Xjp27GhSNmHCBOndu7fDYqwPbO2n7du3CwApKipyQnT1EwDZtGlTjXXstT1xz6AO8vLyUFBQgNjYWKVMo9Ggf//+1d42293t3r0bAQEB6NWrl1LWu3dvBAQE1LrOO3bsQNOmTdG+fXuMGzcOhYWFjg7XaSpvoV51WwBqvoX67t27zeoPGDAA+/btQ1lZmcNidaW69FOlrl27Ijg4GPfffz+2b9/uyDDdkr22JyaDOqi8Kd6NN8ILCgoyu2GepygoKEDTpk3Nyps2bVrjOg8aNAj/+7//i2+//RaLFi1CZmYm7rvvPpPxJNzZ77//jvLycpu2hYKCAov1r127ht9//91hsbpSXfopODgYK1euxIYNG7Bx40Z06NAB999/P7777jtnhOw27LU9ecTtKCwxGAyYO3dujXUyMzPRvXv3Oi/Dlttm11fW9hNgvr5A7ev8+OOPK48jIiLQvXt3tGzZEps3b8awYcPqGHX9Y+u2YKm+pXJPY0s/dejQAR06dFCmo6KikJ+fj7///e/o16+fQ+N0N/bYnjw2Gbz00kt44oknaqzTqlWrOrWt1+sBXM/IwcHBSnlNt82ur6ztpx9//BH//e9/zeb99ttvNq1zcHAwWrZsiZ9++snmWOujutxCXa/XW6zv7e2Nxo0bOyxWV6pLP1nSu3dvfPLJJ/YOz63Za3vy2GTQpEkTNGnSxCFtt27dGnq9HmlpaejatSuA68dE09PTkZiY6JBlOoq1/RQVFYVLly5h79696NmzJwDghx9+wKVLl2y6Vfj58+eRn59vkkTdWdVbqD/66KNKeVpaGoYOHWrxOVFRUfjqq69MylJTU9G9e3erhlp1R3XpJ0uysrI8ZtuxF7ttTzadbvZQp06dkqysLJk7d640atRIsrKyJCsrS0pKSpQ6HTp0kI0bNyrTCxYskICAANm4caMcPnxYnnzySQkODpbi4mJXrIJTDBw4UO666y7ZvXu37N69Wzp37iwPPfSQSZ2q/VRSUiLTp0+XjIwMycvLk+3bt0tUVJQ0a9bMo/rps88+E7VaLatXr5acnByJi4uThg0byi+//CIiIjNmzJDRo0cr9U+ePCl+fn4ydepUycnJkdWrV4tarZb169e7ahWcwtZ+Wrx4sWzatEmOHz8uR44ckRkzZggA2bBhg6tWwSlKSkqUzyAAkpSUJFlZWXLq1CkRcdz2xGQg1y9/hIWxQ7dv367UASBr1qxRpisqKmTOnDmi1+tFo9FIv3795PDhw84P3onOnz8vo0aNEp1OJzqdTkaNGmV22V/VfiotLZXY2FgJDAwUtVotLVq0kDFjxsivv/7q/OAdbNmyZdKyZUvx8fGRbt26SXp6ujJvzJgx0r9/f5P6O3bskK5du4qPj4+0atVKli9f7uSIXcOWfkpMTJS2bduKr6+v3H777XLPPffI5s2bXRC1c1VeUnvj35gxY0TEcdsTb2FNRES8tJSIiJgMiIgITAZERAQmAyIiApMBERGByYCIiMBkQEREYDIgIiIwGZCd5ObmQq/Xe/RIbzXp0aMHNm7c6OowrPbtt9+iY8eOqKiocHUoTmc0GtGiRQvs37/f1aHUK0wGt4iCggJMnjwZbdq0gUajQWhoKIYMGYJvvvnGpF5WVhaGDx+OoKAg+Pr6KgPSHD9+vMb2Z82ahUmTJkGn0zlyNVzCmjFpZ8+ejRkzZtjtw/Xnn3/Gs88+i+bNm0Oj0aB169Z48sknsW/fPpN627dvx4MPPojGjRvDz88PnTp1wvTp03HmzJka24+Pj8esWbPQoIHnfQRILeOTazQavPLKK3jttddcGGU9dLP30aD6Ly8vT0JCQqRTp07y73//W3Jzc+XIkSOyaNEi6dChg1Lvq6++Eh8fHxkyZIikpaXJyZMnZc+ePTJ9+nQZMWJEte3n5+eLWq2W/Px8Z6yO023ZskVmzZolGzZsqHYYwmvXrknTpk1ly5YtN728zMxM8ff3lz59+sh//vMf+fnnnyUrK0sMBoP069dPqbdixQpp0KCBPPvss7J9+3bJy8uT9PR0ef7552Xq1KnVtr9r1y7x9/eXK1eu3HSs9dGCBQtEp9PJhg0b5PDhw/L444+b3UTy999/Fx8fH8nJyXFhpPULk8EtYNCgQdKsWTP5448/zOZV3mju8uXL0qRJE3nkkUcstlHTOLSLFi2S7t27m5T98ssv8tBDD8ltt90mfn5+0qlTJ9m8ebNUVFRI27Zt5Z133jGpf/jwYVGpVPLzzz+LyPUb3q1YsUIGDx4sWq1WOnbsKBkZGfLTTz9J//79xc/PT3r37q3Ur/T+++9LmzZtRK1WS/v27eXjjz82mQ9A3n//fRk4cKD4+vpKq1at5F//+le163aj6pKBiMgzzzxjcjfJuqioqJDw8HCJjIyU8vJys/mVr0N+fr74+PhIXFycxXZqer0mT54sjz32mEnZwYMHJTo6Who1aiQ6nU66desmmZmZ8scff4hOp5N///vfJvW//PJL8fPzk+LiYsnLyxMAsm7dOrnnnnvE19dXunfvLrm5ubJ3716JjIyUhg0byoABA6SwsFBpo7y8XObOnSvNmjUTHx8f6dKli3z99dfK/Mp2P/30U4mKihKNRiOdOnUyuYGkpf6zdnzy6OhomT17drVt3WqYDDzc+fPnRaVSSUJCQo31Nm7cKAAkIyPD5mUMHTrUbKDzwYMHS0xMjPz4449y4sQJ+eqrr5Q7VM6bN086depkUn/q1Kkm33oBSLNmzWTdunWSm5srjzzyiLRq1Uruu+8+2bp1q+Tk5Ejv3r1l4MCBJuugVqtl2bJlkpubK4sWLRIvLy/59ttvTdpt3LixrFq1SnJzc+WNN94QLy8vq78h1pQM3n//fWnVqpVV7VTnwIEDAkBSUlJqrJeUlCQA5OzZszYvo0uXLiYfliIi4eHh8tRTT8nRo0fl+PHj8q9//UsOHjwoIiLjxo2TBx980KT+o48+Kk8//bSI/PWh3bFjR5PXplu3bhIdHS07d+6UAwcOSLt27Uy2k6SkJPH395dPP/1Ujh07JvHx8aJWq+X48eMm7TZv3lzWr18vOTk5MnbsWNHpdPL7779bXLcTJ04IADlw4IBJ+cMPP6zEWyk+Pl6io6Nt7j9PxWTg4X744QcBYDIWgyWJiYkCQC5cuGDzMrp06SJvvfWWSVnnzp3FYDBYrH/27Fnx8vKSH374QURErl69KoGBgfLRRx8pdQDIG2+8oUzv3r1bAMjq1auVsk8//VR8fX2V6T59+si4ceNMljV8+HCTDzIAZomrV69e8uKLL1q1rjUlgy+++EIaNGhg8Ru9tdatW2fxw+xGL774ovj7+9dpGQEBAWZ7TDqdzqT/q/rhhx/Ey8tLzpw5IyIiv/32m6jVatmxY4eI/PWh/cEHHyjP+fTTTwWAfPPNN0rZ/PnzTQ5LhoSEyLx580yW1aNHD5k4caJJu1UTV1lZmTRv3lwSExMtxrpr1y4BoMRaady4cRIbG2tS9u6779508vYknnf2iEyIlWOhyk3cyfzKlSvw9fU1KZsyZQrefvtt9O3bF3PmzMGPP/6ozAsODsbgwYPx4YcfAgD+85//4M8//8Tw4cNN2rjrrruUx5VDI3bu3Nmk7M8//0RxcTEA4OjRo+jbt69JG3379sXRo0dNyqKiosymb6xTF1qtFhUVFTAajRbnDxo0CI0aNUKjRo0QHh5usY4tr1ddx0u29HpNmzYNY8eOxQMPPIAFCxbgxIkTyryePXsiPDwcH3/8MQDgn//8J1q0aGE2DrE1r1dhYSEAoLi4GGfPnrX59fL29kb37t1rfb2sGWtZq9WitLS0xnZuJUwGHi4sLAwqlarWN0/79u0BAMeOHbN5GU2aNEFRUZFJ2dixY3Hy5EmMHj0ahw8fRvfu3bFkyRKT+Z999hmuXLmCNWvW4PHHH4efn59JG1WH7Kt8I1sqq3oFj60D01f3vLq4cOEC/Pz8oNVqLc7/4IMPcPDgQRw8eBBbtmyxWKfydbDm9bp06RLOnTtnc5yWXi+DwYDs7GwMHjwY3377LTp16oRNmzYp88eOHYs1a9YAANasWYNnn33WrM+seb1uvNrK3q9X1fHJq7I01vKFCxcQGBhY67JuFUwGHu6OO+7AgAEDsGzZMly+fNls/sWLFwEAsbGxaNKkCRYuXGixncp6lnTt2hU5OTlm5aGhoXjhhRewceNGTJ8+HatWrVLmPfjgg2jYsCGWL1+Or7/+Gs8995xtK2bBnXfeiZ07d5qUZWRk4M477zQp27Nnj9l0x44db3r5R44cQbdu3aqd36xZM7Rr1w7t2rVDy5YtLda5++670alTJyxatMjiZaqVr8Njjz0GHx8fu75e7du3x9SpU5Gamophw4YpH/4A8NRTT+HXX3/Fe++9h+zsbIwZM6ba9q3h7++PkJAQm1+va9euYf/+/dW+XlXHJ69UOT75jWN1HzlyRBnDnMBLS28FJ0+eFL1eL506dZL169fL8ePHJScnR959913p2LGjUu/zzz8XtVqtXFqal5cnmZmZ8uqrr8rjjz9ebftffvmlNG3aVK5du6aUvfzyy7J161Y5efKk7N+/X3r27Gl2eerrr78uPj4+JjFUwg3H5iuPH2dlZSlllcMDVl45s2nTJlGr1bJ8+XI5fvy4cgL5xuFLmzRpIqtXr5bc3Fx58803pUGDBpKdnV3t+tU2Jm2l/v37m507qYsffvhBdDqd9O3bVzZv3iwnTpyQQ4cOydtvv21ykn3ZsmWiUqnkueeekx07dsgvv/wiO3fulPHjx8u0adOqbf+9996TyMhIZbq0tFQmTZok27dvV9po27atxMfHmzxv5MiR4uPjY3LSXsS610ZEZM2aNRIQEKBML168WPz9/eWzzz6TY8eOyWuvvWbxBHKLFi1k48aNcvToURk/frw0atRIfvvtt2rXz9rxyVu2bGl27uRWxmRwizh79qxMmjRJGX+2WbNm8vDDD5tdppeZmSnDhg2TwMBA0Wg00q5dOxk/frz89NNP1bZ97do1adasmWzdulUpe+mll6Rt27ai0WgkMDBQRo8ebXYFSOWVHwsXLjRrsy7JQMS6S0uXLVsmMTExotFopGXLlvLpp5/W0HO1j0krInL69Gm7/tYiNzdXnn76aQkJCREfHx9p2bKlPPnkk2YnltPS0mTAgAFy++23i6+vr3Ts2FFeeeWVGq8yunDhgmi1Wjl27JiIiBiNRnniiSckNDRUfHx8JCQkRF566SWz3yF88803AsDsUty6JoOql5aq1epqLy1NSUmRXr16iY+Pj9x5550mJ6UtsWZ88oyMDLntttuktLS0xrZuJUwGZBfLli0zu1qjNjt37hRvb28pKChwUFTmbkwy9vLKK6+YXclUn7366qsyfvx4m57zySefSOPGjcVoNDooKlOWkoy9PPbYY2ZXMt3qeM6A7GL8+PHo16+fVfcmMhqN+PnnnzF79myMGDHC7MSeO2ratCn+9re/uToMq82aNQstW7ZEeXl5rXVLS0uRnZ2N+fPnY8KECfDx8XFChI5jNBrRpUsXTJ061dWh1C+uzkZ061mzZo00aNBAunXrJqdPn3bqsuGgPQNPNmfOHPH29pb77rtPSkpKnLZcR+4ZkDmVyE1cYE5ERB6Bh4mIiIjJgIiImAyIiAhMBkREBCYDIiICkwEREYHJgIiIwGRAREQA/h9POv6xzq2PgwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYkAAAD/CAYAAAAE0SrVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABMp0lEQVR4nO3de1yO9/8H8NfV+aQD0YFOJBUhcihnm8xhzNlszjOWYyE1h7E5H5ofi42R2TDMYdtXozanyKkSUUQ6SY2UG5WKPr8/2n3r7j50X3Xfd915Px+PHqvruu7rfn/Urvf9OXOMMQZCCCFECq3aDoAQQkjdRUmCEEKITJQkCCGEyERJghBCiEyUJAghhMhESYIQQohMOnwuvnv3Lg4cOICoqCikpaWhsLAQjRs3hqenJ/r3748RI0ZAX19fVbESQghRM06ReRLXr19HYGAgoqKi4OPjg86dO6Np06YwNDREXl4ebt26haioKDx//hyBgYGYN29evUkWZWVlePToERo0aACO42o7HEIIqTHGGF68eAFbW1toaVXRoMQUYG9vz7Zu3cqePn0q97ro6Gg2atQotmrVKkVuqxEyMzMZAPqiL/qir3r3lZmZWeUzUKGaRElJCfT09Kq6rNrX12UCgQDm5ubIzMyEqampUu5ZWlqKiIgI+Pr6QldXVyn3rCuobJqJyqaZqlu258+fw87ODs+ePYOZmZncaxXqk+D7wFdVgjh//jw2bNiA2NhYZGdn49ixY/joo4/kvubcuXMICAjA7du3YWtri8DAQMyYMUPh9xQ2MZmamio1SRgZGcHU1LRe/tFS2TQPlU0z1bRsijSh8+q4LigowP79+xEdHY2cnBxwHAcrKyt069YNH3/8MYyNjXkHyff927Vrh8mTJ2PEiBFVXp+amoqBAwdi2rRp+OWXX3Dx4kX4+fmhcePGCr2eEELedQonicTERPTr1w+FhYXo1asX7O3twRjD48ePsXDhQixfvhwRERFwd3dXWbADBgzAgAEDFL7++++/h729PTZv3gwAcHNzQ0xMDDZu3EhJghBCFKBwkpg5cyZ69uyJn376SaI5qaSkBJMmTcLMmTNx5swZpQdZXZcuXYKvr6/Ysf79+2PXrl0oLS2VWj0rLi5GcXGx6Ofnz58DKK/WlZaWKiUu4X2Udb+6hMqmmahsmqm6ZeNzvcJJ4sqVK4iJiZHa36Cnp4cvv/wSnTt3VviN1SEnJwdWVlZix6ysrPD69Wvk5ubCxsZG4jVr1qzBihUrJI5HRETAyMhIqfFFRkYq9X51CZVNM1HZ1ONZMfDkFYfGBgzmSpgtwLdshYWFCl+rcJKwsLDAvXv3ZDYn3b9/HxYWFgq/sbpU7pgRDuaS1WETHByMgIAA0c/CUQC+vr5K7biOjIxEv3796mVHGpVN81DZ1Odw7EOs+D0RZQzQ4oCVQ90xqmOzat2rumUTtpAoQuEkMW3aNEycOBFLlixBv379YGVlBY7jkJOTg8jISKxevRrz5s1T+I3VwdraGjk5OWLHHj9+DB0dHTRq1Ejqa/T19aVOBNTV1VX6H5gq7llXUNk0E5VN+bIFRUjNLYCTZfnAniX/JQgAKGPA0t+T0MfNGjZmhtV+D75l43Otwkli+fLlMDQ0REhICAIDA0WfxBljsLa2RlBQEAIDAxV+Y3Xw9vbGn3/+KXYsIiICXl5e9fZ/BEJI3XHwWgaCjyaIag2fdXcSJQihN4whLbewRklClXgNgV20aBEWLVqE1NRU0Sd0a2trODk5qSS4yl6+fIn79++Lfk5NTUV8fDwaNmwIe3t7BAcHIysrC3v37gUAzJgxA9999x0CAgIwbdo0XLp0Cbt27cKBAwfUEi8h5N2VLSgSJQigvNawMyoVWhzEEoU2x8HRUrn9ncrEK0kIOTk5qS0xVBQTE4M+ffqIfhb2HUycOBF79uxBdnY2MjIyxOIMDw+Hv78/QkNDYWtriy1bttDwV0KIyqXmFkjUGhiAzg4WuJaWjzKUL8MdOKAVUnMLAKBO1iaqlSRqS+/evSFvFZE9e/ZIHOvVqxfi4uJUGBUh5F1SsY/BxswQNzLzcTUtD50dG6KdnYXomryCEnAoTwwVXUnLF33PAKwJvwOgvDnqi14tYG6sK3av2qZRSYIQQmpT5T6G9nbmiMt4Jjrfp1VjODcxwa4LqShjQFWLXlRMIGUMCD2bIvq5i5MFNo/1rPXaBW06RAghCpDWx1AxQQDAmbtPsDMqVXRNlaunynElNR/ea07j873XkC0oqsGdaoaSBCGEKCA2PV+ij0EdIhIfw3vNaRy8llH1xSpQream/Px87Nq1C0lJSeA4Dq6urpgyZQoaNmyo7PgIIaTWHbyWgaAjCbUaw6IjCejp0ljtzU+8axLnzp2Dk5MTtmzZgvz8fOTl5WHr1q1wcnLCuXPnVBEjIYTUmmxBEYKOJNSo6UhZPvj2vNrfk3dNYubMmRg9ejS2b98ObW1tAMCbN2/g5+eHmTNn4tatW0oPkhBCasvuC6l1IkEAgODVaxyOycAoL3u1vSfvmkRKSgrmz58vShAAoK2tjYCAAKSkpMh5JSGE1E3ZgiJEp+QiW1Ak8f2uC6m1HZ6YP+IfqfX9eNckOnTogKSkJLRq1UrseFJSEtq3b6+suAghRGmeFQOXH+TB2dpUok2/4rBW4ZBVBoDjgIFtrGuls1qe1k2Vs9CoongniTlz5mDu3Lm4f/8+unbtCgC4fPkyQkNDsXbtWty8eVN0bdu2bZUXKSGEVMPh2IdYHqcNFhcDLQ6Y2t0Jg9vaICOvEM8KS7H099uiayvmA8aAEwk5kjesZRN91LvaBe8k8fHHHwOA1MX8Pv74Y3AcB8YYOI7Dmzdvah4hIYTIUXkGdOVzS35PBPuvjiBcP2lnVN1qQlLUuhEeah/dxDtJpKZq5j8uIUTzVU4IlWdArxnugTGd3nbqSls/SRN91N4Wiwa41srsa95JwsHBQRVxEEKIXJX7Dj7ubIdfr2WKzYD+8ugtsbkETpbGEquuapKF/V0wvEOzWl2ao1qT6VJSUrB582bRZDo3NzfMnTsXLVq0UHZ8hBAisSQGA7D/aqbEdW8YQ1x6PiyM39Y2Pmpng6Pxj1D1Skp1h7RaUW3hnSROnTqFIUOGoH379ujWrRsYY4iOjkbr1q3x559/ol+/fqqIkxDyDuPTbDRz/3XR90Pb2eKPG9nQhATh3NgYwQNdYaSnC0dLo1pf2E+Id5IICgqCv78/1q5dK3F80aJFlCQIIUoj7IMw1tOuVrPR7zfUO6egumb2boGFH7jWdhhS8U4SSUlJOHTokMTxKVOmYPPmzcqIiRDyDpLXKc0B6ORYvlmPhnYviHzg3gTdXRoj5XEBWjQxxntuVnWm1iAN7yTRuHFjxMfHo2XLlmLH4+Pj0aRJE6UFRgipf2QNV608SmnRB65Yd/KOWB/E1Qqb9WgqDsBXQ9vU6aRQGe8kMW3aNHz++ed48OABfHx8wHEcLly4gHXr1mH+/PmqiJEQUg/IGq4qbZ+GdX/dQVnthqt0wjJrUoIAqpEkli5digYNGmDTpk0IDg4GANja2mL58uWYM2eO0gMkhGi+yiupljEg6Gj50tfSOqXrS4IY18UOY7zsUFhSVqc6o/ngnSQ4joO/vz/8/f3x4sULAECDBg2UHhghpP6ITZfsS2AMiEvPx8NntbfrWk1xAPz6tICvuxW2/HMP/9x5AqB85dRFA1wxvZfmTwuo0R7XlBwIIVUti5GaW4C8gmKpr03NLUBIZLI6wlQqDsDWjz3R0dFCVOZdkzojW1CEtNxCja01SMM7STx9+hTLli3DmTNn8PjxY5SViVcM8/LylBYcIaRuk7csRuVz0myM0IwEUXF1WG2Ow+rhbTC4na3EdTZmhvUmOQjxThKffvopUlJSMHXqVFhZWYHj6v4kFUKI8knrcBYuiwFA4hzHlTcxaZKZvVuge8vGcLQ0AoB6V0tQBO8kceHCBVy4cAHt2rVTRTyEkFqULXiFhwKBRNORtCYlaR3ObxhDWm4hnhYUS5xj/8130JQ8ETrOE4PaitcW3qXkIMQ7Sbi6uqKoSHM7mggh0l36l4P/pvMSTUfSmpR6ujTG/25mS9xDC8DNrGdYE35H6nvUtQTRs6Ul5vu6YNi2aLGkps1x6OBgUXuB1SG8k8S2bdsQFBSEZcuWoU2bNtDV1RU7b2qq3l2TCCE1ky0owtWUXBx8oCU2RPXLo7fgat1Aotko6GiCzGajMkBmgqgrRns1g42pAfq6NUE7u/JEsGa4B748egtvGBP1ObyLtQZpeCcJc3NzCAQC9O3bV+w4bTREiOapWEuovAjeG8ZwLS1farORpuIA+PdzkUgAYzrZo6dL43eyz6EqvJPEJ598Aj09Pezfv586rgnRYJU7nivT5jg4/ddhq6kGe9jgREJ2+Z7VANbK2dmtPo5MUgbeSeLWrVu4fv06WrVqpYp4CCFqIm/5bWGTi6FejaZS1SptjsPiwW4I7N8Sh8LPYPTAPrC3pLldfGnxfYGXlxcyMyU3+yCE1H3ZgiJEp+QiW1CEhCyB1GvmvOeMHRM6wK6hEbLyC9UcYdW6ODWUenySjwO0/2vZqNivYGNmgJZmDDZmBuoMs97g/TFh9uzZmDt3LhYuXAgPDw+Jjuu2bdsqLThCiHJkC4oQdiEVO6NSRU0vkhg4cNjyz331BscDB2Dz2PY4n/xEtBaUsBlpTCd7TO/VgvoVlIx3khgzZgyA8v0jhDiOo45rQuoo8c7pctJbmbg6N0QVeDu3omLtQFZHM/UrKB/vJJGamqqKOAghSpItKCpfUI8x2Dc0kts5XRfIm2D3+0wfNDE1kFo7oISgHryThKWlJYyNjVURCyGkBoRNSjuiqvtBTnZDlCpUXCSvYvMRUL6Ex9rhHqJ5DJQMag/vJGFlZYXRo0djypQp6N69uypiIoTwdPBahtxJboroa8NwNodTS61D2I8gXCRP2HwUm5YPjgM6OFhQYqgjeCeJAwcOYM+ePXjvvffg4OCAKVOmYMKECbC1lVwRURW2bduGDRs2IDs7G61bt8bmzZvRo0cPqdeePXsWffr0kTielJQEV9e6uek4IUKV10uS9bOxnrbYp/Dq4AAYajOM72IHZytTtG1mhsKSMhjpaSEhS4DHz4vxhjGEnknhfW8tDvh6aGsA5RPxGhrrSU0CNmaGGNyOEkNdwztJfPjhh/jwww/x9OlT7N27F3v27MHSpUvRv39/TJkyBUOGDIGOjmrGVh88eBDz5s3Dtm3b0K1bN/zwww8YMGAAEhMTYW9vL/N1d+/eFVsupHHjxiqJjxBlqbxe0jDPpjh2PUvs56NxWUrpaBb2CZx4qA08LB/ePqJDU2wa3R4ARE0+B69lQIv7b0VXADP7tICrtSk4DkjMfo5tZ1LEGqwqdjYLlw8nmof3PAmhRo0awd/fHzdu3EBISAj+/vtvjBw5Era2tli2bBkKC5U/vjokJARTp07FZ599Bjc3N2zevBl2dnbYvn273Nc1adIE1tbWoi9tbW2lx0aIskhbgvtIXJbEzzVNEFoc8M3Q1lLvcyQuCzcy82XGxABsP/sAHR0tMKitLRb2d0V0cF8cmNYV0cF9Rd9fCOqjkQmi4nySd121P/Ln5ORg7969CAsLQ0ZGBkaOHImpU6fi0aNHWLt2LS5fvoyIiAilBVpSUoLY2FgEBQWJHff19UV0dLTc13p6euLVq1dwd3fHkiVLpDZBCRUXF6O4+O0uWs+fPwcAlJaWorS0tAYleEt4H2Xdry6hstXc/ZznKu8X4ACsHOoOOwvZzTtXHuTC3dpEZkxvGEPKv89haVT+GLE00oGl/dsau/D72v5b4Pt7Oxz7EEt+TxTV2lYOdceojs1UGWK1Vfdvks/1vJPE0aNHERYWhlOnTsHd3R0zZ87Ep59+CnNzc9E17du3h6enJ99by5Wbm4s3b97AyspK7LiVlRVycnKkvsbGxgY7duxAx44dUVxcjJ9//hnvvfcezp49i549e0p9zZo1a7BixQqJ4xERETAyUu46NpGRkUq9X11CZau+f7I4lFfyVTXSiMG/zRsY/3sTDzIAQFvKezG8ykxEeHgiAOBZMcBBG6zCdRwYUuIv42mSisJUMkV+b8+KgeVxb8tZxoDFx2+jNOMmzPVVHWH18f2b5NPSwztJTJ48GWPHjsXFixfRqVMnqdc0b94cixcv5ntrhVReUFA4iU+aVq1aia0x5e3tjczMTGzcuFFmkggODkZAQIDo5+fPn8POzg6+vr5KWwa9tLQUkZGR6Nevn8SMdU1HZVNctuAV0p8WwqGRkWjJiGzBK8zbeL7G95Zn9UetxT4Z69o/xJfHE8WuGd7eFl+M8BA7pmtf+RN26zr7CbsiPr+3yw/ywOJixI4xcGjRvqvM5UBqU3X/JoUtJIrgnSSys7Or/ERtaGiIr776iu+t5bK0tIS2trZEreHx48cStQt5unbtil9++UXmeX19fejrS35k0NXVVfpDTxX3rCuobPLJ2hv65qMnCvU1cP/1NivaKqXFAR93tsesvs4So4rGdXVCd2dLbP3tDKwcW6Jfa2tRZ3Xl6/q4WWvssheK/N6crU1FnfNC2hyHFlamdfrvme/fJJ9reSeJO3fuQFdXFx4e5Z8yfv/9d4SFhcHd3R3Lly+Hnp4e31sqRE9PDx07dkRkZCSGDRsmOh4ZGYmhQ4cqfJ/r16/DxsZGFSGSd4y0LT0VfZ2svaGZghMdGCvfXrOhsT6eFhRj1v7rEteEjvNEBwcLhR7qNmYG6G7DMPA9Z7kPkPo+y9nGzJA2IKqEd5KYPn06goKC4OHhgQcPHmDs2LEYNmwYDh8+jMLCQmzevFkFYZYLCAjA+PHj4eXlBW9vb+zYsQMZGRmYMWMGgPKmoqysLOzduxcAsHnzZjg6OqJ169YoKSnBL7/8giNHjuDIkSMqi5G8G2TVBBQhb29o+4aK9XtpVZhwli0okvrpV3j+XX7AVQdtQCSOd5JITk5G+/btAQCHDx9Gz549sX//fly8eBFjx45VaZIYM2YMnj59iq+//hrZ2dlo06YNwsPD4eDgAKC8KSwjI0N0fUlJCRYsWICsrCwYGhqidevWOHHiBAYOHKiyGEn9ly14JbMmoMgD5ZfL6RLHtDkOjpZGiE3Pl/IKSZ91by42oW7RAFes/+suffpVEkqub/FOEowxlJWVAQD+/vtvDB48GABgZ2eH3Nxc5UYnhZ+fH/z8/KSe27Nnj9jPgYGBCAwMVHlM5N2S/rRQZk2gqgfLjcx8hCdIjsab0au5aP2iqmgBmNzdUaI2s+gDV7RtZk6ffolSVWvToZUrV+Lnn3/GuXPnMGjQIADlq8Py6UAmRBM9KwaeFpRIDBgV1gSqcjUtT+pxHW0OwUcll9ao/D4cB6z5b9RR5drM+pN3KUEQpeNdk9i8eTM++eQTHD9+HIsXL4azszMA4LfffoOPj4/SAySkrjgc+7B8DH3cTXCQvs9BVTo7Sh9G2chET+oEOomkwYCeLo3l9mtQkiDKxDtJtG3bFgkJklXiDRs20HIXpN7KFhRhye+JoklWDG+XtTAz1IWXjId/Ze3sLDCiQ1McicsSHRvoYY2GxvoS+ypoASir9PoyAGm5hXCyNJbaWa1IbYYQPpS2Ep+Bwdv9Y+VNcCNEE0n75F7GgKXHb4sShqIjnDaNbo8J3g6ISctHXkEJtp9LQXhCjkTtJPCDVlh38o7UREBDNYm6KJQk3NzcsHTpUowcOVLuPIh79+4hJCQEDg4OEmssEaLJpH1yB95+8i9jQNDRBJkjnCrPqWhnZ4Empgbotva02KJ5WhywdWz5Rjw2ZoYwN9KVmQhoqCZRB4WSRGhoKBYtWoSZM2fC19cXXl5esLW1hYGBAfLz85GYmIgLFy4gMTERs2bNkjn6iBBNdT75SZWL7jEGxKXnY1Bb8Ye1rDkVsmonjUz0FU4ENFSTqJpCSaJv3764du0aoqOjcfDgQezfvx9paWkoKiqCpaUlPD09MWHCBImF/gipD7IFRQoNTQUgsTOcvNnVivYrUCIgtYlXn4SPjw+NYCL1TlXLa6TmFii2nhKAjo7iax7JG4Xk3aIR9SuQOk81W8gRUkdVTgiKLK/hZGksMfIIEN+BTQvl8xcqP+Crqi1QvwKp6yhJkHqtYlI4n/xEYoZyxdFDspbXsDEzxNoRHmL7SHMcsHa4R5UPeEVGIVFzEqnLKEmQeqtyLYEx8dFI6/66IzEPQdaEtDGd7OHtZIHdv5+Bp6cnOrewFF1T1QOeagtEk1GSIPXSjcx8BB1NEHUkSxuZVIbyGgGrouNYyMbMAJ6WDAM9rHnvLUC1BaKpeK/dREhdIGuj+mxBEVafSMTQ0GiJkUaVaXMcgga4Qvu/iZ/UcUyIJIVrEo8ePUJISAiWLVsmsY2nQCDAypUrsWDBAlrkj6iMsH8h4aFA1JdQsbO5YvOSNBxXvvZRGd4mhDGd7DGknS01BREig8JJIiQkBM+fP5e6z7OZmRlevHiBkJAQrFu3TqkBEgJAZgIQdja7WjeQmyCEyURa3wA1BREim8LNTSdPnsSECRNknp8wYQL+97//KSUoQiqqPCGtsjeM4VpavuwEAeCYnw/GdLKHjZkhvFs0oqRAiIIUThKpqamwt5e9eFmzZs2QlpamjJgIESNtQlpF2hyHTo4W0JKypqRw/kI7OwvJk4SQKimcJAwNDeUmgbS0NBga0qczUjPSOqSFE9KkEfYttLOzwJrhHqJOaC0O+LxHc1wM7qvw3tOEEEkK90l06dIFP//8M3r27Cn1/N69e9G5c2elBUbePbJmP0ubkBY4oBXaNhXfqpPmIxCifAoniQULFqBfv34wMzPDwoULRaOY/v33X6xfvx579uxBRESEygIl9Zu8hfBszAwVTgDUCU2IcimcJPr06YPQ0FDMnTsX3377LUxNTcFxHAQCAXR1dbF161b07dtXlbGSeiw2XbLj+Q1jOHEzG4Pa2oge/pQACFEvXjOup0+fjsGDB+PQoUO4f/8+GGNwcXHByJEj0axZM1XFSOq5g9cyZC7FvfJEElaHJym86xshRLl4L8vRtGlT+Pv7qyIW8g4SNjPJmxwta+E9QojqKTy6KTY2Fn369MHz588lzgkEAvTp0wc3btxQanCk9sla/kJZqhreKiRceI8Qol4KJ4lNmzahb9++Mmdc9+vXDxs2bFBqcKR2HbyWgW5rT2PczivotvY0Dl7LUPp7SBveqgVIHJO38B4hRHUUThJXrlzB0KFDZZ7/8MMPER0drZSgSO2TNdpI2TUK4fDWiovsrRnhIXGMFt4jpHYo3CeRlZWFBg0ayDxvYmKC7OxspQRFap+8bTeV/bCWNbyV5jwQUvsUThKNGzfG3bt34eTkJPX8nTt3YGlpqbTASO2qattNZZM2vJWGvBJS+xRubnr//fexatUqqecYY1i9ejXef/99pQVGape0ZiBq8iHk3aNwTWLJkiXo2LEjunTpgvnz56NVq1bgOA5JSUnYtGkTkpOTERYWpspYiZrRMheEEIWTRIsWLfD3339j0qRJGDt2LLj/PmEyxuDu7o7IyEg4OzurLFCiPsLNfZwsjanJh5B3HK/JdF5eXrh16xbi4+Nx79490Yzr9u3bqyi8+kX48G1mpl/bocgka5E9Qsi7ifeMawBo3749JQaeKj98RztxGCjj2sqf5NWlqkX2CCHvnmolCcKPtIfvwQda8BO8gr2lrti1tflJXp3DXgkhmkHh0U2k+qQ9fBk4ZOSJLzNRnQlsylw2Q9rsZ5rpTMi7jZKEGkh7+HJgsG8o/vCV90leGmUvm0HDXgkhlWlckti2bRucnJxgYGCAjh07IioqSu71586dQ8eOHWFgYIDmzZvj+++/V1Okb1V++GpxwJjmZbAxMxC7Tt4n+co1BlUtmzGmkz0uBPXBgWldcSGoD3VaE/KOq1GfhIeHB8LDw2FnZ6eseOQ6ePAg5s2bh23btqFbt2744YcfMGDAACQmJsLeXvJhlpqaioEDB2LatGn45ZdfcPHiRfj5+aFx48YYMWKEWmIWGtPJHq7WDXAtLR/tm5ki6+ZFiWukbdO5engbnE9+ItFPYdfQSGX9BzTslRAiVKMkkZaWhtLSUmXFUqWQkBBMnToVn332GQBg8+bNOHXqFLZv3441a9ZIXP/999/D3t4emzdvBgC4ubkhJiYGGzdulJkkiouLUVxcLPpZuDR6aWlpjcp6OPYhlvyeKDa6qZ+U+w1vbwNvJwtk5BWKmqN6bzovVmMIPpqAQ593kVg2Q4sDmprpqfV3UpnwvWszBlWhsmkmKpvs1ylCY0Y3lZSUIDY2FkFBQWLHfX19Za4+e+nSJfj6+ood69+/P3bt2oXS0lLo6upKvGbNmjVYsWKFxPGIiAgYGVWvA/dZMfBVnDaA8rYk4egmt/9FwlzOlImnAO4JOJQxbbHjZQw4GxWN0U7l92HgwIFhtFMZrl88jety4njyikNjAyb3fZUhMjJStW9Qi6hsmonK9lZhoeJ7s9QoSfTo0QOGhupplsjNzcWbN29gZWUldtzKygo5OTlSX5OTkyP1+tevXyM3Nxc2NjYSrwkODkZAQIDo5+fPn8POzg6+vr5S99KQ5cZDAWLT89HRwQKXYh8CyBI7z8DBoY0XurVsIvHabMErpD8thEMjIzR9UYzQpCtglWoMowf2gY2ZAfwEr0S1jsp9HBUdjn2IFRVqMiuHumNUR+VvOVtaWorIyEj069dPahLWZFQ2zURlkyRt8zhZapQkwsPDa/LyahEuByLEGJM4VtX10o4L6evrQ19f8mO2rq6uwr+E+YficSQuq4qrGJo3MZW4Z8V5EpzoyreE/RT2luXLtttb6oq+lyVbUCRq6gLKayJLf09CHzdrlfU98Pn30jRUNs1EZRO/XlEa09xkaWkJbW1tiVrD48ePJWoLQtbW1lKv19HRQaNGjVQS543MfAUSBODT5O3oJuEMa2M9bbERS5V39dQCcNTPG+3sLHjFRJPkCCHVpTFJQk9PDx07dkRkZCSGDRsmOh4ZGSlzxzxvb2/8+eefYsciIiLg5eWlsk8UV9PyFLrOxaz8v2I1Bw5izUqVlQEoLCnjHZO694YghNQfGjVPIiAgAD/++CN2796NpKQk+Pv7IyMjAzNmzABQ3p8wYcIE0fUzZsxAeno6AgICkJSUhN27d2PXrl1YsGCBymLs7NhQoeucGjBkC16J1xzkJAghIz3+vzKaJEcIqS6NqUkAwJgxY/D06VN8/fXXyM7ORps2bRAeHg4HBwcAQHZ2NjIy3s46dnJyQnh4OPz9/REaGgpbW1ts2bJFpXMk2tlZYESHpjKbnDgAqz5yh/G/N5H+tFCiGQgoz9yy6gvVqUkAtDcEIaR6apQkiouLpXbyqpKfnx/8/PykntuzZ4/EsV69eiEuLk7FUYnbNLo9Jng7ICYtH16OFmhiaoC49HwwBnR0tIClkQ7Cw2/CoZGR1Gago37eyMwrwpxfryu1iYgmyRFC+OKVJE6dOoUDBw4gKioKGRkZKCsrg5GRETp06ABfX19MnjwZtra2qopVo7SzsxDrYB7U9u3DWTiRxcbMQOoMa+FrC0peS5xTxkNe1lLktbVEOSGk7lIoSRw/fhyLFi2CQCDAwIEDsXDhQjRt2hSGhobIy8vDrVu38Pfff+Obb77BpEmT8M0336Bx48aqjr1ekNcMpIomIllLkdNmQ4QQaRRKEqtXr8bGjRsxaNAgaGlJdpyOHj0aAJCVlYX/+7//w969ezF//nzlRlqPyWsGUmYTkaxFAV2tG9BmQ4QQqRRKElevXlXoZk2bNsX69etrFBBRHVnzJa6l5dM8CkKIVBo1BJbUjKylyDs5WtBmQ4QQqZSWJDIzMzFlyhRl3Y6ogKz5Eu3sLGgeBSFEKqXNk8jLy8NPP/2E3bt3K+uWRAVkdYbTPApCiDQKJ4k//vhD7vkHDx7UOBiiHrI6w+V1ktPwWELeTQoniY8++ggcx4lWUZVG3mqsRHPR8FhC3l0K90nY2NjgyJEjKCsrk/ql7lnNRD1UtZc2IUQzKJwkOnbsKDcRVFXLIJpJ3jLj6pAtKEJ0Si4lJUJqicLNTQsXLkRBQYHM887Ozjhz5oxSgiJ1R20uM66MZi7qSyGkZhROEj169JB73tjYGL169apxQKRuEQ6bVcUaUvLIaubiMwuc+lIIqTmNWiqc1I7aGB5b0930lJFkCCGUJIiC1L3MeHWbuYTNS3kFJbTUCCFKQEmC1EnVaeYS2woW5V8V8wQtNUIIf5QkSJ2laDNXtqAIsen5CDqSIEoKDOVJQlgboaVGCKkeShKkTquqmati7aEyBmCBrwv0dbTRybF8Iyca7UQIP9VKEnfv3sXWrVuRlJQEjuPg6uqK2bNno1WrVsqOjxCRyg/4yp3T0mw4lQygvEbRzdkSF+/nikY7LfrAFR7NzChhECIH7yTx22+/4eOPP4aXlxe8vb0BAJcvX0abNm2wf/9+jBo1SulBEiJtOKtdQyO5CaKiMgZE3csV+3nNX3cA0PBYQuThnSQCAwMRHByMr7/+Wuz4V199hUWLFlGSIEonazjrUT9viRFQlX9WBA2PJUQ23vtJ5OTkYMKECRLHP/30U+Tk5CglKEIqkjVnorCkTGIfDL/eLar1HjVdaoSWDyH1Fe+aRO/evREVFQVnZ2ex4xcuXKhyVjYh1SFvzoR3i0ZiI6BScwvw3ZkU3u9Rk+GxNLOb1Ge8k8SQIUOwaNEixMbGomvXrgDK+yQOHz6MFStWiO07MWTIEOVFSt5ZVc2ZqDwCSlqTk3DOhBaAz3o6oZGJPtb/dVfsfgAQnZKrcEd2tqAIMWl5YkNvyxgQdDSBmq5IvcE7Sfj5+QEAtm3bhm3btkk9B5SvCvvmzZsahkdIOUXnTMhKKNJeO6SdrejY+eQn8FlzWjS/Yu0I+bUBuUNvGRCXno9BbSlJEM3HO0mUlZWpIg5CqqTo0iCyEkrl1wrvly0okpiIF3REvDaQLSjC/ZzneFYMZAteVTn0Vtqq+TRHg2gimkxH6iU+a03FpOWh8jOdAYhNy8fgdoaVlvvQRoZhutwEwQHo6Gghdkxav0VPl8aUNEidV60kce7cOWzcuFE0mc7NzQ0LFy6kjmuikWRtu8txksNvGTiERadLrAtVEQNwPvmJqLlK2hDeoCMJ4P7rO6HOblKX8R4C+8svv+D999+HkZER5syZg1mzZsHQ0BDvvfce9u/fr4oYCVGpjg4WqJwmOA7o4GAhdfhtGQOm9XSS+z/Pl0dv4UZmPqJTchGbni9xDwZIzPug4bOkLuJdk1i1ahXWr18Pf39/0bG5c+ciJCQE33zzDcaNG6fUAAlRNRszQ6wd4SHRHCRsApI2YW9yNycM8rDBR9uipfY/vGFMdE7airTSrq9qGXPhaCqO42BnYYiCkjfUVEVUjneSePDgAT788EOJ40OGDMGXX36plKAIUTd5nd0VR0txYFg5tLWoz2PtcA+5o5wAyRVptf47xmcZ84PXMrDoSILEcWqqIqrGO0nY2dnhn3/+kZhM988//8DOzk5pgRGibrI6u4UJJOXf50iJv4xRHZtJnAu7mIofz6eiDOVJoPIYQAZg61hPNDLRh6OlETaeuosjcVmi8x952spdCl1aggDKk04wzcsgKsQ7ScyfPx9z5sxBfHw8fHx8wHEcLly4gD179uD//u//VBEjIbXOxswQlkY6eJok/dyXA90xuZsT0nILYaSnhWHboiVmiHd0tBANuT12PUvsHsfisrCgfyupD/qYtDy5sZUxIOxiKr4c6A6AhtoS5eKdJL744gtYW1tj06ZNOHToEADAzc0NBw8exNChQ5UeICGaomJNRN4Mcamd4QDCLqThy0FuEveVNfqqop3nUzG5mxPOJz+hJUKIUlVrCOywYcMwbNgwZcdCSL0hb4a4k6Wx1I7sHy88wOTujhKf/oWjr+R1fAvndUhbLbfypECqZRA+eA+Brejly5d4/vy52Jeq5OfnY/z48TAzM4OZmRnGjx+PZ8+eyX3NpEmTwHGc2JdwvSlCVM3GzBDeLRpJnek9rYeTxPVlDFJXoj2f/ERughDaf1Vykl/F1W1/OJ8Cn7WnMW7nFXRbexoHr2UoXBby7uKdJFJTUzFo0CAYGxvDzMwMFhYWsLCwgLm5OSwsLKq+QTWNGzcO8fHxOHnyJE6ePIn4+HiMHz++ytd98MEHyM7OFn2Fh4erLEZCFDW5uxO0KrUiVR7hlC0owv9uPkKQjE7ryqJTJPsutDgg9+UrbDh1B2vC74hGXAk7vP+8kSU2PyNb8EpsyXNaAp3wbm765JNPAAC7d++GlZWVQu2lNZWUlISTJ0/i8uXL6NKlCwBg586d8Pb2xt27d+Vum6qvrw9ra2uF36u4uBjFxcWin4W1o9LSUpSWllazBOKE91HW/eoSKptiLI10sHKoO5b8nijqP/hmqBssjXRQWlqKw7EPReeqi0P5MNzZB+Klni/775wWB6wY3ArXsjjM23i+fLVcDvionQ2O38gWxbdyqLvYyC5NQX+Tsl+nCI4xaVOBZDMxMUFsbKxa97PevXs3AgICJJqXzM3N8e2332Ly5MlSXzdp0iQcP34cenp6MDc3R69evbBq1So0adJE5nstX74cK1askDi+f/9+GBlVb78BQmR5Vgw8ecWhsQGDuf7bY8vjtMEk5oHzJZyhoei1qHS9+Os5MCzv8EYUJ9FchYWFGDduHAQCAUxNTeVey7sm0alTJ2RmZqo1SeTk5Eh9sDdp0kTubngDBgzAqFGj4ODggNTUVCxduhR9+/ZFbGws9PWl/6UHBwcjICBA9PPz589hZ2cHX1/fKv8xFVVaWorIyEj069cPurq6SrlnXUFlq7nLD/LA4mKUcCc+SUbateLHGDi0aN8V9g2NkP60EA6NjGBjZlCjCNWB/iYl8ek/5p0kfvzxR8yYMQNZWVlo06aNRGBt27ZV+F6yPrVXdO3aNQDShwEyxuQ2d40ZM0b0fZs2beDl5QUHBwecOHECw4cPl/oafX19qQlEV1dX6X9gqrhnXUFlqz5na1OpS4GsGNIaX/1xW+x4VaOelEmb43A75yUmhMVo5BBb+psUv15RvJPEkydPkJKSItbEw3Gc6IHNZ6OhWbNmYezYsXKvcXR0xM2bN/Hvv/9KjcXKykrh97OxsYGDgwPu3bun8GsIUTdZGyeN6WQPPR0tieP3H7/EzqhUpcfhbmOKO9nPy2eRc8CM3s2x7q87cofYkvqHd5KYMmUKPD09ceDAgRp3XFtaWsLS0rLK67y9vSEQCHD16lV07twZAHDlyhUIBAL4+Pgo/H5Pnz5FZmYmbGxsqh0zIeoga56FtOPZgiL8GJWq9BpFYvbbJokyBoRK2TtckYUJiWbjnSTS09Pxxx9/SKzdpEpubm744IMPMG3aNPzwww8AgM8//xyDBw8W6xtxdXXFmjVrMGzYMLx8+RLLly/HiBEjYGNjg7S0NHz55ZewtLSkiYBEI8haS6ryceEqtkFHE6SuSKtKHICfolNx9u6/8GhmTqvT1kO8k0Tfvn1x48YNtSYJANi3bx/mzJkDX19fAOWrzn733Xdi19y9excCgQAAoK2tjYSEBOzduxfPnj2DjY0N+vTpg4MHD6JBgwZqjZ0QVRPWMOLS88FY+c54W0/fw/4rmSp9Xwbg5G3JpuCK/RXyZnnTDPC6j3eS+PDDD+Hv74+EhAR4eHhIdIAMGTJEacFV1LBhQ/zyyy9yr6k4mtfQ0BCnTp1SSSyE1EU2ZoYY1Pbtg3Z235b49WpmjeZaVFcZA4KPJODGw2c4cCVTNPeiYuLYfSEVuy6k/rctLDC0vQ3sGhrhfTcrtLNT3cRcwg/vJDFjxgwAwNdffy1xjm/HNSFEdaR1gH/kaSu2RLkqlQFiNZkyBiw6koCMvEJsO5Mi1ofCAByPzwYAbD2dghEdmmLT6PYAqLZR23gnibKyyivlE0LqKmkd3Qv6t8LRuIfYcCq5VmKS1gFe2ZG4LDhZGuPRsyIcuJopmtY3rYcTujRviAe5Bejs2JBqHGrAO0mkpqbCyUlycTJCSN0kraN7Zp+W0NHWwprwO7UYmXwbI8STGAOwIyoVOyoM9+3R0hILfF2QmV8Exhi8HBuKlTVbUIT7Oc/xrBikmngnCWdnZ/Ts2RNTp07FyJEjYWBQ92dcEkIkTe/ZAum5Bdh/VbWd26oUdS8XUfdyxY593sMJk7s74Y8bj7D2rzv/7TOuDV37hxjXlT7g8sV7FdgbN27A09MT8+fPh7W1NaZPn46rV6+qIjZCiIrNfq+l1NVof5/pgwPTuuL3mT4S5+u6HVGp8F5zWmzVWwYOS35PrLTiLa1wqwjeSaJNmzYICQlBVlYWwsLCkJOTg+7du6N169YICQnBkydPVBEnIUQFhJ3bwkSgxQGrh7dBOzsLeLdohIKSN7UyOkoVhNu8AsDBaxnoVmFvjVUnEilZyFDtTYd0dHQwbNgwHDp0COvWrUNKSgoWLFiAZs2aYcKECcjOzlZmnIQQFRnTyR5n5/fELPc3ODu/p9haTE6WxhI1CS0O2DWxY43XqK0NO86n4p+kHAQdEd/Bb+d/tY+Np+5Q7aKSaieJmJgY+Pn5wcbGBiEhIViwYAFSUlJw+vRpZGVl0X7XhGgQGzMDtDRjEqu6Cmsa2v8tv6PNcVgz3APvuVlj7QiPmm1tWUum/hQrcwmT786k0M59lfDuuA4JCUFYWBju3r2LgQMHYu/evRg4cCC0tMr/XJycnPDDDz/A1dVV6cESQtRP3jpSrtYN8NG2aLUvB6JqtHjhW7w/CGzfvh3jxo1DRkYGjh8/jsGDB4sShJC9vT127dqltCAJIbVL1n7d7ewssLZSTSN4gCs+7+mkkc1RFVXcH/xdxrsmocgy23p6epg4cWK1AiKEaBZZNY3J3ZyQlluIwpJSTP0ptpaj5K/ynuPvKt5J4uTJkzAxMUH37t0BAKGhodi5cyfc3d0RGhoKCwuaAUnIu0bairUVj43o0FRty4Eoi7WZPi7ce4KMvEI0MTWArZkBLtx/CjCG7i0t8ejZKzx+8arerzXFO0ksXLgQ69atAwAkJCRg/vz5CAgIwOnTpxEQEICwsDClB0kI0WybRrfHQA9rjapRZD17hYW/JUg9FxadLvq+8lpT9U21luVwd3cHABw5cgSDBw/G6tWrERcXh4EDByo9QEJI/fCemzXWjXi74KAWgP5trBFx+1+80fCe7yNxWSh5/QaWJvr4yLNpvapZ8E4Senp6KCws78z5+++/MWHCBADlS3nz2VybEPLukbWz3omb2Vh5Iqm2w6uRP2/mACivZXRxaohPu9pLrCWliXgnie7duyMgIADdunXD1atXcfDgQQBAcnIymjVrpvQACSH1i7QFBwe1tcHq8KR6M7v7SmoerqTmAQBm9m4Bc2NdNLc0hqGejsYtec47SXz33Xfw8/PDb7/9hu3bt6Np06YAgL/++gsffPCB0gMkhNR/lfe+0EL5qq8Vc4YWB41MIqFnJZdGDx7gium9WtRCNPzxThL29vb43//+J3H822+/VUpAhJB3U+WmqPPJT8Q2TAoc0Arr/rqjkYmisjV/3cGNzGfwdDCv8/tiKJQkCgoKYGxsrPBN+V5PCCGAeFOUtP4Lc0NdUeLQdOG3chB+q7wfo4WlMb4c5Fonh9UqNOPa2dkZq1evxqNHj2RewxhDZGQkBgwYgC1btigtQELIu6vyTO8xnexxIagPvvvYU+OWMJcnJbcAU3+KxdLfb2Pr6RQMDY3G/EPxtR0WAAVrEmfPnsWSJUuwYsUKtG/fHl5eXrC1tYWBgQHy8/ORmJiIS5cuQVdXF8HBwfj8889VHTch5B1lY2aIhiYFMpudtDkOM3o1x7azKTIX8tMER+KyMNDDGu+5WddqHAoliVatWuHw4cN4+PAhDh8+jPPnzyM6OhpFRUWwtLSEp6cndu7cKbbQHyGEqIpwCfPKiUIL5fthjOlkj0+9HZCWWwhdLYbQP6JxJlu7VmKtiak/xaKLkwU2j/WstRFRvDqumzVrBn9/f/j7+6sqHkIIqZLEaCgO+Kx7c0zu7ih6mAr7N0pLS/GRI8PQHm0x79DNWo6cvyup+fBecxrrRniI7fWhLrxHNxFCSF0ga2FBWTrYm2vsMFoAWHQkoVaWLqe2IUKIxpK1hLn0aw0wtbuTGqJSndAz4qtwZwte4Z6AQ7bglcrek5IEIeSdMaW7/H0u6vqIqVMJOaLvD17LQO9N5/FdojZ6bzqvsp30KEkQQt4ZNmaGWDvi7SZJHAdR0tDmOJk1DQ5A8EBX9He3Uk+gMjwpKEW2oAjZgiIEHxXfp/vLo7dUsjc39UkQQt4plfsyAIh9v+tCqli/hRaAYzN9yie39QS+PHYT+69kSty3k70FrmXkqzz+tNxCMDCJvhXhTnrK7rNQuCZx7949fPzxx1JXehUIBBg3bhwePHig1OAIIUQVKvZlVP5+TaXtWNeM8BCb/ezQSHI1CW2Ow8TujmqJ3dHSSDQEuHIMqthJT+GaxIYNG2BnZwdTU1OJc2ZmZrCzs8OGDRuwfft2pQZICCHqJG/UVLagCOv+uiPxmsAPWqGjg4XKR0+tG+EhimfNcA9Rk5MWVz4/RBUjnxROEufPn8fPP/8s8/zo0aMxbtw4pQRFCCG1Sdp2rACQmit9pnfbZuawMTPEogGuWBMumURqqn9rKywf0lospjGd7OHtZIFD4WcwemAf2Fs2UPr7AjySRHp6Opo0aSLzvKWlJTIzJdvpCCGkvpA207tiM49HUzOlvt/nPZ0wuZuTzBqCjZkBWpox2JgZKPV9K1K4T8LMzAwpKZLrogvdv39falMUIYTUF9L6LCo280jrK6iOKd0ccSm4L74c6F7rGxQpXJPo2bMntm7dir59+0o9v2XLFvTo0UNpgRFCSF0kr89CmESCjiZAuJo5B8CvdwvcyXmB03ceiy06yAESixBqcxym9Wxe68lBSOEkERwcDG9vb4wcORKBgYFo1aoVAODOnTtYv349Tp06hejoaJUFSgghdYWsPgvgbRKJS88HY0BHRwvRtdmCIqTlFsJITwuFJWVSN1dSVQd0dSmcJDw9PfHbb79hypQpOHbsmNi5Ro0a4dChQ+jQoYPSAxRatWoVTpw4gfj4eOjp6eHZs2dVvoYxhhUrVmDHjh3Iz89Hly5dEBoaitatW6ssTkIIKd+3W/JBLy258F2DSt14TaYbPHgw0tPTcfLkSdy/fx+MMbi4uMDX1xdGRsofn1tRSUkJRo0aBW9vb+zatUuh16xfvx4hISHYs2cPXFxcsHLlSvTr1w93795FgwaqGQlACCF8yauZ1DbeM64NDQ0xbNgwVcQi14oVKwAAe/bsUeh6xhg2b96MxYsXY/jw4QCAn376CVZWVti/fz+mT5+uqlAJIaTeUDhJnD59GrNmzcLly5clRjEJBAL4+Pjg+++/rzOd16mpqcjJyYGvr6/omL6+Pnr16oXo6GiZSaK4uBjFxcWin4UzzEtLS1FaWqqU2IT3Udb96hIqm2aismmm6paNz/UKJ4nNmzdj2rRpMmdcT58+HSEhIXUmSeTklK+WaGUlviCXlZUV0tPTZb5uzZo1olpLRREREUpvUouMjFTq/eoSKptmorJpJr5lKywsVPhahZPEjRs3sG7dOpnnfX19sXHjRoXfGACWL18u9YFc0bVr1+Dl5cXrvhVxnPigZcaYxLGKgoODERAQIPpZIBDA3t4e3t7eSuvHKC0txZkzZ9CnTx/o6uoq5Z51BZVNM1HZNFN1y/bixQsA5c/DqiicJP7991+5Qejo6ODJkyeK3g4AMGvWLIwdO1buNY6OjrzuKWRtXb55eE5ODmxsbETHHz9+LFG7qEhfXx/6+vqin4XNTU5Omr1ZCSGEVPbixQuYmcmfJa5wkmjatCkSEhLg7Ows9fzNmzfFHsaKsLS0hKWlJa/XKMrJyQnW1taIjIyEp6cngPIRUufOnZNbI6rM1tYWmZmZaNCggdwaCB/Pnz+HnZ0dMjMz690sdSqbZqKyaabqlo0xhhcvXsDW1rbKaxVOEgMHDsSyZcswYMAAGBiIrxNSVFSEr776CoMHD1Y4SL4yMjKQl5eHjIwMvHnzBvHx8QAAZ2dnmJiYAABcXV2xZs0aDBs2DBzHYd68eVi9ejVatmyJli1bYvXq1TAyMuK1EKGWlhaaNWumiiLB1NS03v3RClHZNBOVTTNVp2xV1SCEFE4SS5YswdGjR+Hi4oJZs2ahVatW4DgOSUlJCA0NxZs3b7B48WJeQfKxbNky/PTTT6KfhbWDM2fOoHfv3gCAu3fvQiAQiK4JDAxEUVER/Pz8RJPpIiIiaI4EIYQoiGOK9Fz8Jz09HV988QVOnTol6vDgOA79+/fHtm3bqt1/8K55/vw5zMzMIBAI6t0nGyqbZqKyaSZ1lI3XZDoHBweEh4cjPz9fNOO6ZcuWsLCwqPrFRERfXx9fffWVWAd5fUFl00xUNs2kjrLxqkkQQgh5tyi8nwQhhJB3DyUJQgghMlGSIIQQIhMlCUIIITJRklCBbdu2wcnJCQYGBujYsSOioqLkXn/u3Dl07NgRBgYGaN68Ob7//ns1RVo9fMp39OhR9OvXD40bN4apqSm8vb1x6tQpNUbLD9/fndDFixeho6OD9u3bqzbAGuBbtuLiYixevBgODg7Q19dHixYtsHv3bjVFyw/fsu3btw/t2rWDkZERbGxsMHnyZDx9+lRN0Srm/Pnz+PDDD2FrawuO43D8+PEqX6OSZwkjSvXrr78yXV1dtnPnTpaYmMjmzp3LjI2NWXp6utTrHzx4wIyMjNjcuXNZYmIi27lzJ9PV1WW//fabmiNXDN/yzZ07l61bt45dvXqVJScns+DgYKarq8vi4uLUHHnV+JZN6NmzZ6x58+bM19eXtWvXTj3B8lSdsg0ZMoR16dKFRUZGstTUVHblyhV28eJFNUatGL5li4qKYlpaWuz//u//2IMHD1hUVBRr3bo1++ijj9QcuXzh4eFs8eLF7MiRIwwAO3bsmNzrVfUsoSShZJ07d2YzZswQO+bq6sqCgoKkXh8YGMhcXV3Fjk2fPp117dpVZTHWBN/ySePu7s5WrFih7NBqrLplGzNmDFuyZAn76quv6myS4Fu2v/76i5mZmbGnT5+qI7wa4Vu2DRs2sObNm4sd27JlC2vWrJnKYqwpRZKEqp4l1NykRCUlJYiNjRXb6AgoX0Y9Ojpa6msuXbokcX3//v0RExNT5zZJqU75KisrK8OLFy/QsGFDVYRYbdUtW1hYGFJSUvDVV1+pOsRqq07Z/vjjD3h5eWH9+vVo2rQpXFxcsGDBAhQVFakjZIVVp2w+Pj54+PAhwsPDwRjDv//+i99++w2DBg1SR8gqo6pnCe/tS4lsubm5ePPmjdSNjoSbIFWWk5Mj9frXr18jNzeX98q6qlSd8lW2adMmFBQUYPTo0aoIsdqqU7Z79+4hKCgIUVFR0NGpu/8rVadsDx48wIULF2BgYIBjx44hNzcXfn5+yMvLq1P9EtUpm4+PD/bt24cxY8bg1atXeP36NYYMGYKtW7eqI2SVUdWzhGoSKsB3oyNp10s7XlfwLZ/QgQMHsHz5chw8eBBNmjRRVXg1omjZ3rx5g3HjxmHFihVwcXFRV3g1wuf3VlZWBo7jsG/fPnTu3BkDBw5ESEgI9uzZU+dqEwC/siUmJmLOnDlYtmwZYmNjcfLkSaSmpmLGjBnqCFWlVPEsqbsffzSQpaUltLW1JT7ByNvoyNraWur1Ojo6aNSokcpirY7qlE/o4MGDmDp1Kg4fPoz3339flWFWC9+yvXjxAjExMbh+/TpmzZoFoPzByhiDjo4OIiIi0LdvX7XEXpXq/N5sbGzQtGlTseWk3dzcwBjDw4cP0bJlS5XGrKjqlG3NmjXo1q0bFi5cCABo27YtjI2N0aNHD6xcubJO1d75UNWzhGoSSqSnp4eOHTtK7DcbGRkJHx8fqa/x9vaWuD4iIgJeXl51bqvF6pQPKK9BTJo0Cfv376+z7b58y2ZqaoqEhATEx8eLvmbMmIFWrVohPj4eXbp0UVfoVarO761bt2549OgRXr58KTqWnJys0v1VqqM6ZSssLISWlvijT1tbG4Bi23nWVSp7ltSo25tIEA7H27VrF0tMTGTz5s1jxsbGLC0tjTHGWFBQEBs/frzoeuGwNX9/f5aYmMh27dqlEUNgFS3f/v37mY6ODgsNDWXZ2dmir2fPntVWEWTiW7bK6vLoJr5le/HiBWvWrBkbOXIku337Njt37hxr2bIl++yzz2qrCDLxLVtYWBjT0dFh27ZtYykpKezChQvMy8uLde7cubaKINWLFy/Y9evX2fXr1xkAFhISwq5fvy4a2quuZwklCRUIDQ1lDg4OTE9Pj3Xo0IGdO3dOdG7ixImsV69eYtefPXuWeXp6Mj09Pebo6Mi2b9+u5oj54VO+Xr16MQASXxMnTlR/4Arg+7urqC4nCcb4ly0pKYm9//77zNDQkDVr1owFBASwwsJCNUetGL5l27JlC3N3d2eGhobMxsaGffLJJ+zhw4dqjlq+M2fOyP1/R13PEloqnBBCiEzUJ0EIIUQmShKEEEJkoiRBCCFEJkoShBBCZKIkQQghRCZKEoQQQmSiJEEIIUQmShKEEEJkoiRBCCFEJkoS5J11/fp1jBo1ClZWVjAwMICLiwumTZuG5ORkseuOHDmC3r17w8zMDCYmJmjbti2+/vpr5OXl1VLkhKgPJQnyTvrf//6Hrl27ori4GPv27UNSUhJ+/vlnmJmZYenSpaLrFi9ejDFjxqBTp07466+/cOvWLWzatAk3btzAzz//XIslkFRSUlLbIZD6qMarPxGioF69erFZs2axuXPnMnNzc9akSRP2ww8/sJcvX7JJkyYxExMT1rx5cxYeHi56zevXr9mUKVOYo6MjMzAwYC4uLmzz5s2i80VFRczd3Z1NmzZNdOzBgwfM1NSU7dixQ2ocBQUFzNLSUubG9/n5+Ywxxq5cucIAiL2ftOukuXnzJuvTpw8zMDBgDRs2ZNOmTWMvXrxgjDF28uRJpq+vL/H62bNns549e4p+vnjxIuvRowczMDBgzZo1Y7Nnz2YvX74UnXdwcGDffPMNmzhxIjM1NWUTJkyQGsvhw4dZmzZtRLG899577OXLl+zcuXNMR0eHZWdni10fEBDAevTowRgrXzHVzMyM/fnnn8zFxYUZGhqyESNGsJcvX7I9e/YwBwcHZm5uzmbNmsVev34tukdeXh4bP348Mzc3Z4aGhuyDDz5gycnJovPC+x47doy1bNmS6evrs/fff59lZGSIromPj2e9e/dmJiYmrEGDBqxDhw7s2rVrMv/NiWpQkiBq06tXL9agQQP2zTffsOTkZPbNN98wLS0tNmDAALZjxw6WnJzMvvjiC9aoUSNWUFDAGGOspKSELVu2jF29epU9ePCA/fLLL8zIyIgdPHhQdN/r168zPT09duzYMfb69WvWrVs3NnToUJlxHD16lAFg0dHRcuOdM2cOMzExYSUlJbzKWVBQwGxtbdnw4cNZQkIC++eff5iTk5No9c7Xr18zKysr9uOPP4peIzz2ww8/MMbKk4yJiQn79ttvWXJyMrt48SLz9PRkkyZNEr3GwcGBmZqasg0bNrB79+6xe/fuScTy6NEjpqOjw0JCQlhqaiq7efMmCw0NFSUsFxcXtn79etH1paWlrEmTJmz37t2MsfKHua6uLuvXrx+Li4tj586dY40aNWK+vr5s9OjR7Pbt2+zPP/9kenp67NdffxXdZ8iQIczNzY2dP3+excfHs/79+zNnZ2fRv6Xwvl5eXiw6OprFxMSwzp07Mx8fH9E9WrduzT799FOWlJTEkpOT2aFDh1h8fDyv3wWpOUoSRG169erFunfvLvr59evXzNjYWGxN/OzsbAaAXbp0SeZ9/Pz82IgRI8SOrV+/nllaWrLZs2cza2tr9uTJE5mvX7duHQPA8vLy5MY7YMAA1rZt26qKJWHHjh3MwsJC7FP/iRMnmJaWFsvJyWGMlSegvn37is6fOnWK6enpiWIaP348+/zzz8XuGxUVxbS0tFhRURFjrDxJyKoNCcXGxjIAor0VKlu3bh1zc3MT/Xz8+HFmYmIiij0sLIwBYPfv3xddM336dGZkZCRKNIwx1r9/fzZ9+nTGGGPJyckMALt48aLofG5uLjM0NGSHDh0Su+/ly5dF1yQlJTEA7MqVK4wxxho0aMD27Nkjt3xE9ahPgqhV27ZtRd9ra2ujUaNG8PDwEB0Tbjn5+PFj0bHvv/8eXl5eaNy4MUxMTLBz505kZGSI3Xf+/Plo1aoVtm7dirCwMFhaWsqMgSm4Oj5TcO/uypKSktCuXTsYGxuLjnXr1g1lZWW4e/cuAOCTTz7B2bNn8ejRIwDAvn37MHDgQFhYWAAAYmNjsWfPHpiYmIi++vfvj7KyMqSmporu6+XlJTeWdu3a4b333oOHhwdGjRqFnTt3Ij8/X3R+0qRJuH//Pi5fvgwA2L17N0aPHi0Wu5GREVq0aCH62crKCo6OjjAxMRE7JvydJSUlQUdHR2x3vkaNGqFVq1ZISkoSHdPR0RGL39XVFebm5qJrAgIC8Nlnn+H999/H2rVrkZKSIresRDUoSRC1qryNIsdxYseED+WysjIAwKFDh+Dv748pU6YgIiIC8fHxmDx5skQn7ePHj3H37l1oa2vj3r17cmNwcXEBANy5c6fK61JSUlBaWqpY4f4jL7kIj3fu3BktWrTAr7/+iqKiIhw7dgyffvqp6LqysjJMnz5dbHvUGzdu4N69e2IP7IoPc2m0tbURGRmJv/76C+7u7ti6dStatWolSjRNmjTBhx9+iLCwMDx+/Bjh4eGYMmWK2D2q+p0Jjwl/Z7KSsLR/F2n/TsJjy5cvx+3btzFo0CCcPn0a7u7uOHbsmNzyEuWjJEHqtKioKPj4+MDPzw+enp5wdnaW+olyypQpaNOmDfbu3YvAwEAkJibKvKevry8sLS2xfv16qeefPXsGABg3bhxevnyJbdu2yb2uMnd3d8THx6OgoEB07OLFi9DS0hIlKOH99+3bhz///BNaWlpi+3936NABt2/fhrOzs8SXnp6ezLJJw3EcunXrhhUrVuD69evQ09MTe9h+9tln+PXXX/HDDz+gRYsW6NatG6/7V+bu7o7Xr1/jypUromNPnz5FcnIy3NzcRMdev36NmJgY0c93797Fs2fP4OrqKjrm4uICf39/REREYPjw4QgLC6tRbIQ/ShKkTnN2dkZMTAxOnTqF5ORkLF26FNeuXRO7JjQ0FJcuXcLevXsxbtw4jBw5Ep988onMIaHGxsb48ccfceLECQwZMgR///030tLSEBMTg8DAQMyYMQMA0KVLFwQGBmL+/PkIDAzEpUuXkJ6ejn/++QejRo3CTz/9JPX+n3zyCQwMDDBx4kTcunULZ86cwezZszF+/HhRc5rwuri4OKxatQojR46EgYGB6NyiRYtw6dIlzJw5E/Hx8bh37x7++OMPzJ49m9e/35UrV7B69WrExMQgIyMDR48exZMnT8Qe1v3794eZmRlWrlyJyZMn87q/NC1btsTQoUMxbdo0XLhwATdu3MCnn36Kpk2bYujQoaLrdHV1MXv2bFy5cgVxcXGYPHkyunbtis6dO6OoqAizZs3C2bNnkZ6ejosXL+LatWticRM1qdUeEfJO6dWrF5s7d67YMQcHB/btt9+KHQPAjh07xhhj7NWrV2zSpEnMzMyMmZubsy+++IIFBQWJ9pJOSkpihoaGbP/+/aLXCwQC5ujoyAIDA+XGc+3aNTZ8+HDWuHFjpq+vz5ydndnnn38uMUro4MGDrGfPnqxBgwbM2NiYtW3bln399dfVHgJbUadOnRgAdvr0aYlzV69eZf369WMmJiai9121apXcf7vKEhMTWf/+/UVldHFxYVu3bpW4bunSpUxbW5s9evRI7LhwqGpF0vbynjhxotiIMuEQWDMzM2ZoaMj69+8vdQjskSNHWPPmzZmenh7r27evqIO9uLiYjR07ltnZ2TE9PT1ma2vLZs2aJeq0J+pDe1wTQjBt2jT8+++/+OOPP9Tyfnv27MG8efNkNtmRukOntgMghNQegUCAa9euYd++ffj9999rOxxSB1GSIOQdNnToUFy9ehXTp09Hv379ajscUgdRcxMhhBCZaHQTIYQQmShJEEIIkYmSBCGEEJkoSRBCCJGJkgQhhBCZKEkQQgiRiZIEIYQQmShJEEIIken/Ae/Ku02b5IXFAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "CC_dif=reindexing_record[\"CC_symop1\"] - reindexing_record[\"CC_symop0\"]\n",
     "CC_max=reindexing_record.apply(lambda x: max(x[\"CC_symop1\"], x[\"CC_symop0\"]), axis=1)\n",
@@ -555,20 +775,118 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "5cc6350e-4ad4-4143-a211-b5e69e4d4b11",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_idx</th>\n",
+       "      <th>best_symop</th>\n",
+       "      <th>num_duplicates</th>\n",
+       "      <th>reindexed_file</th>\n",
+       "      <th>CC_symop0</th>\n",
+       "      <th>CC_symop1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>134</th>\n",
+       "      <td>0159</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.141</td>\n",
+       "      <td>0.022</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>0162</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.017</td>\n",
+       "      <td>0.157</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>158</th>\n",
+       "      <td>0183</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.077</td>\n",
+       "      <td>0.250</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>359</th>\n",
+       "      <td>0418</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>0.044</td>\n",
+       "      <td>0.072</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>368</th>\n",
+       "      <td>0429</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2</td>\n",
+       "      <td>/n/holyscratch01/hekstra_lab/dhekstra/valdo-te...</td>\n",
+       "      <td>-0.011</td>\n",
+       "      <td>-0.054</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_idx  best_symop  num_duplicates  \\\n",
+       "134     0159           0               2   \n",
+       "137     0162           1               2   \n",
+       "158     0183           1               2   \n",
+       "359     0418           1               2   \n",
+       "368     0429           0               2   \n",
+       "\n",
+       "                                        reindexed_file  CC_symop0  CC_symop1  \n",
+       "134  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.141      0.022  \n",
+       "137  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.017      0.157  \n",
+       "158  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.077      0.250  \n",
+       "359  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...      0.044      0.072  \n",
+       "368  /n/holyscratch01/hekstra_lab/dhekstra/valdo-te...     -0.011     -0.054  "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "reindexing_record[reindexing_record[\"num_duplicates\"] > 1].head(4)"
+    "reindexing_record[reindexing_record[\"num_duplicates\"] > 1].head(5)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "996622f0-1b8e-4ead-ae4e-0e14b8068454",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "### Automatic Refinement Code Example"
    ]
@@ -585,10 +903,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "89d2dda4-8c68-4b62-8231-a79d875303d1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Example command to run automatic refinement:\n",
+      " \n",
+      "valdo.refine --pdbpath 'xxx/xxx_apo.pdb' --mtzpath '/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/*.mtz' --output '/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/' --eff 'xxx/refine_drug.eff'\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Example command to run automatic refinement:\")\n",
     "print(\" \")\n",
@@ -609,10 +938,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "4e15ee6e-7bdf-4cf8-a27c-451dbcc660cb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['refine', '0001', '0', '001', 'log']\n"
+     ]
+    }
+   ],
    "source": [
     "loglist = glob.glob(os.path.join(refined_path, \"*log\"))\n",
     "loglist.sort()\n",
@@ -629,11 +966,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ea2df43c-cdfc-4290-bf59-acca4bcaea7e",
+   "metadata": {},
+   "source": [
+    "Compiling refinement statistics. Note that the parsing of filename strings in the cell below may require adjustments based on your naming scheme."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b1b2d259-70ca-4f86-ac9d-188f0f65d534",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1702/1702 [00:37<00:00, 45.76it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "for file in tqdm(loglist):\n",
     "    with open(file, 'r') as f:\n",
@@ -675,10 +1028,109 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "7a78af95-82d9-49d1-b0cc-25229a8d0d85",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_idx</th>\n",
+       "      <th>symop</th>\n",
+       "      <th>Rw_start</th>\n",
+       "      <th>Rf_start</th>\n",
+       "      <th>Rw_final</th>\n",
+       "      <th>Rf_final</th>\n",
+       "      <th>time(s)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0001</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.531</td>\n",
+       "      <td>0.521</td>\n",
+       "      <td>0.254</td>\n",
+       "      <td>0.270</td>\n",
+       "      <td>300.09</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0002</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.534</td>\n",
+       "      <td>0.555</td>\n",
+       "      <td>0.251</td>\n",
+       "      <td>0.270</td>\n",
+       "      <td>185.14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0003</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.528</td>\n",
+       "      <td>0.526</td>\n",
+       "      <td>0.240</td>\n",
+       "      <td>0.275</td>\n",
+       "      <td>181.38</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0004</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.536</td>\n",
+       "      <td>0.551</td>\n",
+       "      <td>0.258</td>\n",
+       "      <td>0.293</td>\n",
+       "      <td>165.05</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0006</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.525</td>\n",
+       "      <td>0.524</td>\n",
+       "      <td>0.259</td>\n",
+       "      <td>0.278</td>\n",
+       "      <td>347.72</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  file_idx symop  Rw_start  Rf_start  Rw_final  Rf_final  time(s)\n",
+       "0     0001     0     0.531     0.521     0.254     0.270   300.09\n",
+       "1     0002     1     0.534     0.555     0.251     0.270   185.14\n",
+       "2     0003     1     0.528     0.526     0.240     0.275   181.38\n",
+       "3     0004     0     0.536     0.551     0.258     0.293   165.05\n",
+       "4     0006     0     0.525     0.524     0.259     0.278   347.72"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "df_refine.head()"
    ]
@@ -693,7 +1145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "f89c522e-e6c4-48f5-8344-31309ba80258",
    "metadata": {},
    "outputs": [],
@@ -708,80 +1160,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "89ddc34d-6bec-4b21-81f4-74217d7b3018",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ambiguous indexing for: \n",
+      "['0159', '0162', '0183', '0418', '0429', '0480', '0487', '0492', '0494', '0495', '0496', '0497', '0632', '0698', '0768', '0988', '0999', '1014', '1105', '1116', '1202', '1912']\n",
+      "    file_idx symop  Rw_start  Rf_start  Rw_final  Rf_final  time(s)\n",
+      "136     0159     1     0.643     0.735     0.599     0.669    93.37\n",
+      "139     0162     0     0.635     0.614     0.617     0.626   197.82\n",
+      "161     0183     0     0.537     0.519     0.501     0.557   119.56\n",
+      "363     0418     0     0.635     0.617     0.578     0.628    91.63\n",
+      "\n",
+      "Will filter out the following: \n",
+      "['0159_1.mtz', '0162_0.mtz', '0183_0.mtz', '0418_0.mtz', '0429_1.mtz', '0480_1.mtz', '0487_0.mtz', '0492_1.mtz', '0494_1.mtz', '0495_1.mtz', '0496_1.mtz', '0497_1.mtz', '0632_0.mtz', '0698_1.mtz', '0768_1.mtz', '0988_1.mtz', '0999_1.mtz', '1014_0.mtz', '1105_0.mtz', '1116_1.mtz', '1202_1.mtz', '1912_1.mtz']\n"
+     ]
+    }
+   ],
    "source": [
-    "ambiguous_idx = reindexing_record[reindexing_record[\"num_duplicates\"]>1][\"file_idx\"].tolist()\n",
-    "df_ambiguous = df_refine[df_refine[\"file_idx\"].apply(lambda x: x in ambiguous_idx)].copy()"
+    "filter_list1=[]\n",
+    "if reindexing_record is not None:\n",
+    "    ambiguous_idx = reindexing_record[reindexing_record[\"num_duplicates\"]>1][\"file_idx\"].tolist()\n",
+    "    df_ambiguous = df_refine[df_refine[\"file_idx\"].apply(lambda x: x in ambiguous_idx)].copy()\n",
+    "    print(\"Ambiguous indexing for: \" )\n",
+    "    print(ambiguous_idx)\n",
+    "    df_worseops = df_ambiguous.loc[df_ambiguous.groupby(by='file_idx')['Rf_final'].idxmax()].copy()\n",
+    "    print(df_worseops.head(4))\n",
+    "    filter_list1 = (df_worseops[\"file_idx\"] + \"_\" + df_worseops[\"symop\"] + '.mtz').tolist()\n",
+    "    print(\"\\nWill filter out the following: \")\n",
+    "    print(filter_list1)\n",
+    "else:\n",
+    "    print(\"Did not find reindexing records?\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b2973fad-313b-48a9-81b8-1a3e1223c916",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(ambiguous_idx)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8cf478ee-d042-45c0-a75e-c54767077b51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_worseops = df_ambiguous.loc[df_ambiguous.groupby(by='file_idx')['Rf_final'].idxmax()].copy()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ed94a2d0-f217-4ba6-be41-a8e36cb6dd4d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df_worseops.head(4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "50a530da-255b-423e-ac2c-4c473b561072",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
+    }
+   ],
    "source": [
     "# We will also filter out all datasets for which no refinement is available. Otherwise these will linger as polluting duplicates\n",
     "refined=df_refine[\"file_idx\"].to_list()\n",
     "filter_list0=[]\n",
-    "for file_idx in reindexing_record[\"file_idx\"].to_list():\n",
-    "    if file_idx not in refined:\n",
-    "        filter_list0.append(file_idx)\n",
+    "if reindexing_record is not None:\n",
+    "    for file_idx in reindexing_record[\"file_idx\"].to_list():\n",
+    "        if file_idx not in refined:\n",
+    "            filter_list0.append(file_idx)\n",
     "print(filter_list0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41e832c6-e5a4-410c-8ef0-dac7577f5df8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# List 1 of files will be filtered out from reindexed mtzs: symops with worse R-factors in duplicates\n",
-    "filter_list1 = (df_worseops[\"file_idx\"] + \"_\" + df_worseops[\"symop\"] + '.mtz').tolist()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8eaad20-b3d0-43e3-aae9-1aa4b93683a0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(filter_list1)"
    ]
   },
   {
@@ -789,12 +1227,13 @@
    "id": "01709cf2-ea4e-4e8b-bdc7-e2ed4fbec996",
    "metadata": {},
    "source": [
-    "#### Screen out datasets with bad R-factors in apo refinement"
+    "#### Screen out datasets with bad R-factors in apo refinement\n",
+    "Be careful with these filter--cases of strong conformational change may also yield poor R factors at this point!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "4568856a-8b2c-4b0a-af9a-5c8e6bddc079",
    "metadata": {},
    "outputs": [],
@@ -804,26 +1243,154 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "eeb696b0-3e5d-49bc-9afa-33f4b0fe8977",
+   "execution_count": 23,
+   "id": "b138f433-2de1-4511-b9a3-6c1660174ffc",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>file_idx</th>\n",
+       "      <th>symop</th>\n",
+       "      <th>Rw_start</th>\n",
+       "      <th>Rf_start</th>\n",
+       "      <th>Rw_final</th>\n",
+       "      <th>Rf_final</th>\n",
+       "      <th>time(s)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>135</th>\n",
+       "      <td>0159</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.599</td>\n",
+       "      <td>0.681</td>\n",
+       "      <td>0.492</td>\n",
+       "      <td>0.556</td>\n",
+       "      <td>86.16</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>0159</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.643</td>\n",
+       "      <td>0.735</td>\n",
+       "      <td>0.599</td>\n",
+       "      <td>0.669</td>\n",
+       "      <td>93.37</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>139</th>\n",
+       "      <td>0162</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.635</td>\n",
+       "      <td>0.614</td>\n",
+       "      <td>0.617</td>\n",
+       "      <td>0.626</td>\n",
+       "      <td>197.82</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>140</th>\n",
+       "      <td>0162</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.633</td>\n",
+       "      <td>0.626</td>\n",
+       "      <td>0.598</td>\n",
+       "      <td>0.623</td>\n",
+       "      <td>155.61</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>157</th>\n",
+       "      <td>0179</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.623</td>\n",
+       "      <td>0.621</td>\n",
+       "      <td>0.504</td>\n",
+       "      <td>0.487</td>\n",
+       "      <td>90.29</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    file_idx symop  Rw_start  Rf_start  Rw_final  Rf_final  time(s)\n",
+       "135     0159     0     0.599     0.681     0.492     0.556    86.16\n",
+       "136     0159     1     0.643     0.735     0.599     0.669    93.37\n",
+       "139     0162     0     0.635     0.614     0.617     0.626   197.82\n",
+       "140     0162     1     0.633     0.626     0.598     0.623   155.61\n",
+       "157     0179     1     0.623     0.621     0.504     0.487    90.29"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "filter_list2=[]\n",
-    "if filter_by_Rfree:\n",
-    "    filter_list2 = (df_badR[\"file_idx\"] + '.mtz').tolist()\n",
-    "    print(filter_list2)"
+    "df_badR.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
+   "id": "eeb696b0-3e5d-49bc-9afa-33f4b0fe8977",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['0159_0.mtz', '0159_1.mtz', '0162_0.mtz', '0162_1.mtz', '0179_1.mtz', '0183_0.mtz', '0268_1.mtz', '0320_0.mtz', '0342_1.mtz', '0400_0.mtz', '0413_0.mtz', '0418_0.mtz', '0418_1.mtz', '0427_0.mtz', '0429_1.mtz', '0433_1.mtz', '0480_1.mtz', '0487_0.mtz', '0492_1.mtz', '0494_1.mtz', '0495_1.mtz', '0496_1.mtz', '0497_1.mtz', '0568_0.mtz', '0632_0.mtz', '0698_1.mtz', '0768_1.mtz', '0944_1.mtz', '0946_0.mtz', '0988_1.mtz', '0999_1.mtz', '1014_0.mtz', '1086_0.mtz', '1105_0.mtz', '1116_1.mtz', '1144_0.mtz', '1165_0.mtz', '1179_1.mtz', '1202_0.mtz', '1202_1.mtz', '1323_0.mtz', '1354_0.mtz', '1377_0.mtz', '1405_0.mtz', '1406_0.mtz', '1431_1.mtz', '1459_1.mtz', '1463_1.mtz', '1529_1.mtz', '1539_1.mtz', '1587_0.mtz', '1709_0.mtz', '1724_0.mtz', '1912_1.mtz']\n"
+     ]
+    }
+   ],
+   "source": [
+    "filter_list2=[]\n",
+    "if filter_by_Rfree:\n",
+    "    # filter_list2 = (df_badR[\"file_idx\"] + '.mtz').tolist()\n",
+    "    filter_list2 = (df_badR[\"file_idx\"]+ \"_\" + df_badR[\"symop\"] + '.mtz').tolist()\n",
+    "print(filter_list2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
    "id": "a7dbe717-727c-45e8-9b82-6fd524e11973",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Get union of filter_list1 and filter_list2\n",
     "filter_list = list(set().union(filter_list0, filter_list1, filter_list2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "06fa7596-2a9e-49ce-b887-6a2ee37ee40d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print(filter_list2)"
    ]
   },
   {
@@ -839,49 +1406,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "f04a8177-b4e4-42d9-a194-83b85858a330",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reindexing_record.head()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 65,
    "id": "0d0d95fe-1efa-4f7d-81b8-aeed41c38372",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using the reindexing record.\n",
+      "Reindexed reference mtz: 0001_0.mtz\n",
+      "Our reference will be /n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/0001_0.mtz\n",
+      "We have 1701 MTZ files before filtering.\n",
+      "54 MTZ files were removed; 0 MTZ files were already not in the list and did not need to be removed.\n",
+      "We have 1647 MTZ files ready for scaling.\n"
+     ]
+    }
+   ],
    "source": [
     "if reindexing_record is None:\n",
     "    file_list = glob.glob(input_mtz_path + \"*mtz\")\n",
     "    reference_idx = file_list.index(input_mtz_path+ref_mtz+\".mtz\") \n",
     "else:\n",
+    "    print(\"Using the reindexing record.\")\n",
     "    file_list = glob.glob(reindexed_path + \"*mtz\")\n",
     "    idx=reindexing_record[reindexing_record.file_idx==ref_mtz].iloc[0]\n",
     "    reindexed_ref_mtz=ref_mtz+\"_\"+str(idx[\"best_symop\"])+\".mtz\"\n",
     "    reference_idx = file_list.index(reindexed_path + reindexed_ref_mtz) \n",
+    "print(\"Reindexed reference mtz: \" + reindexed_ref_mtz)\n",
     "print(\"Our reference will be \" + file_list[reference_idx])\n",
     "file_list.sort()\n",
     "\n",
+    "m=0\n",
     "n=0\n",
+    "print(\"We have \" + str(len(file_list)) + \" MTZ files before filtering.\")\n",
     "for mtz in filter_list:\n",
     "    try:\n",
     "        file_list.remove(reindexed_path+mtz)\n",
+    "        m=m+1\n",
     "    except:\n",
     "        n=n+1\n",
-    "print(f\"{n} MTZ files were alread not in the list and did not need to be removed.\")\n",
+    "print(f\"{m} MTZ files were removed; {n} MTZ files were already not in the list and did not need to be removed.\")\n",
     "    \n",
     "print(\"We have \" + str(len(file_list)) + \" MTZ files ready for scaling.\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 66,
    "id": "a967005f-b041-4628-82c0-edaa46e47a9a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_scaled/\n",
+      "contained 1647 files.\n",
+      "Removing...\n",
+      "Done.\n"
+     ]
+    }
+   ],
    "source": [
     "print(scaled_path)\n",
     "# print(glob.glob(scaled_path + \"*mtz\"))\n",
@@ -903,19 +1489,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 67,
+   "id": "b6e82116-6f80-4778-ace0-00561094b6ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/0001_0.mtz\n"
+     ]
+    }
+   ],
+   "source": [
+    "reference_idx = file_list.index(reindexed_path + reindexed_ref_mtz) \n",
+    "print(file_list[reference_idx])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
    "id": "6d989673-1405-4abe-b168-7fbdda97c406",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  6%|██▎                                      | 92/1647 [00:21<03:59,  6.48it/s]/n/home12/dhekstra/ipython_notebooks/drug-screening/valdo/scaling.py:110: RuntimeWarning: overflow encountered in exp\n",
+      "  FB_scaled = np.exp(ln_k) * np.exp(-args) * FB\n",
+      "/n/home12/dhekstra/ipython_notebooks/drug-screening/valdo/scaling.py:110: RuntimeWarning: invalid value encountered in multiply\n",
+      "  FB_scaled = np.exp(ln_k) * np.exp(-args) * FB\n",
+      "100%|███████████████████████████████████████| 1647/1647 [04:45<00:00,  5.77it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scaling metrics have been saved at: /n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_scaled/run_23_11231_scaling_metrics.pkl\n",
+      "CPU times: user 3min 19s, sys: 3.54 s, total: 3min 23s\n",
+      "Wall time: 4min 45s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Scales all datasets to the previously provided reference, writes a `metrics.pkl`, take ~30s\n",
     "# Returns some metrics on the quality of the dataset.\n",
+    "# The single-cpu version now supports additional scaling\n",
     "\n",
-    "if ncpu > 1:\n",
-    "    scaler = valdo.Scaler_pool(reference_mtz=file_list[reference_idx],columns=[amplitude_col, error_col],verbose=False, n_iter=15,ncpu=ncpu)\n",
+    "if ncpu > 1 and not num_opt_scales:\n",
+    "    scaler = valdo.Scaler_pool(reference_mtz=file_list[reference_idx],\n",
+    "                               columns=[amplitude_col, error_col],\n",
+    "                               verbose=False, \n",
+    "                               n_iter=10,\n",
+    "                               ncpu=ncpu)\n",
     "    scaling_metrics = scaler.batch_scaling(mtz_path_list=file_list, \n",
     "                                   outputmtz_path=scaled_path,\n",
     "                                   prefix=run_prefix)\n",
@@ -924,17 +1562,162 @@
     "    scaling_metrics = scaler.batch_scaling(mtz_path_list=file_list, \n",
     "                                   outputmtz_path=scaled_path,\n",
     "                                   prefix=run_prefix, \n",
-    "                                   verbose=False)"
+    "                                   when_opt=\"all\",\n",
+    "                                   verbose=False)\n",
+    "    scaling_metrics=pd.DataFrame(data=scaling_metrics,columns=[\"sample\",\"start_LS\",\"start_corr\",\"end_LS\",\"end_corr\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 69,
+   "id": "5ae6b184-aa91-4f7b-8118-d638be31bbd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/mtzs_reindex/0001_0.mtz\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(file_list[reference_idx])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
    "id": "5c8d1f2f-b9ba-463a-8811-2015cbe59794",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample</th>\n",
+       "      <th>start_LS</th>\n",
+       "      <th>start_corr</th>\n",
+       "      <th>end_LS</th>\n",
+       "      <th>end_corr</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0001_0</td>\n",
+       "      <td>0.000e+00</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.000e+00</td>\n",
+       "      <td>1.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0002_1</td>\n",
+       "      <td>3.338e+06</td>\n",
+       "      <td>0.955</td>\n",
+       "      <td>8.525e+05</td>\n",
+       "      <td>0.955</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0004_0</td>\n",
+       "      <td>6.935e+06</td>\n",
+       "      <td>0.873</td>\n",
+       "      <td>1.897e+06</td>\n",
+       "      <td>0.886</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0006_0</td>\n",
+       "      <td>1.879e+06</td>\n",
+       "      <td>0.996</td>\n",
+       "      <td>9.161e+04</td>\n",
+       "      <td>0.996</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0009_1</td>\n",
+       "      <td>2.359e+05</td>\n",
+       "      <td>0.998</td>\n",
+       "      <td>5.188e+04</td>\n",
+       "      <td>0.998</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sample   start_LS  start_corr     end_LS  end_corr\n",
+       "0  0001_0  0.000e+00       1.000  0.000e+00     1.000\n",
+       "1  0002_1  3.338e+06       0.955  8.525e+05     0.955\n",
+       "2  0004_0  6.935e+06       0.873  1.897e+06     0.886\n",
+       "3  0006_0  1.879e+06       0.996  9.161e+04     0.996\n",
+       "4  0009_1  2.359e+05       0.998  5.188e+04     0.998"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "scaling_metrics.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "f5f6edc8-0efb-434d-82ed-07b9933cbbcf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(array([  9.,   5.,   1.,   2.,   4.,   2.,   0.,   4.,   2.,   3.,   8.,\n",
+       "         11.,  10.,  15.,  18.,  40.,  61., 140., 341., 970.]),\n",
+       " array([0.17397236, 0.21527374, 0.25657513, 0.29787651, 0.33917789,\n",
+       "        0.38047927, 0.42178065, 0.46308204, 0.50438342, 0.5456848 ,\n",
+       "        0.58698618, 0.62828756, 0.66958894, 0.71089033, 0.75219171,\n",
+       "        0.79349309, 0.83479447, 0.87609585, 0.91739724, 0.95869862,\n",
+       "        1.        ]),\n",
+       " <BarContainer object of 20 artists>)"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAADuCAYAAADC3kfBAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAAbTklEQVR4nO3dfVBU1/0/8PfKwgoMrIKyywoqdjbxAWIUIhHTYAtCGgl1Mi200IxpaYqDTxslCmMaH6YBxYrWx0THqlURpzG0zpQ0kNYSEY2I2qrY2EZUqGyIZt2FSBeE8/3Dn/fXBZ8WdwGP79fM/WPP/dy7n3sG355cbq4qIYQAERFJZUBfN0BERK7HcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikpDa2QM+/fRTrF69GjU1NWhsbERJSQlmzJih7BdCYPny5di6dSssFguio6OxadMmjBs3Tqmx2+3Izs7Gvn370Nrairi4OGzevBkhISFKjcViwbx583Dw4EEAQHJyMjZs2IBBgwY9VJ+dnZ24evUq/Pz8oFKpnL1MIqJ+RwiB5uZmGAwGDBjwgLW5cFJpaalYsmSJOHDggAAgSkpKHPavXLlS+Pn5iQMHDogzZ86I1NRUERwcLGw2m1Iza9YsMWzYMFFeXi5OnjwpvvOd74jx48eLW7duKTUvvfSSCA8PF1VVVaKqqkqEh4eLpKSkh+6zvr5eAODGjRs36bb6+voHZqBKiJ6/OEylUjms3IUQMBgMMJlMWLx4MYDbq3SdTodVq1YhMzMTVqsVQ4cOxe7du5GamgoAuHr1KkJDQ1FaWorExEScP38eY8eOxbFjxxAdHQ0AOHbsGCZPnox//vOfePrppx/Ym9VqxaBBg1BfXw9/f/+eXiIRUb9hs9kQGhqKGzduQKvV3rfW6dsy91NXVwez2YyEhARlTKPRIDY2FlVVVcjMzERNTQ3a29sdagwGA8LDw1FVVYXExEQcPXoUWq1WCXYAeP7556HValFVVXXXcLfb7bDb7crn5uZmAIC/vz/DnYik8jC3ml36C1Wz2QwA0Ol0DuM6nU7ZZzab4eXlhcGDB9+3JigoqNv5g4KClJqu8vPzodVqlS00NPSRr4eI6HHllqdluv6tIoR44N80XWvuVn+/8+Tm5sJqtSpbfX19DzonIpKDS8Ndr9cDQLfVdVNTk7Ka1+v1aGtrg8ViuW/Nl19+2e38X331Vbf/KrhDo9Eot2B4K4aInnQuDfewsDDo9XqUl5crY21tbaioqEBMTAwAIDIyEp6eng41jY2NOHv2rFIzefJkWK1WHD9+XKn57LPPYLValRoiIro3p3+h2tLSgn//+9/K57q6Opw+fRoBAQEYPnw4TCYT8vLyYDQaYTQakZeXBx8fH6SlpQEAtFotMjIysHDhQgQGBiIgIADZ2dmIiIhAfHw8AGDMmDF46aWX8MYbb+D9998HAPziF79AUlLSQz0pQ0T0xHvoB8f/n0OHDt31ucuZM2cKIYTo7OwUS5cuFXq9Xmg0GvHiiy+KM2fOOJyjtbVVzJkzRwQEBAhvb2+RlJQkrly54lBz/fp1kZ6eLvz8/ISfn59IT08XFovlofu0Wq0CgLBarc5eIhFRv+RMrj3Sc+79mc1mg1arhdVq5f13InKbkTl/6tFxl1ZOd/oYZ3KN75YhIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCTHciYgkxHAnIpIQw52ISEIMdyIiCbk83G/duoW3334bYWFh8Pb2xqhRo7BixQp0dnYqNUIILFu2DAaDAd7e3pg6dSrOnTvncB673Y65c+diyJAh8PX1RXJyMhoaGlzdLhGRlFwe7qtWrcJ7772HjRs34vz58ygoKMDq1auxYcMGpaagoACFhYXYuHEjqqurodfrMW3aNDQ3Nys1JpMJJSUlKC4uRmVlJVpaWpCUlISOjg5Xt0xEJB21q0949OhRfP/738f06dMBACNHjsS+fftw4sQJALdX7evWrcOSJUvw6quvAgB27doFnU6HoqIiZGZmwmq1Yvv27di9ezfi4+MBAHv27EFoaCg++eQTJCYmurptIiKpuHzl/sILL+Avf/kLLly4AAD4+9//jsrKSrz88ssAgLq6OpjNZiQkJCjHaDQaxMbGoqqqCgBQU1OD9vZ2hxqDwYDw8HClpiu73Q6bzeawERE9qVy+cl+8eDGsVitGjx4NDw8PdHR04N1338WPf/xjAIDZbAYA6HQ6h+N0Oh0uX76s1Hh5eWHw4MHdau4c31V+fj6WL1/u6sshInosuXzlvn//fuzZswdFRUU4efIkdu3ahV//+tfYtWuXQ51KpXL4LIToNtbV/Wpyc3NhtVqVrb6+/tEuhIjoMebylftbb72FnJwc/OhHPwIARERE4PLly8jPz8fMmTOh1+sB3F6dBwcHK8c1NTUpq3m9Xo+2tjZYLBaH1XtTUxNiYmLu+r0ajQYajcbVl0NE9Fhy+cr95s2bGDDA8bQeHh7Ko5BhYWHQ6/UoLy9X9re1taGiokIJ7sjISHh6ejrUNDY24uzZs/cMdyIi+v9cvnJ/5ZVX8O6772L48OEYN24cTp06hcLCQvzsZz8DcPt2jMlkQl5eHoxGI4xGI/Ly8uDj44O0tDQAgFarRUZGBhYuXIjAwEAEBAQgOzsbERERytMzRER0by4P9w0bNuCXv/wlsrKy0NTUBIPBgMzMTLzzzjtKzaJFi9Da2oqsrCxYLBZER0ejrKwMfn5+Ss3atWuhVquRkpKC1tZWxMXFYefOnfDw8HB1y0RE0lEJIURfN+EONpsNWq0WVqsV/v7+fd0OEUlqZM6fenTcpZXTnT7GmVzju2WIiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQm4J9//85z/4yU9+gsDAQPj4+ODZZ59FTU2Nsl8IgWXLlsFgMMDb2xtTp07FuXPnHM5ht9sxd+5cDBkyBL6+vkhOTkZDQ4M72iUiko7Lw91isWDKlCnw9PTERx99hNraWqxZswaDBg1SagoKClBYWIiNGzeiuroaer0e06ZNQ3Nzs1JjMplQUlKC4uJiVFZWoqWlBUlJSejo6HB1y0RE0lEJIYQrT5iTk4MjR47g8OHDd90vhIDBYIDJZMLixYsB3F6l63Q6rFq1CpmZmbBarRg6dCh2796N1NRUAMDVq1cRGhqK0tJSJCYmPrAPm80GrVYLq9UKf39/110gEdH/GJnzpx4dd2nldKePcSbXXL5yP3jwIKKiovDDH/4QQUFBmDBhArZt26bsr6urg9lsRkJCgjKm0WgQGxuLqqoqAEBNTQ3a29sdagwGA8LDw5Warux2O2w2m8NGRPSkcnm4X7x4EVu2bIHRaMTHH3+MWbNmYd68efjd734HADCbzQAAnU7ncJxOp1P2mc1meHl5YfDgwfes6So/Px9arVbZQkNDXX1pRESPDZeHe2dnJyZOnIi8vDxMmDABmZmZeOONN7BlyxaHOpVK5fBZCNFtrKv71eTm5sJqtSpbfX39o10IEdFjzOXhHhwcjLFjxzqMjRkzBleuXAEA6PV6AOi2Am9qalJW83q9Hm1tbbBYLPes6Uqj0cDf399hIyJ6Urk83KdMmYLPP//cYezChQsYMWIEACAsLAx6vR7l5eXK/ra2NlRUVCAmJgYAEBkZCU9PT4eaxsZGnD17VqkhIqJ7U7v6hG+++SZiYmKQl5eHlJQUHD9+HFu3bsXWrVsB3L4dYzKZkJeXB6PRCKPRiLy8PPj4+CAtLQ0AoNVqkZGRgYULFyIwMBABAQHIzs5GREQE4uPjXd0yEZF0XB7uzz33HEpKSpCbm4sVK1YgLCwM69atQ3p6ulKzaNEitLa2IisrCxaLBdHR0SgrK4Ofn59Ss3btWqjVaqSkpKC1tRVxcXHYuXMnPDw8XN0yEZF0XP6ce3/B59yJqDc8Mc+5ExFR32O4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJyO3hnp+fD5VKBZPJpIwJIbBs2TIYDAZ4e3tj6tSpOHfunMNxdrsdc+fOxZAhQ+Dr64vk5GQ0NDS4u10iIim4Ndyrq6uxdetWPPPMMw7jBQUFKCwsxMaNG1FdXQ29Xo9p06ahublZqTGZTCgpKUFxcTEqKyvR0tKCpKQkdHR0uLNlIiIpuC3cW1pakJ6ejm3btmHw4MHKuBAC69atw5IlS/Dqq68iPDwcu3btws2bN1FUVAQAsFqt2L59O9asWYP4+HhMmDABe/bswZkzZ/DJJ5+4q2UiImm4Ldxnz56N6dOnIz4+3mG8rq4OZrMZCQkJyphGo0FsbCyqqqoAADU1NWhvb3eoMRgMCA8PV2qIiOje1O44aXFxMU6ePInq6upu+8xmMwBAp9M5jOt0Oly+fFmp8fLycljx36m5c3xXdrsddrtd+Wyz2R7pGoiIHmcuX7nX19dj/vz52LNnDwYOHHjPOpVK5fBZCNFtrKv71eTn50Or1SpbaGio880TEUnC5eFeU1ODpqYmREZGQq1WQ61Wo6KiAuvXr4darVZW7F1X4E1NTco+vV6PtrY2WCyWe9Z0lZubC6vVqmz19fWuvjQioseGy8M9Li4OZ86cwenTp5UtKioK6enpOH36NEaNGgW9Xo/y8nLlmLa2NlRUVCAmJgYAEBkZCU9PT4eaxsZGnD17VqnpSqPRwN/f32EjInpSufyeu5+fH8LDwx3GfH19ERgYqIybTCbk5eXBaDTCaDQiLy8PPj4+SEtLAwBotVpkZGRg4cKFCAwMREBAALKzsxEREdHtF7RERNSdW36h+iCLFi1Ca2srsrKyYLFYEB0djbKyMvj5+Sk1a9euhVqtRkpKClpbWxEXF4edO3fCw8OjL1omInqsqIQQoq+bcAebzQatVgur1cpbNETkNiNz/tSj4y6tnO70Mc7kGt8tQ0QkIYY7EZGEGO5ERBJiuBMRSYjhTkQkoT55FJKIqL/p6VMv/RVX7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEmK4ExFJiOFORCQhhjsRkYQY7kREEnJ5uOfn5+O5556Dn58fgoKCMGPGDHz++ecONUIILFu2DAaDAd7e3pg6dSrOnTvnUGO32zF37lwMGTIEvr6+SE5ORkNDg6vbJSKSksvDvaKiArNnz8axY8dQXl6OW7duISEhAd98841SU1BQgMLCQmzcuBHV1dXQ6/WYNm0ampublRqTyYSSkhIUFxejsrISLS0tSEpKQkdHh6tbJiKSjkoIIdz5BV999RWCgoJQUVGBF198EUIIGAwGmEwmLF68GMDtVbpOp8OqVauQmZkJq9WKoUOHYvfu3UhNTQUAXL16FaGhoSgtLUViYuIDv9dms0Gr1cJqtcLf39+dl0hEEhiZ86de/b5LK6c7fYwzueb2e+5WqxUAEBAQAACoq6uD2WxGQkKCUqPRaBAbG4uqqioAQE1NDdrb2x1qDAYDwsPDlZqu7HY7bDabw0ZE9KRya7gLIbBgwQK88MILCA8PBwCYzWYAgE6nc6jV6XTKPrPZDC8vLwwePPieNV3l5+dDq9UqW2hoqKsvh4joseHWcJ8zZw7+8Y9/YN++fd32qVQqh89CiG5jXd2vJjc3F1arVdnq6+t73jgR0WPObeE+d+5cHDx4EIcOHUJISIgyrtfrAaDbCrypqUlZzev1erS1tcFisdyzpiuNRgN/f3+HjYjoSeXycBdCYM6cOfjwww/x17/+FWFhYQ77w8LCoNfrUV5eroy1tbWhoqICMTExAIDIyEh4eno61DQ2NuLs2bNKDRER3Zva1SecPXs2ioqK8Mc//hF+fn7KCl2r1cLb2xsqlQomkwl5eXkwGo0wGo3Iy8uDj48P0tLSlNqMjAwsXLgQgYGBCAgIQHZ2NiIiIhAfH+/qlomIpOPycN+yZQsAYOrUqQ7jO3bswOuvvw4AWLRoEVpbW5GVlQWLxYLo6GiUlZXBz89PqV+7di3UajVSUlLQ2tqKuLg47Ny5Ex4eHq5umYhIOm5/zr2v8Dl3InIGn3MnIqJ+j+FORCQhhjsRkYQY7kREEmK4ExFJyOWPQhIR9aXefuqlv+LKnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJMdyJiCTEcCcikhDDnYhIQgx3IiIJ8ZW/RNQv8dW9j4YrdyIiCTHciYgkxHAnIpIQ77kTkVvx3nnf4MqdiEhCDHciIgn1+3DfvHkzwsLCMHDgQERGRuLw4cN93RIRUb/Xr++579+/HyaTCZs3b8aUKVPw/vvv43vf+x5qa2sxfPjwvm6P6LHD+99PDpUQQvR1E/cSHR2NiRMnYsuWLcrYmDFjMGPGDOTn59/3WJvNBq1WC6vVCn9/f3e3StQjDNsn16WV050+xplc67cr97a2NtTU1CAnJ8dhPCEhAVVVVd3q7XY77Ha78tlqtQK4PRnOCl/6sdPHPIqzyxN79fvI9Xr7Z4Yefz3JpjvHPMyavN+G+7Vr19DR0QGdTucwrtPpYDabu9Xn5+dj+fLl3cZDQ0Pd1qOraNf1dQdE1Nse5c99c3MztFrtfWv6bbjfoVKpHD4LIbqNAUBubi4WLFigfO7s7MTXX3+NwMDAu9Y/CpvNhtDQUNTX1/OWDzgfd8M5ccT5cNTT+RBCoLm5GQaD4YG1/TbchwwZAg8Pj26r9Kampm6reQDQaDTQaDQOY4MGDXJni/D39+cP6v/gfHTHOXHE+XDUk/l40Ir9jn77KKSXlxciIyNRXl7uMF5eXo6YmJg+6oqI6PHQb1fuALBgwQK89tpriIqKwuTJk7F161ZcuXIFs2bN6uvWiIj6tX4d7qmpqbh+/TpWrFiBxsZGhIeHo7S0FCNGjOjTvjQaDZYuXdrtNtCTivPRHefEEefDUW/MR79+zp2IiHqm395zJyKinmO4ExFJiOFORCQhhjsRkYQY7vfgzKuGP/zwQ0ybNg1Dhw6Fv78/Jk+ejI8/lutdIz199fKRI0egVqvx7LPPurfBXubsfNjtdixZsgQjRoyARqPBt771Lfz2t7/tpW57h7NzsnfvXowfPx4+Pj4IDg7GT3/6U1y/fr2XunWvTz/9FK+88goMBgNUKhX+8Ic/PPCYiooKREZGYuDAgRg1ahTee++9R2tCUDfFxcXC09NTbNu2TdTW1or58+cLX19fcfny5bvWz58/X6xatUocP35cXLhwQeTm5gpPT09x8uTJXu7cPZydjztu3LghRo0aJRISEsT48eN7p9le0JP5SE5OFtHR0aK8vFzU1dWJzz77TBw5cqQXu3YvZ+fk8OHDYsCAAeI3v/mNuHjxojh8+LAYN26cmDFjRi937h6lpaViyZIl4sCBAwKAKCkpuW/9xYsXhY+Pj5g/f76ora0V27ZtE56enuKDDz7ocQ8M97uYNGmSmDVrlsPY6NGjRU5OzkOfY+zYsWL58uWubq1P9HQ+UlNTxdtvvy2WLl0qVbg7Ox8fffSR0Gq14vr1673RXp9wdk5Wr14tRo0a5TC2fv16ERIS4rYe+8rDhPuiRYvE6NGjHcYyMzPF888/3+Pv5W2ZLu68ajghIcFh/F6vGr6bzs5ONDc3IyAgwB0t9qqezseOHTvwxRdfYOnSpe5usVf1ZD4OHjyIqKgoFBQUYNiwYXjqqaeQnZ2N1tbW3mjZ7XoyJzExMWhoaEBpaSmEEPjyyy/xwQcfYPp0599xLoOjR492m7/ExEScOHEC7e3tPTpnv/4/VPuCs68avps1a9bgm2++QUpKijta7FU9mY9//etfyMnJweHDh6FWy/Uj1pP5uHjxIiorKzFw4ECUlJTg2rVryMrKwtdffy3FffeezElMTAz27t2L1NRU/Pe//8WtW7eQnJyMDRs29EbL/Y7ZbL7r/N26dQvXrl1DcHCw0+fkyv0eHvZVw13t27cPy5Ytw/79+xEUFOSu9nrdw85HR0cH0tLSsHz5cjz11FO91V6vc+bno7OzEyqVCnv37sWkSZPw8ssvo7CwEDt37pRm9Q44Nye1tbWYN28e3nnnHdTU1ODPf/4z6urqnuj3Rt1t/u42/rDkWla5gLOvGv5f+/fvR0ZGBn7/+98jPj7enW32Gmfno7m5GSdOnMCpU6cwZ84cALfDTQgBtVqNsrIyfPe73+2V3t2hJz8fwcHBGDZsmMOrWseMGQMhBBoaGmA0Gt3as7v1ZE7y8/MxZcoUvPXWWwCAZ555Br6+vvj2t7+NX/3qVz1aqT7O9Hr9XedPrVYjMDCwR+fkyr2Lnr5qeN++fXj99ddRVFQk1X1DZ+fD398fZ86cwenTp5Vt1qxZePrpp3H69GlER0f3Vutu0ZOfjylTpuDq1atoaWlRxi5cuIABAwYgJCTErf32hp7Myc2bNzFggGP8eHh4AHi4f0JONpMnT+42f2VlZYiKioKnp2fPTtrjX8VK7M5jXdu3bxe1tbXCZDIJX19fcenSJSGEEDk5OeK1115T6ouKioRarRabNm0SjY2Nynbjxo2+ugSXcnY+upLtaRln56O5uVmEhISIH/zgB+LcuXOioqJCGI1G8fOf/7yvLsHlnJ2THTt2CLVaLTZv3iy++OILUVlZKaKiosSkSZP66hJcqrm5WZw6dUqcOnVKABCFhYXi1KlTyqOhXefjzqOQb775pqitrRXbt2/no5DusmnTJjFixAjh5eUlJk6cKCoqKpR9M2fOFLGxscrn2NhYAaDbNnPmzN5v3E2cmY+uZAt3IZyfj/Pnz4v4+Hjh7e0tQkJCxIIFC8TNmzd7uWv3cnZO1q9fL8aOHSu8vb1FcHCwSE9PFw0NDb3ctXscOnTovplwt/n429/+JiZMmCC8vLzEyJEjxZYtWx6pB77yl4hIQrznTkQkIYY7EZGEGO5ERBJiuBMRSYjhTkQkIYY7EZGEGO5ERBJiuBMRSYjhTkQkIYY7EZGEGO5ERBJiuBMRSej/AA+Gso8uyW8VAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(scaling_metrics[\"end_corr\"].to_numpy(),20)"
    ]
   },
   {
@@ -949,16 +1732,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 72,
    "id": "7fff5d0c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAEOCAYAAABlz8c+AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAB3YUlEQVR4nO2dd5gc1ZW330qdu6cnaYJyFiIKYQw2wSwLGAxrbJb1t+s1OBtj1kHLYnDGwLLO2OvAssawDutIcACvkW1ETgJJBCWERnFy6twV7/fHnWk00kiakWY0kua+zzOPVNXVVaerq3916txzz9GEEAKFQqFQTAr0iTZAoVAoFIcOJfoKhUIxiVCir1AoFJMIJfoKhUIxiVCir1AoFJMIJfoKhUIxiVCir1AoFJMIJfoKhUIxiVCir1AoFJMIJfoKhUIxiZjUov/oo49yySWX0NzcjKZp3H///aN6/5e+9CU0TdvjLx6Pj4/BCoVCcZBMatEvFAqceOKJfPe73z2g91977bW0tbUN+Vu8eDGXX375GFuqUCgUY8OkFv0LL7yQm2++mXe+853Dvu44Dtdddx1Tp04lHo/zxje+kRUrVlReTyQSNDY2Vv46OjpYu3YtH/jABw7RJ1AoFIrRYU60AYcz73vf+9iyZQu/+MUvaG5u5r777uOtb30rL730EvPnz99j+x/+8IcsWLCAM888cwKsVSgUiv0zqT39ffHaa6/x85//nF//+teceeaZzJ07l2uvvZYzzjiDu+66a4/tbdvmZz/7mfLyFQrFYY3y9PfCCy+8gBCCBQsWDFlv2za1tbV7bH/vvfeSy+W44oorDpWJCoVCMWqU6O+FIAgwDIPnn38ewzCGvJZIJPbY/oc//CEXX3wxjY2Nh8pEhUKhGDVK9PfCkiVL8H2fzs7O/cboW1paePjhh/nd7353iKxTKBSKA2NSi34+n2fTpk2V5ZaWFlavXk1NTQ0LFizg3e9+N1dccQXf+MY3WLJkCd3d3fz1r3/l+OOP56KLLqq870c/+hFNTU1ceOGFE/ExFAqFYsRok7lH7ooVKzjnnHP2WH/llVdy991347ouN998Mz/+8Y/ZuXMntbW1nH766dx4440cf/zxgAwDzZw5kyuuuIJbbrnlUH8EhUKhGBWTWvQVCoVisqFSNhUKhWISMeli+kEQ0NraSjKZRNO0iTZHoVAoDhohBLlcjubmZnR93778pBP91tZWpk+fPtFmKBQKxZizfft2pk2bts9tJp3oJ5NJQJ6cVCo1rsdyXZeHHnqI888/H8uyxvVYkw11bscXdX7Hj/E4t9lslunTp1f0bV9MOtEfDOmkUqlDIvqxWIxUKqV+OGOMOrfjizq/48d4ntuRhKzVQK5CoVBMIpToKxQKxSRCib5CoVBMIpToKxQKxSRCib5CoVAcLggBjz02rodQoq9QKBSHA+vXwznnwFlnwS5tWccaJfoKhUIxkZRK8PnPwwknwCOPQDQKW7aM2+EmVPQfffRRLrnkEpqbm9E0jfvvv3+f269YsQJN0/b4W79+/aExWKFQKMaS5cvh+OPh5pvBdeFtb4O1a+G97x23Q07o5KxCocCJJ57I+973Pi677LIRv2/Dhg1DJlbV19ePh3kKhUIxLoT7+jDe8x745S/liuZm+M534J3vhHGuCTahon/hhRceUOORKVOmkE6nx94ghUKhGE+CAP2OOzj3uuvQi0XQdbjmGrjpJhjnCgGDHJFlGJYsWUK5XGbx4sV87nOfG7YRyiC2bWPbdmU5m80Cciq067rjaufg/sf7OJMRdW7HF3V+x4EXX8T42McwnnkGA/CXLCH4wQ/g5JPl6wdxrkfzPR1Rot/U1MQdd9zB0qVLsW2bn/zkJ5x77rmsWLGCs846a9j33Hrrrdx44417rH/ooYeIxWLjbTIAy5cvPyTHmYyoczu+qPN78BjlMgt/8Qvm/u536EGAG42y7t3vpuXCC6G9HR588KCPUSwWR7ztYdM5S9M07rvvPi699NJRve+SSy5B07S9NiUfztOfPn063d3dh6Tg2vLlyznvvPNU0aoxRp3b8UWd37FB+8MfMD75SbRt2wAI3vlO7K98hYdeeWVMz202m6Wuro5MJrNfXTuiPP3hOO200/jpT3+619fD4TDhcHiP9ZZlHbKL+VAea7Khzu34os7vAbJjB3z843DffXJ55kz43vfQ3/Y2TNeFV14Z03M7mv0c8Xn6q1atoqmpaaLNUCgUCvA8uO02OOYYKfimCZ/+NLzyikzHPAyYUE8/n8+zadOmynJLSwurV6+mpqaGGTNmcMMNN7Bz505+/OMfA3Dbbbcxa9Ysjj32WBzH4ac//Sn33HMP99xzz0R9BIVCoZA89xx85COwapVcftOb4PbbZR7+YcSEiv7KlSuHZN4sW7YMgCuvvJK7776btrY2tg3EwgAcx+Haa69l586dRKNRjj32WB544AEuuuiiQ267QqFQAJDJwOc+B9/7nqydk07DV78KH/iATMk8zJhQ0X/LW97CvsaR77777iHL1113Hdddd904W6VQKBQjQAj4zW/gE5+Atja57p//Gb7xDZgyZWJt2wdH/ECuQqFQHHJaWuBjH4M//lEuz58PP/gBnHvuxNo1Ag6/Zw+FQqE4XHEc+I//gGOPlYIfCsEXvwgvvnhECD4oT1+hUChGxuOPw1VXyUwckGWQf/ADWLhwYu0aJcrTVygUin3R2wsf/CCceaYU/Lo6+PGP4S9/OeIEH5ToKxQKxfAIIcV94UK480657oMfhA0b4D3vGfdqmOOFCu8oFArF7mzYAB/9KDz8sFw+9liZc3/GGRNr1xigPH2FQqEYpFyWA7MnnCAFPxqFW2+FF144KgQflKevUCgUkr/8RXr3r74qly+8UE64mj17Yu0aY5Snr1AoJjednXJS1d/+rRT8pib41a/ggQeOOsEHJfoKhWKyEgRwxx1yoPZnP5MDs9dcA+vWweWXH7EDtftDhXcUCsXk46WXZM79k0/K5SVL4L/+C97whom16xCgPH2FQjF5KBRkqeOTT5aCn0jIUsjPPjspBB+Up69QKCYLDzwg6+Vs3SqX3/lO+Pa3Ydq0ibXrEKNEX6FQHN3s3CkrYQ723ZgxQ2blXHzxxNo1QajwjkKhODrxffjOd2QXq3vuAcOAa6+FtWsnreCD8vQVCsXRyPPPyy5Wzz8vl087TQ7UnnDCxNp1GKA8fYVCcfSQzcpQzqmnSsFPp2X5hCeeUII/gPL0FQrFkY8QcO+98PGPQ2urXPdP/wTf/CY0NEysbYcZSvQVCsWRzZYtMivnwQfl8rx58P3vw3nnTahZhysqvKNQKI5MXFc2IF+8WAq+ZcHnPy+7WCnB3yvK01coFEceTz4pB2pfflkun322jN0vWjSxdh0BKE9foVAcOfT2woc/DG9+sxT82lq4+25ZBlkJ/ohQnr5CoTj8EUIWRVu2DLq65Lr3v1+Gd2prJ9a2Iwwl+gqF4vBm40a4+mpZ7x7kZKvbb4ezzppYu45QVHhHoVAcntg23HijzK//y18gEoFbboHVq5XgHwTK01coFIcfDz8sSx9v3CiXL7hA1suZO3di7ToKUJ6+QqE4fOjqgiuugL/5Gyn4jY3wi1/AH/+oBH+MUKKvUCgmniCAH/5QdrH6yU9k16qrr5ZdrN71rqO2i9VEoMI7CoViYnnlFRnKefxxuXzSSbI42qmnTqhZRyvK01coFBNDsQg33CBF/vHHIR6Hb3wDnntOCf44ojx9hUJx6PnjH2W9nJYWufz2t8va9zNmTKxdkwDl6SsUikNHayv8wz/ARRdJwZ8+He6/X/4pwT8kKNFXKBTjj+/Dd78rJ1b9+teyi9W//qvsYvX2t0+0dZMKFd5RKBTjywsvyOJoK1fK5VNPlQO1J500oWZNVpSnr1AoxodcDj71KXjDG6Tgp1JygtWTTyrBn0CUp69QKMYWIWSM/uMfhx075Lr/9/9kF6umpgk1TaFEX6FQjCVbt8I118Af/iCX58yRXawuuGBi7VJUUOEdhUJx8LgufO1rsovVH/4gu1h99rOy5r0S/MMK5ekrFIqD4+mn5UDtiy/K5bPOgh/8QN4AFIcdytNXKBQHRl8ffPSj8KY3ScGvrYUf/QhWrDjkgm97PpmSi+35h/S4RyLK01coFKNDCPj5z2VmTmenXPfe98rwTl3dITenM1tmzY5+CrZHPGxy4rQ0U1KRQ27HkYLy9BUKxcjZtEnG6N/9bin4ixZJz/6uuyZE8G3PZ82OfrIlj3QsRLbksWZHv/L494ESfYVCsX9sG266CY47DpYvh3BYLq9eDWefPWFmld2Agu1RmwgRNg1qEyEKtkfZDSbMpsOdCRX9Rx99lEsuuYTm5mY0TeP+++/f73seeeQRli5dSiQSYc6cOdx+++3jb6hCMZlZsUJOpvrCF6T4n3eezMr53Oek+E8gEUsnHjbpyTvYnk9P3iEeNolYyp/dGxN6ZgqFAieeeCLf/e53R7R9S0sLF110EWeeeSarVq3iM5/5DB//+Me55557xtlShWLyEcpmMT7wATjnHFi/Hhoa4H//F/70J5g3b6LNAyBsGpw4LU0qatJfdEhFZUw/bBoTbdphy4QO5F544YVceOGFI97+9ttvZ8aMGdx2220AHHPMMaxcuZKvf/3rXHbZZeNkpUIxyRAC7e67Ofdf/xU9l5Ndqz7yEbj1VkinJ9q6PZiSinDWgnrKbkDE0pXg74cjKnvnqaee4vzzzx+y7oILLuDOO+/EdV0sy9rjPbZtY9t2ZTmbzQLgui6u646rvYP7H+/jTEbUuR0n1q7FuOYazIEuVsFxxxH84AeIN75Rvn6Ynm8diJmACHAP83j+eFy7o9nXESX67e3tNDQ0DFnX0NCA53l0d3fTNExdj1tvvZUbb7xxj/UPPfQQsVhs3GzdleXLlx+S40xG1LkdG3TbZuGvf828++9H9zy8cJj1//iPbL74YkRPDzz44ESbeNQxltdusVgc8bZHlOgDaLs1SBZCDLt+kBtuuIFly5ZVlrPZLNOnT+f8888nlUqNn6HIu+/y5cs577zzhn0KURw46tyOHdpDD2EsW4a2eTMAwdvehvv1r/Pahg3q/I4D43HtDkYwRsIRJfqNjY20t7cPWdfZ2YlpmtTW1g77nnA4THiYDAPLsg7ZxXwojzXZUOf2IGhrkxOsfvlLuTx1Kvznf6Jfeimm58GGDer8jiNjeW5Hs58jKq/p9NNP3+OR6KGHHuKUU05RF6ZCMVJ8X1a+XLRICr6uS/Fftw7e8Q45cKs4ajlo0d+6dStr164lCEY/eJLP51m9ejWrV68GZErm6tWr2bZtGyBDM1dccUVl+6uuuoqtW7eybNky1q1bx49+9CPuvPNOrr322oP9GArF5GD1alkr52Mfg2z29QYn3/wmJJMTbZ3iEDBi0f+f//mfSqrkIB/+8IeZM2cOxx9/PMcddxzbt28f1cFXrlzJkiVLWLJkCQDLli1jyZIlfOELXwCgra2tcgMAmD17Ng8++CArVqzgpJNO4qabbuI73/mOStdUKPZHPi970p5yCjz7rBT4734XnnoKBn5/isnBiGP6t99+Ox/+8Icry//3f//HXXfdxY9//GOOOeYYrrnmGm688UZ++MMfjvjgb3nLWyoDscNx991377Hu7LPP5oUXXhjxMRSKSc9vfwv/8i8w6JRdfjncdhs0N0+oWYqJYcSiv3HjRk455ZTK8m9/+1v+7u/+jne/+90A/Pu//zvve9/7xt5ChUJxYGzbJlsW/va3cnn2bNmjdhQTIhVHHyMO75RKpSEpjk8++SRnnXVWZXnOnDl7ZNYoFIoJwPPgG9+QNe1/+1swTbjhBlkvRwn+pGfEnv7MmTN5/vnnmTlzJt3d3bzyyiucccYZldfb29upqqoaFyMVCsUIeeYZWTJhzRq5fMYZcPvtcOyxE2uX4rBhxKJ/xRVX8LGPfYxXXnmFv/71ryxatIilS5dWXn/yySc57rjjxsVIhUKxHzIZ+MxnZJtCIaC6WjY1ed/7ZEqmQjHAiEX/05/+NMVikXvvvZfGxkZ+/etfD3n9iSee4B//8R/H3ECFQrEPhJC59p/6FAyGV6+4Ar7+daivn1jbFIclIxZ9Xde56aabuOmmm4Z9/X//939pa2sbM8MUCsV+eO01uPpqeOghubxggQzlnHPOxNqlOKwZs+e+tWvXMnv27LHanUKh2BuOA7fcIrtYPfSQbGRy442yObkSfMV+OKJq7ygUk55HH4WrrpIlEwDOPVfG8efPn1i7FEcMaoRHoTgS6O6G979f9qNdtw6mTIGf/lT2q1WCrxgFSvQVisMZIeDuu2VxtLvukus+/GHZvvDd71bF0RSjZsThnRdffHGfr2/YsOGgjVEoFLuwfr0M5TzyiFw+7jj4r/+SBdMUigNkxKJ/0kknoWnasLVyBtfvrZGJQqEYBaUS/Pu/w1e+ItsTRqPwpS/JtExVQlxxkIxY9FtaWsbTDoVCATJG/9GPynRMgLe9TVbDnDVrQs1SHD2MqgyDQqEYJ9rbYdky+PnP5XJzM3znO/DOd6q4vWJMUQO5CsVEEgRyQtWiRVLwdV1Wxly3Di67TAm+YsxRefoKxUSxZo0cqH36abm8dKkcqN2lppVCMdYoT1+hONTk83DttVLcn35adrH6zndkhUwl+IpxRnn6CsWh5Pe/h2uukQ1OAP7+72UXq6lTJ9QsxeRBib5CcSjYsUPG6u+7Ty7PnCm7WL3tbRNrl2LSMSLRX7JkyYhz8FX/WoViFzxPplx+/vMyrGOaskH55z8P8fhEW6eYhIxI9C+99NJxNkOhOAp57jnZxWrVKrn8pjfJTJ3jj59YuxSTmhGJ/he/+MXxtkOhOHrIZOCzn4Xvf1/Wzkmn4atfhQ98QHWxUkw4KqavUIwVQsBvfgOf+AQMNhT653+WTcqnTJlY2xSKAUYt+r7v861vfYtf/epXbNu2Dcdxhrze29s7ZsYpFEcMmzfLrJw//lEuz58v69yfe+7E2qVQ7MaonzVvvPFGvvnNb/IP//APZDIZli1bxjvf+U50XedLX/rSOJioUBzGOA7ceisce6wU/FAIvvhF2cVKCb7iMGTUnv7PfvYz/vu//5u3ve1t3HjjjfzjP/4jc+fO5YQTTuDpp5/m4x//+HjYqVAcfjz+uJxR+8orcvmcc6R3v3DhxNqlUOyDUXv67e3tHD+QfZBIJMhkMgBcfPHFPPDAA2NrnUJxONLbCx/8IJx5phT8ujr48Y/hL39Rgq847Bm16E+bNo22gUGqefPm8dBDDwHw3HPPEQ6Hx9Y6heJwQggp7gsXwp13ynUf/CBs2ADveY8qjqY4Ihi16L/jHe/gL3/5CwCf+MQn+PznP8/8+fO54ooreP/73z/mBioUhwUbNsgY/ZVXyn61xx4Ljz0G//3fUFMz0dZNCmzPJ1NysT1/ok05ohl1TP8//uM/Kv//+7//e6ZNm8aTTz7JvHnz+Lu/+7sxNU6hmHDKZTlQ+x//IQdto1H4whdk7ftQaMLMsj2fshsQsXTCpjFhdhwqOrNl1uzop2B7xMMmJ05LMyUVmWizjkgOOk//tNNO47TTThsLWxSKw4s//xmuvhpefVUuX3ihrJcze/aEmjXZBND2fNbs6Cdb8qhNhOjJO6zZ0c9ZC+onxQ1vrDkg0d+4cSMrVqygs7OTIAiGvPaFL3xhTAxTKCaMjg5ZH+dnP5PLTU3w7W/LipjjGLcfifc+GQWw7AYUbPl5w6ZBbSJEf9Gh7AZH7WceT0Yt+v/93//NRz/6Uerq6mhsbBxSiE3TNCX6iiOXIIAf/hA+/Wno75cC/7GPwc03Q1XVuB56pN77ZBTAiKUTD5v05J3KjS4VNYlYqqTFgTBq0b/55pu55ZZb+PSnPz0e9igUE8NLL8mc+yeflMtLlsguVm94w7gfejTe+2QUwLBpcOK0NGt29NNflJ/3xGnpo/YmN96MWvT7+vq4/PLLx8MWheLQUyjAl78M3/ymLIOcSEjP/mMfk2WQDwGj8d4nqwBOSUU4a0H9pBq8Hi9GfVVffvnlPPTQQ1x11VXjYY9Ccej4wx9kvZytW+XyO98pY/fTph3Q7g40o2a03vtkFcCwaUyazzqejFr0582bx+c//3mefvppjj/+eCzLGvK6KsOgOOzZuVNWwrznHrk8Y4bMyrn44gPe5f5i8vu6IRyI964EUHGgjFr077jjDhKJBI888giPPPLIkNc0TVOirzh88X0p7p/7HORyYBjwqU/Bl750UF2s9heTH8kg7WTy3ifbHIPDjVGLfktLy3jYoVCMLytXyoHa55+Xy6edJgdqTzjhoHe9r5g8MOJB2sngvU+2OQaHI0fvkL9CAZDNyobkb3yjFPx0WrYsfOKJMRF8GBqTtz2fnrxDPCxj8sPdEDJFl86cfUSUE7C9YMxKH+z6RJSOhciWPNbs6D8izsPRxIg8/WXLlnHTTTcRj8dZtmzZPrf95je/OSaGKRQHhRAyZv+JT0Brq1z3T/8ks3QaGsb0UIMx+ZVbe2ntL5GOWUNi8rsO0rZ0F+jO2YCgKhYalad7qMMiGQce39RN2RMH5JXvbu9knGNwODIi0V+1ahWu61b+vzc0VWVQcTiwZYtMuXzwQbk8b57sV3veeYfclF0HabtzNt05m7pEmLpkZFSzaccrLLK3G4ntBWzLQ6TsMSUVHfXM3+HsrYpZk26OweHIiET/4YcfZvPmzVRVVfHwww+Pt00KxYHhutKTv/FGKJXAsuD66+GGG2ShtHFiMGxRcgKa03sK5OAgbeeAh1+XjIzK0x2v0gv7upHYro/ta9TGrVF75fuydzLOMTjcGPEtdv78+XR1dVWW3/Wud9HR0XHQBnz/+99n9uzZRCIRli5dymOPPbbXbVesWIGmaXv8rV+//qDtUBzhPPkknHyyFPlSCc4+W7Ys/PKXx1XwYfiB3ILtVQZyQXr8U5JhqmKhYWP/B7v/0bK/+HrYMggbgp6CO8RWXWO/Mf592Tt4AzxnUQNnLahXg7gTwIhFXwgxZPnBBx+kUCgc1MF/+ctf8slPfpLPfvazrFq1ijPPPJMLL7yQbdu27fN9GzZsoK2trfI3f/78g7JDcQTT2wsf/jC8+c3w8stQWwt33w0PPwyLFh0SE/Y1kLsrg6GeVNQclac70v2Phv3dSMKmzowEpCKv2zo1HeXpzT08vL6Dv6zr4LXOHLmyu8dNYDzsVYwdh2ae+V745je/yQc+8AE++MEPAnDbbbfxpz/9iR/84Afceuute33flClTSKfTh8hKxWGJEExbsQLzQx+CwSfQ978fvvpVKfyHkNFMrjqQfPzxKL0wklnAVSE4Y14dPjq6Bk9v7iFb8jB0eK6lj8de7SIVtZhaFaUpHa2Eh/Zlr0rZnHhGLPqDoZTd1x0ojuPw/PPPc/311w9Zf/755/PkYNGrvbBkyRLK5TKLFy/mc5/7HOecc85et7VtG9u2K8vZbBYA13Urg9PjxeD+x/s4k46NG9GvuYalK1YAIBYtwv/e9xBnnilfn4DzXR01OH12Nbbry9CIqe/1e9eBmAmIgHzJG/Kesdj/SNCBxY0JXtqZoTtXIhE2WdyYQBcBrhtU9q0Ln7Clky25ZIo2ibDBhvYCQvh0ZcuUHQ9LB0OHF7b6nDGvjrCpD2tvvmTzwtYesmWP2rhFT0EuD75nsjAeujCafY1Y9IUQvPe97630wS2Xy1x11VXEd5vJeO+9945of93d3fi+T8Nu6XMNDQ20t7cP+56mpibuuOMOli5dim3b/OQnP+Hcc89lxYoVnHXWWcO+59Zbb+XGG2/cY/1DDz1ELBYbka0Hy/Llyw/JcY52dNdl/j33MP83v8HwPPxQiA2XX86mSy9F5HKvZ+scIWQc2JYH29cIG4IZCeldH0q8ANwACjqs3Lzn64PXrhfA+n7I2BrdNrg+5DwworChEwpxWC+gb6OQN7RhKHqwtk8jZsI2XR636O37PUczY6kLxWJxxNuO+FRfeeWVQ5b/+Z//eeQW7YPdnxaEEHt9gli4cCELFy6sLJ9++uls376dr3/963sV/RtuuGHI3IJsNsv06dM5//zzSaVSY/AJ9o7ruixfvpzzzjtvjxpFitGhrViB8bGPoQ10sfL/9m/562WX8eYrrmD+EXhubS/g8U3dRCper0sqYh42Xu9w1+5pOZsXtvXxwtZ+3CDA0nWKrk99MkRTVZTaeGif9tteQPWm7l08/cPrMx8qxkMXBiMYI2HEon/XXXcdkDF7o66uDsMw9vDqOzs79/D+98Vpp53GT3/6072+Hg6HK08nu2JZ1iET4kN5rKOOzk649lr4yU/kcmMj3HYbwTveQfGPfzxiz23Rcyl7gimpKLqmEQ9D3vbw0Q+rz7Pr+Z1aY1GXinJMczUbO7J05Ww6szZTkmGmpGRMPxHd87f2+r7g5Jm1rNnRT872qI6H9/ueseBwrfUzltfuaPYzYQ9VoVCIpUuXsnz5ct7xjndU1i9fvpy3v/3tI97PqlWraGpqGg8TFRNJEMCPfgTXXQd9fbKL1Uc/CrfcIkspHCbjJAdbTrmlq0B/yaErZ1MdC5EtO1RFx1f0D0YEw6bBvCkJptdEKbsBugaBYMT7OtSF5dTA8Z5MaCRt2bJlvOc97+GUU07h9NNP54477mDbtm2VWv033HADO3fu5Mc//jEgs3tmzZrFsccei+M4/PSnP+Wee+7hnsESuYqjg1degY98RNbHATjpJFkc7dRTJ9Ss3TkYQQmbBsc0pli9rZ++kkN9Mkw6FmJ9W44pA5O3Djebd+VgisMdqsJyk7Gf8EiYUNF/17veRU9PD1/+8pdpa2vjuOOO48EHH2TmzJkAtLW1DcnZdxyHa6+9lp07dxKNRjn22GN54IEHuOiiiybqIyjGkmIRbroJvv512cUqHpeTqz7+8UPWxWqkjIWgJKMWs+viLA6nSIZNAsG41qLZm82nzakdlbd+pKBq/QzPhP+Srr76aq6++uphX7v77ruHLF933XVcd911h8AqxSHnj3+U9XIGS3e//e3wne/IBieHIWMhKBFLpypmkS15xEOMuBaN7flkSy6gkYqaIz7ecDZv6ynw1/UdCMFRF/6YjP2ER8KEi75iktPaKith/uY3cnn6dPjP/5SifxgzFoKyv0lXw8XeO7NlHt3Yxbr2LBqwsDHF2XspZ7D7+3e3uSNboiNrY2ga6XiI3l2eVo5UWdz9M6taP3uiRF8xMfg+/OAH8JnPvN7F6pOflF2sEomJtm6/jJWg7G1gc0dvkee39eJ6QaUEc1XMYuXWXta2ZdE1jUAIVm/rJ2RqvPW4piHHHozdZ4oulqlz8sw006vjQ2yOWCbRkE5n3qY1W8bUNcoDojlc3vzhmgUzyN7GKyZLR7KRokRfceh54QU5ULtypVw+9VQ5UHvSSRNq1mgZFJRsycXxBJomhXF/FTN3F6DdBza39xX4xbPb6SvKAd5c2cf1AxY1JunJO5iGhmXotPWX6Cs6rNwiOLY5zbwpicox1uzoZ0dfif6iQ1feZmN7jn88dQbTamIVEfT8gB89nqOn4NCcjtDaX8bzBfow02QO9yyY/Y2xKLF/HSX6ikNHLgdf+IKM1QcBVFXBrbfKgmnGkfmjzBRdHtnYxYb2LAI4pjG11+qRIxFO2/N5YavM6GmsilByfHb2F9nWk6c7Z7MzU6Kv4NBfdCm5PqauIYTGxo4s02uilWYlmaJLf9HB8QSNqQjtmTLPb+ulPhWuiGCm5NKQCmMaGkXbpypqUhUz6S+5VEeMITYd7lkwatB25BypoTvFkYQQcO+9cMwxcNttUvD/3/+D9etl7v0hEHzb88es7d+u+1y5tZe1rVlAQ0NjbVuWlVt79zjOSFsFlt0A1wuoT4QpOQGWqbGxPYcTCJrSERqTUUKGRrbkki976BpELIOunF2pkKlr4AaCjkyZaEin5PjUJ8O4XjCkHLOuQVUsRNQyEAjaMyVWb8uw/OU2Ht/UTcZ53aa9VeQci/M6FvtQlT1HjvL0FePL1q1wzTXwhz/I5TlzZBerCy44ZCaMV2ii7Ab0F11CpkZ1LIQA+orSC9/dwxypJzqY0ZOzQ3TnbbZ0FzENnSXTq0mEQ8yuN7AM8IQgV/KZXR+lJ+/RmbXRtdc/a67k0FN0KLkes+oSpKMhqmKhiggObteTs3lxRwZL1/ABy9DJlD3CBUfWBfICIpY57KB1tuzwbEtuv+d1X2MBYzlvQA3ajgx1G1SMD64LX/saLF4sBd+y4LOflTXvD6Hgj0cz7kHPVNcgHbNwPEF33qEn7+D5gnTM2sPDHG3N/UTYpFj2SIRNplZHydle5X0CEIGGHwS0dBWJhwwaUmHK7uux/ILjE7UMik5A3DKYVhOtiODgOekt2KRiFvGQTnXCoqkqytwpcbxAkAqb2L4mq2QO0wfgmMYU69ty+z2vg9lGD6/v4NGNXXRmyyP6bgbP8XD1+veGatAyMpSnrxh7nnpKDtS+9JJcPussmamzePEhN2VfHvbg66PJ6tjdM51VG6dg+5WY/uKmFKfMrNljf6PxRGUvWYO5DUkaUiF29JbpztkkwyaxsIHjyxtIImLg+QI3CKhLhnE8wY7eIjv7S+iaxrwpCXb2lUjGLE6bU0syYlU+c1t/iZ6Cg+0GlNwAx3NpShu09pdpSIXJ2h5hQxC2pH27Z8GM5MklV3Z5anMPZdejYZg+u3vbx47eIpu7C7T2l+jM2jSkwkPq9e8LNWi7f5ToK8aOvj7Zj/aOO2Qcv7ZWevvvfa+snbMbhyIFcG/59LmSy7Mt2VGFFYYb0IQSbz2ukbcsnAIIUlFrr59lpOmDZTfA8QKmVcuB2dn1BsmIwRvn1hIxDZ7Y1MWJ06vY3lciX3bxA0FdPMRjr3bxyMYu2jIlZtXFaEjFaKyKYOkawS6N73QNOrJ2JWvHNHQcL6A6ZmHoOrXxELXxEH6CIdUvdxfUfc1T6MyWeWpzN89t6aU2HiYVCe1xYxjuu4mGdDZ05MiVPHoLDj0Fma0UtvTDbvD4SEWJvuLgEQJ+/nP41KdkVUzAv+JKCjffSrhpCuFhBP9QpQAO52Evakqyri076myUvXmmgYD65MgqRY7EEx1ODKtiIdJRi7IbEDJ1So5M4ezI2CSjBm3ZMhs7cjSmwvQVHVq6SuiazvR0dEgsH2SBtCkDWTu2FzA1HSUeMvjbY5uYkgwTCDAI+MtmGdMveu4eN6l9PbkM3hzLTkBtPExH1gayNKcj1MTDFVsG97Fyay+t/SXSMYsFDSle3tlPImLi9Qma0xFsLyARsSqDx0r0Dw4l+oqDY9MmuPpqGGwIsWgRfd/4DitnHU+h2yOe69pD0MczBXC4p4e9hSZSUQMvEMRCOl05m2zJpT659+OPdBbuSJ5g9rXNcIJanwjz1/WduF6AADSgYHs0VIWZXZfg2ZYeTENjZl2CdCzExo4csZDBlKrwHmGkiKXTnI4SMQ18IVjflqPsyRBVMlzDlFQE13XJOPD4pm7KnhhyYx60vSpmDfvkMnh+G6oiJKMWkKWnYDOnPrHfwdWwpREPm/TmHUxdq4Sb8mV3yA3jYDncJ5qNJ0r0FQeGbct+tLfcIv8fDuN95jP0Xf0JnmsrUNqHoI8kHrx7fZnB9+3+I93VE80U3b0+PezuYXu+4KnXenE8n7Z+m4aqEOmYxSkza/b6xLGrGLf3lxAazKmvGnYm7L6eYHbNnBEanDq7hrn1ySHb7Hqj6s6Xuff5nfTkbapiFnXJEFPTMd4wq4bUQBnmjR0WXqcYCDnBtJoYJ05L8zeLGiqx/N0/x8qtvbywtQ/T0DhhapqSE1S+K9cL2JaHSNljyi7x+EVNSda37TtjZ/ebY3NVlDn1cf5m0ZQhtgze/EtOQHNaHmN9W45jGlOsa89S9nw8X1AVsYhY8gltLAT6cJ9oNt4o0VeMiCGe0eOPwVVXwYYN8sXzzqPnK9/ihXAtXa/1s7krz3FTq/Yq6PvzmHevL9NcFSUZtbAMrfIjrY4aQzzRkKlTtH00TRvR04MAPD+gK+fg+D6xkEmu7O7zPbmyi+0HxCyTZ7p7KJQ9dvSWeNsJTSxurhr2CWbl1t6KOO8a+ljXlmVjh5wNu2J9F+85fSZvmF2zRwgF4OWdGVozJQIR0NVls7PPwEAntMuN7JSZNRRtv3LOjp+a5sz59RWR3d2znZKK8IZZNfQXXeqTIRLhELbnV74rz/WxfY3auFX5HrtzZV7Y2o/ni0rtnqc29+wh5rs/qdQkZBmJ3W8+e7v5J6PWkBveyzszuJ7P+rYcYcM4KIE+EiaajTdK9BX7ZdAzcts7Oek7t9D821/JFxoa4Fvfwv77y3nh1W6yJY/6ZIhNnbBme4Y3zTPJlrw9QiD7iwcPrS8T8MRr3UxNxzhzQV0lrW/p9KohnuiO3hItPXlOm1Oz3xmZZTdAQ7CoKYWh50hGTfyAfcaN17ZmeODFNrpyNq915alPhFg8tYrW/jIPvNjG9JoYgaAiYroGtu/z8ub+AWEdCLNYBj05m40dOYp2QDpq8lpnnh8+tpnegsNpc2oropYru2zvK9KXs3H9gKIdUBUzaesv05otDSmXUBWzOHthPafPrSVkGkOqb+7Ns01FLeqTYbIlD8vwh9x8XQzChqCn4GIY8gZtmTquJzOFSo5Pa3+ZnoINCE6fUzdEjEcyaL2vm//g9pu7Cng+1CUjYyLQauauEn3FfrA9nzXbeqn+1f9y4nf+HSvTh9A0gg99GOMr/wHpNOWSO+SHdOK0NC/u7KcrZ78udrv9oPYmCoMTnkxDTngqez6BEOi6QEOr/EizJWeIJ9pQFWZLT56OrINVbVQERNcgUxo6EJktO7zalacrY1N0fdqzGnPq43uNG+fKLg+82EZPwSEZNegvOeg6GLpGczpCZ65MZ84mYur4geDVziz9RY+XdvRj6QbHTq2q3KxOm1OL0KCn4FCfCNGesYmHDYQQdOTKFVF7rTPPAy+20Vtw6C7YeH5AKiLLMNclwzSnIpWMnOFEfdcw2WBOfiJi0Vuwhwjn3m6+ugiYkYBUZGhu/os7+9nSXaArX6YnL8s4lHcJC+3+pLK/MY3BcNFwaazjIdCDN5qObIlExKK/4JKImMPWGzpaUaKv2CfOiy+z5IMfpm7VswDkFy7m+Rtu5aR/uLDS1m93j80LBEtnVvOGWbX7rPc+nChELJ107PX4dCAC6fEHGgJBT94lFTVJRUNDPNFsyWNhY4p42KgISF0yVBn8rIpZlUqVj7/aTVdWFiLrGKgumYoYzKqND3niGLwh9ZdcMmWZ3mhoDHilLr15m4ITEDF1ntzUzZaeAvmSS1feIRoyiFomdfEQ7dkyCxsTFGyPQMgY/mMbu2ntKxEgCJsm1bEw09JRCrZHd87ht2t20p11mFYTIVty6cyWSYUt5k9JUBsP05iOki+75AdCUiUnGDZcsWtOvheUMHUN2w3IllxCpjwvp82ppb/kko5aQ0IwVSE4Y14dPnplzKRg+7zWmWdbX5H5U5IsbEwRCxmjEuPObJmVW3vpL7qkYxaLGlJYlr7H8cejHn7YNJiajrJ6Wz/t2V5KTsCxzUme3twzaWL7SvQVw1Mqwc03k/ja10i6Ll4kytZ/uY41l11JMhkdUbhmpGmMuxI2jSHxaV3TePPcOqIhg/b+ErGwbDOYjJh7eKKLmpJETBMQ5Eoe97ywQ7YiTITJ2SFcPyAdCbH8lQ48P8D2A6oiFsmYyay6BPGwQVXM2sNznluXIGqabGzPM6MuSjoSwh4oalaXjFCdsGjpLqBrGmHLwPF9ZiVjxMMmJTcgW3bZ2VemOi7DPnPrk3z4rDncu2oHr7bniVgGJ89MU3QCUlGT1v4i69tk9s3mriJeIHvR6oZGTSxEOh6ivb/MC1tbsL0ALwh44+zaXWLvNp052bB895z81v4y2aLLk691IwS4vkADzIHxkmMaUySjFgbBwPchG7UPht1sN+CU2dX4QuD6AZYxfPOXvWXH2J7PIxu7WNuaJWRqvLjd5dnNvSxqTBINGyydUUN9Klx571iXVrA9n539JZqrItiuh++7FF1/jyegoxkl+oo9+dOfZBrm5s1ogH3h23h22RfpqW0iGR7+hzeWdcunpCJcclIzZ5fqAY2y5/H4q92sa8+BAMcTnDW/dognmiu5rGvLkim6aAMhnZ5CmZpEmJLrUejz2NSRI1v2aMuUqI2HcBwfTYeQrjMladFfdGntK/HiTpljXpMI0ZGx2dyVp7fk0NKT59XODHUJ+Vmb0zEWTImzekcGDUFtIowfCDqyNlnbY15jklfb8xRsnzathKZR8Sib01FOmVlDTTxEtuhScgPqkjpz6xM819KNBuRtj3zJI1NyqI6H0ISgLVfGMnW295UwdA3LgNY+hxe29nHmApMdfSU6MmVKjkdtMszs2jjJqInrB3TlbFIRk5ztkiv5NFSFeXJTD5oGp8+tYUdvidXb+pleEyWka2QGKibYns/atizPbe4hZBkkShYLG5Ns7y3SlXP2COHtKzsmW/LY0J7F0DWSEXmzzJRcTFNW+ly9tZ8FTUmillF571jWwx8MGem6RmumjABaugpMS8cOeB7AkZb+qURf8Tptbfif/CTGrwYGaqdOhf/8T8KXXsqpfrDfC3ssp8CHTYP6pAyzPLeuhzXb++nJO7h+QEe2jB/4RAcKRjqez/PbemntL5O3PTqyZdr6S0RMna6cSzQk870jpoGha2ia7EVrmjoFxycetnhxRw7X93m1I0u27FEdC2H06Niuz6qtfUyrjnHW/DpWbu3DNHQWN6Voz9o8tK6DUtlne1+J7pyNZRnEQwZ18TAhXeekGVVkix4hU6ehKlLJ6AHpZc+uTfBCoY8dfQVils4T+S42dORoTkfoyNiUXB8hYFp1jFn1CVq6CvQX+qmKhahLhBGA6wlZJbO/zNbuAgXbo+T6vLgjw1OWHINo6S4QCxmETIPqmFUp4RAyNZnJFEB/yaE1U8ILAjJFh55OOH57hs6Cw3Obe9nWW6YxFcYPoDfvcNKMKt40t25IZlK25LJya+9ew00gBmoHBeTLLkXbwx6sLJoMsWpbP44veMui+so4yFkL6iuhxIMlYumETJ1V2/pxfYHtBYRNnXXtWU6bUzvq0NGRmP6pRF8hu1jdfjvBZz6Dkc0idJ1t//xBYv9+M/VT64GJq2lSdgO6czbdORtdk+GNvqLDurYsU8syZXNLb4nnNvfiCylitYkwvQWHiKXTkAyzo8+mv+Bw8sw0mqbh+oKi61IXDyPiAtf3KTqCeEhm7xSdgPZMlljIJB21KLoeXhBg6jp1CVnYrOTK9MZcyWNGbYwXd2Z4cWeRsKEzuz7OxSc2s3RWDY7n88SmbtKx1wcjW/tLANQnQ2xoz2MZOgKNde05TEOjKmrRk3eZU58gGjLpLZSZVRenO2dj+wHZokNvwcXxAmIhE8s0OGl6mvkNSV7e2U+m7JJ3fXb2FtEQREImZdcnZOg4nkdvwcbSdZrSUfqLLvGwieN5dGTKA5O/BI1VYbZs1Xjw5TZm1MYJWTqNVWEKtk8kpKPrGsc1V1GflAI3KH5dOXufKbupqMXUdJQnXu3BEz59RZewqZOOhciVPaKWQSSkDxm0H8vMmrBpsKAhxQtb+2hIhcnZPsmIQcjQWdCQGtVxjtT0TyX6k53Vq2VxtGefRQd6F5/I5pu/wdYZC0llfM5q2HcnqPEmYul4QUBrpoyhaYRMnXjIADR2FiCRLdOdL5N3XPqLHhFLZ0dfCdcPBkIkAfGQDkGIRMQiFbHIlT0MHY5pTuEHgjXb+7B0gx7DZd6UBIbhYbs+XhBg6GDpOhvaswSBIFP2SYZNhNDoytskoyadORvfD6iOWjSmowgheGZLDydOTwMQMvUhg5HpmPRaO7IO2bILQNQ08QMBQjCjOo6pl+gp2Jw8M822niLtmTIFxyOk6yxsTJEtu3TlykytjnFccxWnzanF9QN6ivJmENWgI1Om7PnELIOGtMxKKjo+RcentyhvIOmoyfR0lJLtk4iaOH5AImxRKLvETJmCmo6HyNk+fiBr9zemI0xNR5lWEwOGit9IUnaTEYupNRE5pyLu0l906ciUqU2GqI6FCAKGDNqPdU386TVRTp5ZTW/epSZhVf6dXhMd1X6O1PRPJfqTlXxedrH69rchCBDJJC9efR19V3yAcDhE7S4TdSb6Ao6FLGpi8gcl2xHqNKXCvNqmsaO3yJbeMomQRXt/GT/QiYVMykGAgyAS0smUPAIEhbIsN1wVtaiOWfTkbVr7y5i6jhsEZAsuJcfnhGlVGFqEXNmjPVum4PiUHJ/Xugo0pSO8cU41QgjCuk5X1qY1U6S36NJUFaE5Ld/X2lfiobXtRC0ZRhEwZDASYOXWXlq6BUEAqajOizvyBEA8YpKOhphTn+BvFk0hU3R5bFMXL27vZ0oqwqLGFKYB7RmbN8+rZWq1FN8dfSVqYxbdBZedvSUKro8GOEHA9p6SnL0rIB0NoWs6/UWHvO0yNR2jJhnm/MUNPLKhm/ZMmdqYSdKCmkQY2/WZXh2lNy9TVacOjEfsLbVyXym7ZTfAMjTOnF+PhszI2t5TIBq2sHSN2bVy4lym6IAGU9Ov31jGKm4+mCwwGJZpGKZUxUgYj+yiQ4ES/cnI/ffDv/wL7Nghly+/HOfr36AzL/PAa3ebqLM/RvuDHM32g9tdenIzmzoLdOfK9BQdnECwpSBwMzbxkMHOvhLxsEltIkzI1ElGDHrzDkXbpyEVwXZ8NA3SUZMggGjYoC9vowFoGiXXpeh4CCBk6MyaWsXzLX3s6JOFwGbVxPCB6dVRzlowhWREDo6ua8sRt0w0DbJl6bUWbI9k2CLwBekqKQYhQ+PYqVWkoxamIVMgzz2mgYUNSZ58rZtHN3Zh+4JUxKS1rwxC463HN5KMyDTGi09oljcz1yMakvMQGqsiTK2OVcpPZIoO0ZBJ2PYoewExS07S0jSNvqKL6/vUxcPEIwamAZ05l2TYpOD6lB2fTMnjnUun8vLODCXbpRQVvPXYBjrz8jO9YXY1CxuSTKuJ7VHLZ1fxK3seC6YkOWF6mmnV0WHTMAefADoyNo3pKGfOrycQ8vXOXJkV6zt5ravA+rYcTVVRqqJWJcNoLOLmY5F4sK95DoczSvQnE9u2SbH/3e/k8uzZ8L3vwYUXEgZOHIjL7usC3l2wRzuQtbft93Yj0DXwAkG+7HNsU4qnyy7Tq2PMqo3xpKaBBomIQTpuYegaU9NRjmmWMdvegkvY0unOSUHPln0cT47+1qfC9Jdc8rZPR7aEZconhLn1cWbWxZg/JcmarX1YhoGua8TCJt35Mjv7Sjzb0kMsbJIpuyydVcX8xgTpeIh1rTJ7aFZdjOk1MaYOiKOpa6zZ0U9rpkSu5FXqwx/TmCIVtbAMnapoiMXNEUqOTM+cXh0hFQlVzkMyYnH6nNo9vh+gElqpS0aIh/P0ttl4voy9N6TChE2TmpjLjJoYDVURNrTlyJRcLENn8dQqABIRk4LtUZeI8NbjYuSLNlar7A+wSNP3KY67it+2ngKvduYpOj7r27IsaEryhlm1lf69g9s+srGLZzb3IICIlaLk+JXr4KUdGVq6i5i6nOz25KZuptZEOXN+3ZDB3eFsGY1DMRbjVGOZtXaoUKI/GfA8Gcb54hehUADThH/7N/jc5yAWq2y2vwt4j/z1+gQvDaQ3Dmam7O8HOdzA196KeA3W4Hl+Wy/dOZt42EJDcPLMGunVR8AQ0jNPhS1SIZMZNVHChkYqalEbD+P6Ae3ZEhoaU6sjdOVsCo5HdcwiHjLJlLJ4fkBNPEx1PERdMoLnBbzamScUMuSs2WyZl3IZhIAZtQa+L3hxRz8tXQV0oKEqghCwqCHF9JoozdURDH1wVrDBmh2yXk2u5FXqw9uez+pt/TRWRdjcmR/owCXFtz1TJjpMV63hvp/MLrOht/cWeWZzH71Fm2hIPn0U7ACNgGOaqrj4hCZe3JnB9bNoaKRjJt05h1l1MfJlj5pEqLJfPWoxWEp/JOI4JRXh5BnV/Kw1w2tdOUxNp0uDTV05NrbneMPsmkoxu8EmMbPqEjSkQmRLfuW62X1Gtu36BAhEICi5AamoMSS1cleR31fBvfFkopIcDhQl+kc7zzwjB2rXrJHLZ5yB893vUVpwjPyB77b54AU82K5uUAR2F+yW7gLPtPSSLbpUJyyiIX2Pgazdva7hBr66c2WeeLWbXNmnIRWiI2uzcmsvZ86vr9TgiYcsggRs6cqRd2S++YKGBCB7xfbmXYquR7bk0We7nDqzlll1cnbtizv66craWKZOVcTCD5C5+ZaBpsGUZIQTpkWIh03SsRDtmTJFNyCmaSydUUPYMMiUPFw/oC4eZlpVlDU7M1RFDVxf0FuQE5/cQJCOmlQnQ6xvLzCtOkpTOkJXzkHXYP6UOFt7izSkwrIyqOPTV3CYUx9H0zXytkdtwqA9W6Y6FpLH3otXPVxoZWdfgcdf7aa36DAlKQdJbc+nORXhhBlplkyvpjNvs623SE0iLHvclmQv31TErBRFAznHYXBy1u719HNld9jZu53ZMn94sZUHX2onZ7s0JKN4vk8AuEFAb96tFJ8DcLyAhlQITdNJRakI+e4zsv1ATgLb0V8itK2/0p0sYulDnJDRFtzbF0da3v1oUaJ/tNLfD5/5DNx+u2xyUl0NX/sanZf9I2tasxTWd+y39O+QWi6WMaSYWH/RoStbpuz6bOsrsLOvxLFNKZqrY0MadO+6D+nhDR346sjaPNfSS8n1CITG9Joo1fEQU6uiFY8vFbHoypcoODJObRo6Gzvz6J7gDU1JMmWfbT0+1XGLshewtbdAVcwiETaY3yCn2Pfkbda2ZynZgvpkiHn1cXJlj/BATn3e9tjWW8R2AzwvYHveoS4Z5rhpSXb2F6lzQ+i6RnfBwfF8LCOK6wdMr4njej5t2TI52yMSMrCdgLZMibce10TI1PjzOljXmqM1U6Rg+zQkw3QXbKKmwaZO2fhke59PXSzEgoYkJ89MM606Nvz3uhuD4ZI/vVKmt+hQEwuRiljEIwZbeorEoxYx02DFhi4SEYOQqVMTD5EIG5w0I03Z8Xnz/HqmJMNkii6PbuwiU3TQNcH2nEyJzdtyPCRiGry0M0vecamKhIZUF125tZeNHTlZk0jT6crJp6tE1CQZDhGxNF7Y2lcpvdBbcHhxRwnT0PB8URHy3Wdkg6C5Koqua5iGhuPJQXHHC4Y4IXsruDdYbmKkAn4k5t2PFiX6RxtCwC9/KbtYtbfLdVdcAV//OnZ1DWs2du0zr3hvIZjT5tRWBNsyZNaMGwTUJyJYhs6O3iJFx+MM0+CxV7so2D76MF7XrgNfpgGvdebYmRkQ20BQdDxOmp5mS2+BRNjE8wWdWVncCw2mVkeZVRenK1um39ZIhS1auku4QYAR6CTDJiFDoypi4noyHTMRMXcRDNmEZPX2fmriYd44q5ac7RItyolaDakQ86ekaOkq0J2zQQiKjo+haUxLR9nYmSNX9vADQXIgDu74PgXHw9Q0iraLoRlyQNiUYSZL13E8H88L6C86dOfl4DNhWL0tQ85xmVMbJ9osyzFMr47v1aPeG7GQTGUtOHIy15auPJ7QaKoKEw4b9BTKoIWJhQzyZTnPID8wK3fKQLmMlVt72dpdJG97dOZKbGwFty5D2ROsbc3S2l+iPhlmycxqegrOkOqi/UWXeMhkRk2M7b1FsmWB6wsSYZP6pMWLO7KYhkZ9MkRvwWFbT5FACCzDQAiZsTPI4Izs03O1dOcd1rVlqE2EK9k+Bdujf7cif8MV3BNC8NyWXhwvGJGAH6l596NFif7RxGuvyfIJDz0klxcskJ7+OecA7FENc7i84n21BDxxWppHN3bx3JZeOrJlHC+gJhai5AX4QlB2fCIhk96Cy5buPG+cU4uuaUQsnZ6cHARNRmSBr0DAqq29rG3PgdDwAoGuycf85nSEgu1z0vRqirbHmp0ZLE0jHQkRMQy295bozJZwS9CaK7Gzv8iOvhKIgUHdWIj+oouGxpbeAkEAJ01PEw+bA/HzMEtn1dBXcHhmSw+NSdkntqkqwtz6BGHTYHZ9HNfz2NKdZ1tPAccXtGdLLGyo4oRpYWbWRlm1tZ917TmiIYPqqIXjB2ztLlGbsFjclCZiGZUG7LXJEGHLoDYZ5oWtfZRd2bbQ8XyyZY+qiMW6thymrtMzxWH52g4yZYeqSIjzFjcwuz4xrLc6KFSeD6fNrePR9V1s6c2jaxqWofPKzixdWYe+gkvRCThtTh3ZUg4CqElYlcH6TZ15nmuRbQs1XWNK3CLvaqxvy6LrBqahUfZ8Co5PZ8ZmRl2U3oJD50Bph3hYPgkWbX9gcFZnRn2MxnSE9W05uvMOb5xTQ9g0SUQEnghY1BDHDWSxO0PXhnjlmaLL2rYsmaLD9t4SJTdgdl28krufjg59aty94F40pFOwfXJld9jqosNxpObdjxYl+kcDjiMbkN98M5TLsovV9ddT+OS1RBLRStx+JHnFu26Tihp0ZB1q4hYRS6YZun6AH0BjVYS1rVmefq2X5nSERNgiETHpzJVY2JCkpRs2deQpez7beopkSi4vbO8nFbFY2JhiXkOcv2zoIFvyMDSBpWvYfkAyrLOlR+a9axqgweKmJPOnJOkvOLzc2s/O/jJ+IPBL8PD6bjw/YEoyQlfBob/kohs67TsyOJ5POmrRV3J5dovH/LoEJS9gUTpMTUxm22zoyJGtcTE0HUvXSIQNauIh1rflWL2tj629BfqKLoKAfNmh7AWcFavjmMY0c+sT/H51G5qhETI0MkWXlu4Cvh9g6jn+9HI7b5xbg6bBlu4ijhewtaeI6wt0TVATN9hedKlNhKiKWgRCsGZHP6+09lNyZX/YzZ0F7nh0M2fNr6M2GWZRU5JUJDRknKS1v0RnzqZoe0TDOnHXYm59gtc687zWVaSv6OAFAkPTyZddTplVzYKBQefBsZeNHVkcPxgoS2DQmi0TNaCv6FKd0NEBXdPozdu8psu6QE1VEV7ZmSEQgpIrS2CjaTSno8Qti1TMZFFjiiAQLF/fzooNXfQVXGoTFtmiyy+f24kXCCxD541zagiZskH7rvH5umSEXNmnO2eTDJuVaqkhU2d2XYKNHVm6B+oRLZ1RWynW5ngBf3ypdY/qovsS8CM17360KNE/0nn0UdnFat06uXzuufR87TZeCNdRaOknZGaH/MD3l1ccNg0WNSV5eH0XL+3sx9Q1wmaKrqyN4wds7MgRBIKyFxCxDDJlm6qohTGQe95XlHH6+fUJWnoL9BddbN+nYLsYukbEMnh+aw8v7cxQcgIWTImzuUdWktSELBkQDRksbkzxcmu2UgystU827Jg3JU7ZlRk5WReMgo3tQ30ixNzaGD1FF4QgZ3v4foBlyMYf23qK9Bds6pNRPF/QV5SP7o4X0J0zKLseyahFcynKmu0ZdvYW6C959Bc8bC+ozPDVC9LzvOf57RwzNcWChgReIJ8wVm7pI2LpNFVHiFo6a9uyMoxSdtnQlqO7UEYDLENH02TLRg1BxNSJWiamrlO0PYoiYGZtnLBp4AUBXXkbNDn5avW2fmbXxaiKhTimMYXrB7zSmmFnX4loSMbxIwNealfeIFN2yJV9ZtXG0NCIhfQhHbUAsiU5v+D4qSkKtpyUFzI0pkTBTIbJl2VpitpEmL6CLds8BpCOmfQUHKZVR+jKy34Cbz+pCcswKDgeL27vJxkxWduahUDOY3hhay8za2N05RyKrk8ibJIvezy9uZfGZIjGdJzOjM2W3gJLZlShaxqz6+MkIwZvnFs7ZOxhsMZQ2fExDY0Xd/ZziikzhHrytnQ2yh7Ta6K09pfxfDGkbv7uA7ZHat79aFGif6TS3Q3XXQd33SWXp0yBb34T+x/eVeliZeoaK7f08cLWPk6eWc0pM2uoilmcNL0aEJVCWbvSmS3LPOmuPK4fcHxzNb1FmzsefY1ExOKVnVkyJYeQpWOgEQ0ZWKbBwsY4z27uwxOCiGVw7qIGTENHaIJ1rbmBMr4BvQPeuOf5zKiN05SO4gWCrT0FGqtjTK+Jc8K0KqqiIUKmhuPKvO1XdmZ4rStfGSjtL7nYLmjCp+wK1rbnqEuEcb2AaMjAcQMQAd15G9cTmAZURWRO/Ib2LO2ZMq19RQQauZJDyQswdI1goNSwEwQ4vkem5OIPxJx1ZPipI1+iO+/QW3KIWQYhS3qo23uKCAF9BZes5uH5PuvasoQMQbZko+kaYUN6zRHLoKEqgjVwHnUd/CDguGkptvYW2dpdJBYyBhqcm2zrKVJyPXJlnwWNCXb0lnji1W4KZY9V2/uwTJ1GM0I8JEV0bVuGnrxD2fVpqIrKEg8arG3LsnRmiTlTZO59tiwrdK5rzaLpcMLUKjZ25vD9AKMs+LvTZ7F6R4bHX+0iYpk0JMPEIgaJkInjCXb0FsmUZA2i1qxNtD2PNlDOOV922diRpaVbXkuJsIkGbOoqUHQ86SzoGlUxS3Yk6y7SW/IplD02d+XI2x5T01HS0RDTaqKVsYfBuHsqavL0az10DaSdtnQXKdo+p82p5fltffSVHGxPXnMNqTA18RBlNyAQrqzK2p7dY8D2SMy7Hy1K9I80hID/+R+49lro6ZHrPvxh+I//gOrqStw+FTV4pTWL7fjoBnRmbB7Z2EU8bOw2sPV6aqWuyR9Ub94lZOoYus769hyvtPbT0l0gYmn0FOQgZnVUFvpqqorIeje9ZabWRJlVG8f2ArZ05dENHcf1iVoDU/5LHlUxC02DvC17nrq+T3fewdINZtbE0HWNlVt6Ob65ii3debb3Sm+t7AYIIciVPUCj4MiGJGFNI2QKPF/QW5BNVzJlnbCpEwh5nEBA1DJxAnCKNoEQOK6g4Pjkyz6GAemogetpvLgjQ10yTE/elgO2AgJAA3xA+JAreiSjOr6A1v4yTekIi5uSbOkp0Npv05Uv01d0sV0fTdfRCCi5AkODqqooiYiF7/ssnVFDUzrCyi19ZMoOsZDJ7LoErifY3FlgXVsJXYemdJjNPXlaOmUq6MbOPNmCw9q2HCFDo+T5lL2AhpTGjJoom7ryssVgIkQgoCdvYybD6JrGjr4SP326hXn1SSwD1rblcANB2NRp7S2TLXrEQwZOIOgoapW6RNOrY9ieLxvOxMKkBgaxX2nNMLtOFoaLWDrPtPSiawJd10mEdNZs6yM38B1URSzyjktvzqav5GHoGjXxECXbxRMa+bJLfTLCpq48GtL+rryN5wvOW9xQmZeQKbpEw/LprK/o4hOQiJoUyj4vt2ZAE/iBYFp1jLb+EmFTZ0oiTMgyeG5LD0Xbp6W7QF0izOz6+LC9jI9GsR9Eif6RxLp18NGPwiOPyOXjjoP/+i9405sqmwzGJV/tzLN6Wx/deYewqYPQ8EXA4mY5NX4wM2F6OsaqHX34no9hGpRsn+m1MfpKDn0Fh5d39LO+I4cOOL5OyfbxBDiOQygkhe+4qVVMr4njeAEvbs/QlS+TL3ucMK0K05BVLYXQKLo+lDWSYZPaeJjN3XkKZY8AmFkTpj1nD3SOsnlyUw+2GxAIQdn18AIhY7zxEEU3IGxA2YewoRGJhig7PtGQhWUIugduTLXJEELY5O2AouvhBgG+H8gqmREfLxD4yCKjPXmfiAU526PoytmsRccfyFZ/PbskANqzZRlrLrm4XkBrpoQQULR9TAL6CgEFx8P3QeDLBiiAE0BXvkx1wuT4qTVccFwjL7dmmNcQJxFJ019weeq1HmbUxHjbCQ38aW0n+bLL1p4inVlZVjoZsdjaXWBdW5byQPni2liY9lyJVzuzNKUi1MVDnLtoCo3pGB39Jf5vXQemoRENmdRELVZty7C+PU8qZNDSWyQWNlgyvZqGVJjtfSUsM0I6btHqw4OvdFAVtWiuitKZc8iUXWrjDidMq6Iz51T6E0ytiRIP6WhAImxh+wH9ZY9c2cX3qeTrIyARDVH0AkqOR2umhKFp0osXGu2ZMhFLOhMnTksTACXbJzlQWjlXkuMmfSWHuGXQX3KpippYA3Eb3xcUbfkUOTijuadgoxsaZdcjEAGJiEVfSU6S07UEhk4lnXSwVlBVzDpqvX0l+kcCpRL8+7/DV74CrgvRKHzpSzIt0xqazjcYk3+mpYfOnANAMmyxqTNP2NJZOlMOyKWiJs9v7eUXT2+lv+yhaVATC2EaOrYvs0le3p5hW28RPwiwLIOy4+EOqJ8PFJwALW/z8s4s1VGLpzb34YuAvO3RV3J5bmsvGrJxRn0qTF0iRLbksrVgY7sBRdur3BS29BSwvYCCHVRCKQLpYQ8KrqkJ+kouqUgInQDXkWUVHN9HoCEcl3jYIG5qZMoexbKGaRhoWkAgIBAC09SxPUFnTpYRHsQHSq48br7kkS+Dv2se4QA64Hqwtq2fxkSE4sA+CkWXvqIU5qLr4gcDTwbI/QwOBbqeAKHxloX1mIbMUglbBjoQj8gYfCKSwtA12Tc3axMydHRNEA8bFB2XDW2yTaJAo6dgI4QUOx2YXZsAHV7tKtCQjhINmxzTmKS34FCftHi1o4CPTI3NlaXX3JUvkym6VEUtLFMfqK2jU/TBdgO0CHTlHcKGLHSXtwNWbOiiNh5iejpCe84hb/t058uUHJ+OLIRMo1LF09UEmYJLtiQbrgghxzVcXSduyu+/p+DwzJZeauMhYiHZZtI0dLIDT4cRS8f2ZO5+XSKMacgbRDwkC+gNptEunpoaKE0tB2Ob05GBdE/Bho4ctfEwc6cY1CfCdOVsmdWzPYOmyVLX2ZK3lyfioydXX4n+4c7y5dK7f+01ufy2t8F3vwuzZg27ue35gEZzKsLxU6soOC6uJ3CDANsNeOq1PtKxPL0Fm40decquTypiUXR8dB1SIZPHXu3GdgXZkoNl6iSFSdH1KXuvq6COFGRDE+zoK/L4ZkFHv4NuSKEoOx7tGRdL1xCahmnohE2Nkhvg+QEF28ULwPYFgYCS5w35HP4u/9eRnqIjICxkFk0gwADZts8FTZMpoyXHRwRy276iSyoqJwbpaBi6hmlAtuwT+OCKoTcVDTAMsH3QdxFqfxc7DI2BJiCy6YhA1rfJOR5F26Ps+Lj+UPsZsF8HkhGDiGny1OYeOnM2L+3opz1bJmqZpKIm8ZDJtp48HXmb9n4b2/HBAtPU8X1BpuxScgJZn9/Q6MjJfPR0zJLesiYIGTo7+ks8/moXi5pSLJ2d5rfPt/Jsd4H+oiNLGngBdfEQru/jCyi5PjoQDZns7CmwFUFnGQxcugs6huZiez7RkEk8pBOxDMKGztr2/EB40McPBGHLBCF78EbDJhoa8ZAJQUBvUWC7Pn6gDXQ4E4QxcQKBEAJNk3MiHF8gNEGm6FAVC7GoKUnZlU1XunI202qizDUT5MouO3sLRMMmnidIxSxOnSNnUQ8OxiYjFrrtEwSC2niYjqwNUJkDkiu56DqcMDVNIhwCXJ7Z3MOsusSQJ+KjKVdfif7hSns7LFsGP/+5XG5uhu98B975TmQu454Mzibsydts7ytScDxKTkDJ8ekvO0yvjlEdD7G+LSNrrpuGrMBYcKhJhMgUXHxf0J6xsQwN15cectkXOK78vw6ETQ3HF5gaCE2j4Phs6y7iIygXAvzAJ2vLmZO+L3/MHZkS0ZCOZeikIhbdObcijMN/mqEMinPJA50AXddknD2QghoMPoHsorZOACFDwxcmCIHjD6YWSsEXu+0bwBt4v64hB1f9gZvLLttYOsTCFq7r4fge7Vl5Myi7ASFLIxAC//WHiApS9EMIAhzX55XWDG2ZEqZhkLc9HC+gvjnM6u1ZuvJlCo6LQJApuYQNnUAICrYgEAIhAizTIhWRM5Rr4ha9RYctPQWiIYOFDUk8X7Bqaz/ZkjvwXciURU0T+EFAZ85GoKEjxTZsyvEBdNA8KHuQ1gymxENs6M4TBAGmYdBTdLCdgJ19RQqOTzJiEgQahiaIhXR0DPwAQoaBGwgc26W76KGjkSv7xMOyyqfny9RPNxCIAGxdw/NcDEOjUPKY25CkKmzx7OYeOjJleksuhbJPxDI4cXoVfQWXTNkHXRv4LIL1bTmOaUxVkhVA44lNXaST4YEQUZaegs2c+gRvPb6RiGny3JYeSk6A7fl0ZGwE0JA6enP1legfbgQB3HEHXH89ZDJSea65Bm66CTsWp1z29jlJZ0tPnu6cQ3feYWtPkYhlSAH3pAdedGR8HGTdGt/3ydnyUT8WMsjbPp4IqI9G2d5fJFt0MTQwDI2QJrB0WRSst+ShD3iVliHj37om46bugHAOimkgIPBBOAG6LguP7eoJDxNFGYLYdZsAMGSYxB9c3tupFNBdsEnHQyA0bN/H0DV8H8KGwPFfz8rxGeqd+wK0gX3rGkNnjWoaRcel7A48Hfg+RV9gAMlIBIGDZwdyH8gfmdAgasn4csn1sHSDhlQI1xeETXlzgoDtvUUipk5DSs50zpVc2jNlSoGHrstZt5YxUJ64LG8UiZBs5NKdk9kqWtGlv+Aysy5GyQkGnuZkg5TaRIiwoZO1XXoLDoYm8ARELQPbCyg7gu6cQ3XMIm3JkIfQIW7o5IW8WcUjBiXHp2D7REOGPAc6lFwBJRddA00I0lGDsicH33Uhv0kNgSYEpqYhdA3Xk09mvoCC42PoYBg6HTmH1Vv72NxVoKU7T96WN6U59Ql8EbBmez8hS6+U0MiXfTIhD7s9xzOv9TBvSqIyr2HX3Pvmqihz6uP8zaIplbTVwdr6/UWHmoRFxEqRLflYoywxfqSgRP9wYs0aWRztmWfk8tKlcqB26VLpxQ/kJg8XZyy7MmVwzbYMJU+2xrN0mD9FzuSMWiVcz+fV9hw7+krEIyamptGWKaHrBsmQQSRksKOvjKVrtDh5PF8KVyBkYc5UxMT2BLWJCM1p2dEqEILtfSU5mUZQyXYZjMkP/pkaxEM6nhDk3JGfkpAmjy9zdiBk6fhBsN8bxSBBwIBia1gaZB2BGHizQHrohgaakE8wtidFcNfXYyGNkGniBQFOIPA9+dRTefpwZGZOKKSTipi4XoDrOmj6gNcvI26UHECT5SZe7cjRlTfJlQMEshWjaeg0JAWLmpK82plHQ+D4MgfdcQMsU+a61yXCaFAJqZRcl9Z+GdvXkecrV/bZ1J5DoBEayJ4yNZ1kzGJmc5ypWoyNnTlMTaM372BZGo4rEBqUPYGua5TFwPHiIXQDigUfAx3D1IhaJlpcJx01MQydTEcOTZO9bz0hx1ICAW4gC1/4gTwJAZCxPSKmTjhsACauG5B3XLyBL9nQ5M3x8Ve7KDoesbBJzvZwfOgrOJx3bBP9RQc/kHNFOrNlGlJh2jNlevM2edfHGAglAhzTmGJde3ZA1GVhuV3nKeyepjlYrfNozdVXon84kM/LgdnbbpPxhGQSbrlFllQwhla4HGw8sdLv5dxjGioXo65Ba7ZEd96mKR2hr+CgazqFsodlhKiPh9iRKdKaKWP7AU7RpeR6uF7AjOowpqHL9+hgmHLmZiCkWPsCHE8AAZoGlqlxxZtmULQD7n1+B7bj4wV7euyDTrgOhEx5Y0Ls37MfJGTAtOoQrX1OJezi+8FQz38fyEwSg5p4mFzZJVcO9hicDcSA6GsMZBnJ9YYs1Y8roOAIyp68Uwkh/wydIZk9Mj00YEdfkXjYoDkdIW/79BZdvIH3aEDc1IiEDTKOR8H1sXSZsy+PqeEPZBgVbJfegosQAQVblhe2AoHnBbRny8ysjuJ4cmJSrihDWQBhXY43DIbCNGQPYF2DshYQlGUGTHM6yqkzq3E86MyVyJdd+ooeZddDQ5Y3DgIoOgGbe0vkbVl/KG+7hAf6EM9JRRCBoC1bIh2x5I1iIH1U0wR9RRs3AMs0CDwNOxDoaJQHGqGnYzrN6Si5smxe45sBhiZDdp3ZMoWySypu0agZhC2d3rxDImzQliniuAHrOrLkih5FV5aP9oWgYPvMrInh+YL+kkOyaJCMWvvMvd81ZbnsBlTFRrb9kZrZo0R/grA9n+6cg/GH3zHls9ehb98GgH/ZZRjf/jZMnSovrpLseZopOji+4OXWAmXHZ0uPqMy0HZx2PiURJhkx6crapGMhoiGTqphJtuTI8r+erPUSiICQbqANeIa9BZeQpZMteyQjlsxx9wN8ERAPmXTl5aCr8AJMDVr7ijy4pp1jmqukWA4j+BryhhEICJtge+CNVO0H8Hxo63cqQi0AezDkMrCNqTPsDWfwtUhINv0uuzJXfjg0jUpa4SCBeH3ZFVRCVpX37D5SiwwPZe2AkhsQMVwK7tB9CqDgCkxTENY1+ZRh6vhCYAIF16PY71P2fHJlD02ISmlhJwDb9eT4gi/Y0VfC9gS7fyR7mHCXJiDQ5PcxqyZOXSJMTSLEhcc2sa4ty7ObfRxfVtIMmQbVsRB9BQcNmFYVZlt/mZIjU2ttL6C36JCMmkytkv0JwqZBJGQOPBnKm9TgF2IYkEYbOIeyLr5A3gRztk93rkxTOk4sZNCWKckYvydLM3gB9OZdskUXTdMQAYDNYxu7yZXdSsy9M1eg6PqEdBki2tRVwDJ1EmHZ97Y37yAIqIqGKA+ck0Gx3tFb5PltvfTkbHoKbqXBza5pm7tuP9oqnIfjDUKJ/gSwo7fIn/74LCd+/YucsvpRALINzTyz7Mtkzz2fU2NpwgMXV6boki27bOrMsa2niGnoNKbCxMIWT73WzZrtskqhFwg2debJlDxKrofjC2bVxphdl+Dl1mwlP13ToOwECAscP8DSZG56JJApgo4vJ+AkIqbsMqVphE0oulLcfUAUPZ54rZtXO7P4aMMq7mBUxUCGWEYr+IP7KHlgaa9n8Oz6GkivMGzIp5HBDMzBQ4V06M/bdAPOMCI9uJ9dNGqP/e+NfX0cL4DcXnYggEzJpzoiRaDgehRtgabLwdaqiEUgTGw3oK9oo2taxYsPdrErv5cb2O7nCWRoDDlBGcPQOLY5RSxkkCk5bOnOkyk5MqWyKDOBeos2nh9gDNxM87ZHsRxgmPKJ0nYDevIuT27qxjINqiIWyQh05sr05f0hYyOeBx2ei4nsYwADGVABlB2f3sDnmMYUtqnT0pXFccE05JOh6wcIAc7A2FEqahEdCO/ZAyHMcMhgSipMS08e25c1kASClu4iUwfqQ/3xxXYKjk88ZHBsU5KmmhhvnFULGvzvs9vozZcp2j6WoWMaGmFL59GNXcR2S9usilmjqsJ5uJZpVqJ/CLE9n82t/bz6+X/nH3/xA2JOCU83+Nmb/567/ubdJCJVhJ/ZylOvdXPi9DReAN15mdZXKPuy5jyCkhOwdFaYP6/rIBkySCdCdGVsdmZKhHWNkKHLIrRCUHYDGYoQgo6cLFQGMuYbCHAGbHNtQcSQE4xyJR/TAEOXcd5dM1cCoDyQLrOj1wZ9z/TEwe1ACo63PwXdD3vRt9ft2Yug2/7Ibja7zwc4WEYyMF1wAgpuUBlMHjyJfQWXkuMRNnVK3kj2NpR9nWoP2NSeJV+ScwNa+6Vn7Q+kze6aTTV4Tta15yg6AYEmu5QNPtVlig6ZkkcqYsqS2LbsCraXr4IAMMXr4zODYyllFx57rRsNjfzAxeh7MoznDITE5EC3Tm/BoWD7mLrADbSBgWSdtv4yJScgEdZxfY2wppOKmmRKskaPYWhY6LT2F9nSk6c2HuZPL7WTiprs7C8hEORtn6qoRXVcFqtbs6Of2bUJptW8nrZ50vT0fqtw7j67fbgbxEQPCU+46H//+9/na1/7Gm1tbRx77LHcdtttnHnmmXvd/pFHHmHZsmW88sorNDc3c91113HVVVcdQosPjM5smRd+8ycWfuk6/m77RgBenLGYmy++hjXpGegOZHvzCE1nS3eWV3ZmOaYphWXo2K5PV6GEpes0pKLYrs+Dq3dS9H3CpknZdukt+pVMlLAJyahFZ86mI1dmY0deZps4QoYyguEnHpX91/PvbZ/hN9oFF/bvEk8go3m6GCvBHynDhWFgYNKbK+Ts5XGg6ARs6S5I8d3L+IrY5d9MOcAaGJX3BwZTTEPOj9CRIpcpOJQGQmh7QwdMU8N25biJMZCyGQBFZ+gozeCcjEEbyh4EeGgCKfRhg6qISdEJaM+UcXyImDqeL+dreJ5PT87GHsibjVoGtvApux62rzO73mJLdwH6NVIx2V8AIejJ23TkQnTmbDSgoSo8RNxB22cVzl09e02DTNFlxkDhvF1vELEJVt0JPfwvf/lLPvnJT/L973+fN7/5zfzXf/0XF154IWvXrmXGjBl7bN/S0sJFF13Ehz70IX7605/yxBNPcPXVV1NfX89ll102AZ9g38hWc5Dv6GHbVcs4/8FfoAtBJhznK295H/effD7lQCcY+H2XygJdBkzoL+XZ3J0nbMrCWG4gPaOObFkOrLpChlAYOqkpQD5SF3IuluayrbdEMIrB08NYwycV43UTckc6Cr4LugYhSzah0QbGaTRA0+VcATcYfiB/VwIgYplEzYCS64OmoetioFTF8Gi8PkfC9WSjmJAhxz8sw2B+Q1QWmLM9IqZBV6FMZ8YGQ7bDNA1ZU992fcpOgBMENFaF0IQmS0W4HrrQqIlZ9BQcUtEQUdMkHbOoilpkSx6WoVfEfTCTZ7jMnt0bsHRkynRkbcKWdNSG3CDExP7KNCHEoXZyKrzxjW/k5JNP5gc/+EFl3THHHMOll17Krbfeusf2n/70p/nd737HusEywsBVV13FmjVreOqpp0Z0zGw2S1VVFZlMhlQqdfAfYi90Zsu8sKWbzPe+w8X33E28pwuA+489h5vO+QA98fQ+328hPendZ4wO/t/S9h322JWxDF0cXvhIWVCMDz46BlFLIxaysH0fU9exDCEHkX1BU1UYXdPRhKClp1gZf9idREjjuGlVzKtLsK2vRGumSFu/HDvwhpnBDHJMxtTluI6pQXM6gi+QAhwxaU7HiIcHUo9zZRzXZ0tvkcWNKWxPzvzuyJbJlF08X6bF1iTCsrRztoyh6yQiJpmiQzoe4vipVUyvifE3ixooOf5e4/HDDc5mSi4Pr++QM6UHbgJbewqkYyGEEEP24bouDz74IBdddBGWtf+uaCNhNLo2YZ6+4zg8//zzXH/99UPWn3/++Tz55JPDvuepp57i/PPPH7Luggsu4M4778R13WFPoG3b2LZdWc5mswC4rovrjiJhfBTYXsC6J17ghC/fQPPTcqB2S00zX77oGp6bcyK2K1NDBnqEAHt62IYFDGS86AwMiLJLSQBdZpDsT8x1wDJk9slg/rzy5l/HHLgjarqMVx8u7O9GPfi9WgaUnaEzhveFNXABDF75u14PUVP2q/UHUlL1AMyQRipsEgsbNCRjAxPTZLaPH2g0V4VJRSwMHbqLsmSxM3Bt60BN1CActji2OUlzOkptPETI0KmOmtREbbpyNmXfpyvnIAI5gBu1TGzfJwjANDRiuiAesqhLyLo8tiezyk6cmiQSMgd6Heu095eYVx9nUWOCnoLNq50FGtMRFoTizJ2S4JjGFE++1kPB8alpTDK9OopAzkBvrIowoybG8VOriBgQiRqcPrsa2/UJWwZhU6/ohQ4yRCMC3IGLxiAgYmp0ZkvUxi2ZCZQMceqsGoQQQ/YxuJ+x1J/R7GvCRL+7uxvf92loaBiyvqGhgfbB3q670d7ePuz2nufR3d1NU1PTHu+59dZbufHGG/dY/9BDDxGLjaz59GjQXJeZ9/2WN/36V1iug2eaPPLWv+eGxZfRr4XA9vCQJ95koCAXewqx5skXB3+UHtL7Z+A9wQgEHwZuKru4USbyB7+vR+qJeioII0MJ7sBg38jwMRnN9hITeV6tgRx9gbyx2gz9/IM3ZX3gz9vl/R4Hd652f4pjwIaIIW0qeK9Pbhscawlp0gPWdIibcvymHyg48nvd131LB8ICfF1mVBnIfUQMsHSBbmhS6HWBK+REqrDuEdI9agzBFJGjvaARA2ID9jQ4gpAPBV+j3gDdHJjXMRCOrLJ85scdCr0FWnqBpKA5Bm4R/EBOABMezIjJDCtDh6kxn4wLvWWI6DAlLliUcnFFEV9omKZgWhgSXe0UPGjPQ9HTSGqC2RHo39ZG1tYIO4KYoVHtC6r6oFCAhR4UAoj7YPZKO6uAoBsKvbBy84F/nxkHtuXB9jXChmBGAh7bx/6WL19+4AfbjWKxOOJtJ3wgV9utjowsvLT3aizDbT/c+kFuuOEGli1bVlnOZrNMnz6d888/f8zDO9oTT2B87GNoa9cC0HHyadz/9+8h9ZYLuKSryCOvdtGVczA0jWOnpphZG+WpzX3S23HkBJqqqEUkZGBoGmIgV9x2PTJlj4ihU5uUFQNztk/RkSmYiIBM+XX50ZATm6amIwRCPo4mIhazamIUHZ/2TInOgosmZCE2S9exTFnpsSpqoulywM/zA6KWSWMyRMQy2N5XljVh7GCPgmjJiI7jB5R2czgsDWricuJO2NQrE6D6yy6OK7tRCQGxiJyoUx0NsbAxThDAs1v6aO8vYQ9MyDI1OUU/bOjoukaxWCYSCRMJW0Qtjc6MTcGVHqLOwNMQA6KpQ9gw8IRszRgLm8yujXHCtDT9JZdXWrOytIDjkYgYxC2LeMggZGlky7KgmKnpMg/d8YlZOo1VEWw3YHN3gZLjY5k6QkDedrEHRkkNDdnUZeAzRCzZjjEZNrE9H9sNCFkGrucTNnXm1CdY0JBEAC/u6GdDhyxoFrNMpiTDnDwjTWNVhGMakjSkI2hAS0+BB15sY82ODN05G12Xxe0MXaPkyIJqqbBJYzpK3nbR0IlaGtUxi+pYmOOnpThlZg0a0iNNRiy2dGW55y9Ps3DRYhLRMEtmyBaFj2/qZkO7bIqzqCnJGfPqAHhpZ4YZ7Xleac1gGrJU8uLmFKauDczV0Jk/JcG0alnBszNn89LODNt6irTnyjQmw8TDJq4vKuXBm6uiJMMmdUk5/8T2giGe9yC7rx9c1jRtiJd9KNibjbviui7Lly/nvPPOG9PwzkiZMNGvq6vDMIw9vPrOzs49vPlBGhsbh93eNE1qa2uHfU84HCYcDu+x3rKsMTvh9PTApz8Nd94pl+vqyN7yFVaddj47nn2BNycifOTYqXzwrHls6MySClnMb0xScnwWNrTxwtZ+bD9gfkOcv1nUIPu95mySEZOIZdCVK9OZswcamchSsnUJC9eDHX1FCm7Alq4sL+7IkC25WJbOOQum8E+nzUIDegsy26ApHSVf9ujIlRE+FDyPuGkOlG3QEMjOSoNtBqfVRGmuipEYsGN7b4kXtvbQ0l2kI1OiKmqSjJrMqk0gNI3tPUVWbu2l5PiETJ3FTSnOX9xIbSpM3DJlRUwvGEiR81jZ0kt33iEdtwgbOgKNhqowp8+poypm0Z2z6ck7uL78AVsDMVhNg3zR5vHHHufYpSewM2sP9AsQVMcsUuEQGdulKytL53bmbGoTIRqrohzbnEIImQI4qz5OaGCgvGh7AzXaTXwREDblwJ2c+DY0mdHxAgKodHLa0VfC8wISEflzypU9sgPduOricpKc68ka+/GwSXM6StmVM1djlkHJ9dDQCJkGIVMjNVA7PltyyZd9cmWHkKlTP9DAffeJPjPrUyydVUfXQJ/csudTG4/IlMS+Io4vmJqODgxsyk5g6YGevCDLbO+eZ56MmLTUwVtOnEoiFq68funJUbIld4/31aWinD5POgpFV/YmTkasvU5OmlpjUZeKVtIbA0ElC2Zvk5ksCxLRPX9+u6/f23aHgtEceyw1aDT7mTDRD4VCLF26lOXLl/OOd7yjsn758uW8/e1vH/Y9p59+Or///e+HrHvooYc45ZRTxk7AR4MQ8JOfwL/+q2xfCPDBD8JXvkKqpoYzSjZ9rwrOmFdHIioFoin9+hWRjFj8w6kzeOvxzezevnDX7Qb/P9wPaNd1+bLHjr6SHOSqjla2mV3/usnhhEFtYs+b4CCLmlJ7/dEtbraYO9Cjdtcf6uDAVdkN+IAfyKqQpk5dMrzHPnbl+GnpyrFgzx/71OoYU6uHD8G5bpjXEnDa3DoCTR/W5l1zpne1dXfCpryR7nrOB0mOYC7NMU3jc+3VJw3qkwDx/W6bjFhD6skMsvt3XZ/c+3e/O6YOqaiFtVsP5frk8Odw8NzW7mX9vt6z+3rF+DGh4Z1ly5bxnve8h1NOOYXTTz+dO+64g23btlXy7m+44QZ27tzJj3/8Y0Bm6nz3u99l2bJlfOhDH+Kpp57izjvv5OeD5YcPJRs2yDr3Dz8sl489Fm6/Hc44o7JJ2NSJmezz0XJvP6K9bbv7D2LXdfsT9AM9xkheH/KjH6ENu+/rQH/sI7FJoVBIJlT03/Wud9HT08OXv/xl2traOO6443jwwQeZOXMmAG1tbWzbtq2y/ezZs3nwwQf51Kc+xfe+9z2am5v5zne+c2hz9MtluPVW2ZPWcWQXqy98Qda+D4UOnR0KhUJxAEz4QO7VV1/N1VdfPexrd9999x7rzj77bF544YVxtmov/PnP0rvftEkuX3ghfO97MHv2xNijUCgUo2Siy0AcOVxzDZx3nhT8pib41a/ggQeU4CsUiiMKJfoj5bjjZPL0NdfAunVw+eV7bVuoUCgUhysTHt45Yvjwh+FNb4ITTphoSxQKheKAUZ7+SNF1JfgKheKIR4m+QqFQTCKU6CsUCsUkQom+QqFQTCKU6CsUCsUkQom+QqFQTCImXcrmYCnm0ZQiPVBc16VYLJLNZiemINxRjDq344s6v+PHeJzbQT0bSSPESSf6uVwOgOnTp0+wJQqFQjG25HI5qqqq9rnNhPbInQiCIKC1tZVkMrnPZi1jwWDDlu3bt49rP97JiDq344s6v+PHeJxbIQS5XI7m5mZ0fd9R+0nn6eu6zrRp0w7pMVOplPrhjBPq3I4v6vyOH2N9bvfn4Q+iBnIVCoViEqFEX6FQKCYRSvTHkXA4zBe/+MVhe/QqDg51bscXdX7Hj4k+t5NuIFehUCgmM8rTVygUikmEEn2FQqGYRCjRVygUikmEEn2FQqGYRCjRP0i+//3vM3v2bCKRCEuXLuWxxx7b5/aPPPIIS5cuJRKJMGfOHG6//fZDZOmRx2jO7YoVK9A0bY+/9evXH0KLjwweffRRLrnkEpqbm9E0jfvvv3+/71HX7cgY7bmdiOtWif5B8Mtf/pJPfvKTfPazn2XVqlWceeaZXHjhhWzbtm3Y7VtaWrjooos488wzWbVqFZ/5zGf4+Mc/zj333HOILT/8Ge25HWTDhg20tbVV/ubPn3+ILD5yKBQKnHjiiXz3u98d0fbquh05oz23gxzS61YoDphTTz1VXHXVVUPWLVq0SFx//fXDbn/dddeJRYsWDVn3kY98RJx22mnjZuORymjP7cMPPywA0dfXdwisO3oAxH333bfPbdR1e2CM5NxOxHWrPP0DxHEcnn/+ec4///wh688//3yefPLJYd/z1FNP7bH9BRdcwMqVK3Fdd9xsPdI4kHM7yJIlS2hqauLcc8/l4YcfHk8zJw3quh1/DuV1q0T/AOnu7sb3fRoaGoasb2hooL29fdj3tLe3D7u953l0d3ePm61HGgdybpuamrjjjju45557uPfee1m4cCHnnnsujz766KEw+ahGXbfjx0Rct5OuyuZYs3t5ZiHEPks2D7f9cOsVozu3CxcuZOHChZXl008/ne3bt/P1r3+ds846a1ztnAyo63Z8mIjrVnn6B0hdXR2GYezheXZ2du7hFQ3S2Ng47PamaVJbWztuth5pHMi5HY7TTjuNV199dazNm3So6/bQMt7XrRL9AyQUCrF06VKWL18+ZP3y5ct505veNOx7Tj/99D22f+ihhzjllFNUS7pdOJBzOxyrVq2iqalprM2bdKjr9tAy7tftIRsyPgr5xS9+ISzLEnfeeadYu3at+OQnPyni8bjYsmWLEEKI66+/XrznPe+pbL9582YRi8XEpz71KbF27Vpx5513CsuyxG9+85uJ+giHLaM9t9/61rfEfffdJzZu3Chefvllcf311wtA3HPPPRP1EQ5bcrmcWLVqlVi1apUAxDe/+U2xatUqsXXrViGEum4PhtGe24m4bpXoHyTf+973xMyZM0UoFBInn3yyeOSRRyqvXXnlleLss88esv2KFSvEkiVLRCgUErNmzRI/+MEPDrHFRw6jObdf+cpXxNy5c0UkEhHV1dXijDPOEA888MAEWH34M5gmuPvflVdeKYRQ1+3BMNpzOxHXrSqtrFAoFJMIFdNXKBSKSYQSfYVCoZhEKNFXKBSKSYQSfYVCoZhEKNFXKBSKSYQSfYVCoZhEKNFXKBSKSYQSfYVCoZhEKNFXKMaY9773vVx66aUTbYbiMONA2lTuype+9KVhWyvG4/FR7UeJvuKoobOzk4985CPMmDGDcDhMY2MjF1xwAU899VRlmwP5se2NLVu2oGkaq1evHrL+29/+NnffffeYHGNf7O/msmrVKi6++GKmTJlCJBJh1qxZvOtd71I18CeIA22lOMi11147pKViW1sbixcv5vLLLx/VflQ9fcVRw2WXXYbruvzP//wPc+bMoaOjg7/85S/09vaO+bEcx9nra1VVVWN+vNHS2dnJ3/7t33LJJZfwpz/9iXQ6TUtLC7/73e8oFosTbd6k5MILL+TCCy/c6+uO4/C5z32On/3sZ/T393Pcccfxla98hbe85S0AJBIJEolEZfs1a9awdu3a0TepH9fKPgrFIaKvr08AYsWKFXvdZubMmUOKYM2cOVMIIcSmTZvE3/3d34kpU6aIeDwuTjnlFLF8+fI93nvTTTeJK6+8UqRSKXHFFVfsUVRrsJDWlVdeKd7+9rdX3nv22WeLf/mXfxH/9m//Jqqrq0VDQ4P44he/OGT/69atE29+85tFOBwWxxxzjFi+fPl+e6zufpxdue+++4RpmsJ13b2+XzFxDPfd/tM//ZN405veJB599FGxadMm8bWvfU2Ew2GxcePGYfdxzTXXiAULFoz62Cq8ozgqGPSC7r//fmzbHnab5557DoC77rqLtra2ynI+n+eiiy7iz3/+M6tWreKCCy7gkksuYdu2bUPe/7WvfY3jjjuO559/ns9//vM8++yzAPz5z3+mra2Ne++9d6/2/c///A/xeJxnnnmGr371q3z5y1+u1KgPgoBLL72UWCzGM888wx133MFnP/vZgzofjY2NeJ7HfffdV+lypTh8ee211/j5z3/Or3/9a84880zmzp3LtddeyxlnnMFdd921x/a2bfOzn/2MD3zgA6M/2AHcpBSKw5Lf/OY3orq6WkQiEfGmN71J3HDDDWLNmjVDtmE/3vMgixcvFv/5n/9ZWZ45c6a49NJLh2zT0tIiALFq1aoh64fz9M8444wh27zhDW8Qn/70p4UQQvzxj38UpmmKtra2yusH6+kLIcRnPvMZYZqmqKmpEW9961vFV7/6VdHe3r7X7RWHjt2/21/96lcCEPF4fMifaZriH/7hH/Z4///+7//ucc2MFOXpK44aLrvsMlpbW/nd737HBRdcwIoVKzj55JP3O6haKBS47rrrWLx4Mel0mkQiwfr16/fw9E855ZQDtu2EE04YstzU1ERnZycAGzZsYPr06TQ2NlZeP/XUUw/4WIPccssttLe3c/vtt7N48WJuv/12Fi1axEsvvXTQ+1aMLUEQYBgGzz//PKtXr678rVu3jm9/+9t7bP/DH/6Qiy++eMg1M1KU6CuOKiKRCOeddx5f+MIXePLJJ3nve9/LF7/4xX2+59/+7d+45557uOWWW3jsscdYvXo1xx9//B6DtaNNjduV3dsKappGEATAvhu+Hyy1tbVcfvnlfOMb32DdunU0Nzfz9a9/fVyOpThwlixZgu/7dHZ2Mm/evCF/uwt7S0sLDz/88IGFdlDZO4qjnMWLFw9J0bQsC9/3h2zz2GOP8d73vpd3vOMdgIzxb9myZb/7DoVCAHvsb7QsWrSIbdu20dHRUWn8PjjeMJaEQiHmzp1LoVAY830r9k8+n2fTpk2V5ZaWFlavXk1NTQ0LFizg3e9+N1dccQXf+MY3WLJkCd3d3fz1r3/l+OOP56KLLqq870c/+hFNTU37zATaF0r0FUcFPT09XH755bz//e/nhBNOIJlMsnLlSr761a/y9re/vbLdrFmz+Mtf/sKb3/xmwuEw1dXVzJs3j3vvvZdLLrkETdP4/Oc/X/HC98WUKVOIRqP83//9H9OmTSMSiRxQuuZ5553H3LlzufLKK/nqV79KLperDOTu7wkgk8nsMU+gpqaGF198kV/84hf8v//3/1iwYAFCCH7/+9/z4IMPDjswqBh/Vq5cyTnnnFNZXrZsGQBXXnkld999N3fddRc333wz//qv/8rOnTupra3l9NNPHyL4QRBw99138973vhfDMA7MkAMfilAoDh/K5bK4/vrrxcknnyyqqqpELBYTCxcuFJ/73OdEsVisbPe73/1OzJs3T5imWUnZbGlpEeecc46IRqNi+vTp4rvf/a44++yzxSc+8YnK+2bOnCm+9a1v7XHc//7v/xbTp08Xuq7vM2Vz130JIcTb3/72St9UIV5P2QyFQmLRokXi97//vQDE//3f/+31M1955ZV77cf62muviQ996ENiwYIFIhqNinQ6Ld7whjeIu+66a4RnVHG0onrkKhSHIU888QRnnHEGmzZtYu7cuRNtjuIoQom+QnEYcN9995FIJJg/fz6bNm3iE5/4BNXV1Tz++OMTbZriKEPF9BWKw4BcLsd1113H9u3bqaur42//9m/5xje+MdFmKY5ClKevUCgUkwiVp69QKBSTCCX6CoVCMYlQoq9QKBSTCCX6CoVCMYlQoq9QKBSTCCX6CoVCMYlQoq9QKBSTCCX6CoVCMYn4//4kocy3wqqkAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.plot(scaling_metrics[\"start_LS\"].to_numpy(),scaling_metrics[\"end_LS\"].to_numpy(),'.',alpha=0.25)\n",
     "xlim=plt.xlim()\n",
     "plt.plot(xlim,xlim,'r-')\n",
     "plt.xlabel(\"Starting LS\")\n",
     "plt.ylabel(\"Final LS\")\n",
+    "# plt.xscale('log')\n",
+    "# plt.yscale('log')\n",
     "plt.grid()\n",
     "plt.show()"
    ]
@@ -967,7 +1763,6 @@
    "cell_type": "markdown",
    "id": "13c24816-8832-4a38-953e-e0e02df2b4ea",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -979,7 +1774,8 @@
    "id": "6a4c5cf6-11a1-45f1-bc60-cb64aa6b7b06",
    "metadata": {},
    "source": [
-    "This step involves normalizing the scaled structure factor amplitudes obtained in the previous step. The input is restricted to only those Miller indices present in the _intersection_ of all datasets, and the VAE will predicts structure factor amplitudes for all Miller indices in the _union_ of all datasets.\n",
+    "This step involves normalizing the scaled structure factor amplitudes obtained in the previous step (in the machine learning sense of 'normalizing'). \n",
+    "Normalization is performed per Miller index over datasets. The input is restricted to only those Miller indices present in the _intersection_ of all datasets, and the VAE will predicts structure factor amplitudes for all Miller indices in the _union_ of all datasets.\n",
     "\n",
     "Additionally, we standardize all the input data, such that the structure factor amplitudes for each Miller index in the union of all datasets have a mean of zero and a unit variance across datasets. "
    ]
@@ -988,7 +1784,6 @@
    "cell_type": "markdown",
    "id": "2e23f578-3067-43a8-a3b8-c78fbcdb4399",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1043,10 +1838,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
    "id": "45dbb815-398f-4797-a191-ea9ed6a8bee5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Current file list contains 1647 entries.\n"
+     ]
+    }
+   ],
    "source": [
     "# Identify all scaled files to use as input and output for the VAE\n",
     "\n",
@@ -1067,10 +1870,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 74,
    "id": "883ad07d-e684-4aed-b568-9117ab062cdd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The file list contains 1617 entries after filtering.\n"
+     ]
+    }
+   ],
    "source": [
     "metrics_df = pd.read_pickle(scaled_path + run_prefix + \"scaling_metrics.pkl\")\n",
     "\n",
@@ -1095,10 +1906,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 75,
    "id": "3e2cb462-46ef-43b1-b7a1-fe2df24780e0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Subsampling 1617 entries.\n"
+     ]
+    }
+   ],
    "source": [
     "if fraction < 1.0:\n",
     "    file_list = sample(file_list, int(fraction * len(file_list)))\n",
@@ -1126,10 +1945,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 76,
    "id": "b64475a6-ae79-4136-81da-d955fe548e97",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1617/1617 [00:33<00:00, 47.75it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The intersection has shape (2783, 1617). Pickling begins now.\n",
+      "CPU times: user 43.8 s, sys: 1.93 s, total: 45.7 s\n",
+      "Wall time: 46.1 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Creates an `intersection.pkl` file at the specified path\n",
@@ -1141,10 +1977,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 77,
    "id": "d8ec5d5a-d74f-4730-ad5c-8a25b4823fe7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done reading in 1617 files (disregarding errors); now starting concatenation. Please be patient.\n",
+      "The union has shape (77821, 3234). Pickling complete.\n",
+      "CPU times: user 1min 3s, sys: 3.3 s, total: 1min 7s\n",
+      "Wall time: 1min 7s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Creates a `union.mtz` file at the specified path\n",
@@ -1162,10 +2009,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 78,
    "id": "d32f2c8d-3d30-414b-9c68-c194dbc9b174",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size of vae_output (training data): (1617, 77821)\n",
+      "Size of mean across datasets: (77821,)\n",
+      "Size of stdev across datasets: (77821,)\n",
+      "Size of vae_input (training data): (1617, 2783)\n",
+      "Size of vae_sigF (like training data): (1617, 77821)\n",
+      "Created starting files for VAE in /n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/ with prefix = \n",
+      "CPU times: user 1min 11s, sys: 6.98 s, total: 1min 17s\n",
+      "Wall time: 1min 18s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Generates VAE input and output data from the intersection and union datasets\n",
@@ -1183,7 +2045,6 @@
    "cell_type": "markdown",
    "id": "f20af9fe-70d3-4683-b199-c4ee0d8b946f",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1202,7 +2063,6 @@
    "cell_type": "markdown",
    "id": "943c3057-4c5c-43fd-94bc-fc718affe32e",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1267,7 +2127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 79,
    "id": "2a5f672b-47ce-464c-997b-3ed9ececd1c2",
    "metadata": {},
    "outputs": [],
@@ -1281,10 +2141,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 80,
    "id": "9c70c992-6ff2-4890-8330-09384cba57f7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(1617, 2783)\n",
+      "(1617, 77821)\n",
+      "(1617, 77821)\n"
+     ]
+    }
+   ],
    "source": [
     "# Sanity checks\n",
     "print(vae_input.shape)\n",
@@ -1294,7 +2164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 81,
    "id": "313d667f-30a3-468d-91ac-c3067d898223",
    "metadata": {},
    "outputs": [],
@@ -1312,10 +2182,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 82,
    "id": "29715979-2e73-4a58-87d5-d60cf33b2d60",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD/CAYAAADoiI2GAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAADSTElEQVR4nOz9e4xle1rXj78+t3XZe1dVd58zZ4aBYUZBMICIZkgEyQDJdxAwBATxghicwWhUCBcjhkhE/jBjvI3+5fCXaNSJCTBAvBtuwxgnRiZEoziA8GOcM8y5dXdV7b3X+tx/fzxr7arqU92nu0/36e5z9js5OV1Vu/ZeVbX2s571ft7v96NqrZU99thjjz2eOOhHfQB77LHHHnvcH/YFfI899tjjCcW+gO+xxx57PKHYF/A99thjjycU+wK+xx577PGEYl/A99hjjz2eUOwL+B577LHHEwr7qA/g1aCUwqc+9SkODg5QSj3qw9ljjz32eNWotXJ6espb3/pWtL5zj/1EF/BPfepTvO1tb3vUh7HHHnvs8cDx//7f/+OzPuuz7viYJ7qAHxwcAPKDHh4ePuKj2WOPPfZ49Tg5OeFtb3vbrr7dCU90AZ9pk8PDw30B32OPPV5XuBtaeD/E3GOPPfZ4QrEv4HvsscceTyj2BXyPPfbY4wnFvoDvsccegMjX9niy8EQPMffYY49Xj1oruVRqBaUqRqu9r+IJwb4D32OPNzjm4q21olb5eI8nA/sCvsceb2DUela84ayI7+mUJwP7Ar7HHk8gHlSBVUqhFJSp6y6lotTdaZD3ePTYc+B77PEE4WHw1UYrcqm74m30vng/KdgX8D32eIJwnq8uRYq5Na+u4CqlsEZRa9133k8Y9hTKHns8IXjYfPW+eD952BfwPfZ4QrDnq/e4FfsCvsceTxCE82bPV+8B7DnwPfZ4orDnq/c4j30HvsceTyD2xXsP2BfwPfbYY48nFvsCvscee+zxhGJfwPfYY489nlDsC/gee+yxxxOKfQHfY4899nhCsS/ge+yxxx5PKPYFfI899tjjCcW+gO+xxx57PKHYF/A9XpfYLyTY442AvZV+j9cV9vsd93gjYd+B7/G6wqPe77jv/Pd4LbHvwPd43eCyvOxS6msS/LTv/Pd4FNh34Hu8bvAo87Ifdee/xxsT+wK+x+sKjyIve7/ZfY9HhT2FssfrCo8iL1s6f1kKPNM2r/WmnMt+3n1m+Osf+wK+x+sSr3XhelSb3S/j3oE9H/8Gwb6A77HHA8Cj2pRz2ZZ64IFvrt/j8cSeA99jjweI15o2Oc+9z9z/TOXAno9/vWPfge/xhsHrjROeufecCxXIuaK10DePko/f47XDvoDv8brHq9FoP+5F32hFyoVSwBjFfKT7zfVvDOwL+B6ve1zGE9/KCc8Uw1ysX6noP06F3WiNNWfHXsrZMPNxOcY9Hg72BXyP1zVeyZ1ZayXlQspSwK1RWKNvW/QfN8flTKPI8by25qU9Hj32Q8w9Xtd4JXdmLpWU6/Q4RcpS0G9nzHkcHZcPw7y0H3o+Gdh34Hu87nE7jXat8+fUrliXwq67LoULg0D5npd386UUtH50vdCDlDA+bncYe9wZd33WlVIe5nHsscdDgxQ4vaNH5oI0F+65kM/Uitbz4y52tbd28zkXcinkwtS1P9qu9UEU2sfxDmOP2+OuC7hzjueff3738V/7a3+N69evP5SD2mOPh4HLCpzRZ91rrcJzz8X6sqJ/nq4otaJ3F4Env9jtM12ePNx1Ab/1j/ijP/qj3Lx580Efzx57vKZQSuGsoXWarjE4ay4U+luL/lzYjRb1hzHyFnoSi92tx/oo0xz3uD/cN3H3JJ2oe+xxO8wqlFxm+qBe+NrtoLV+YovdeeXNrdTPo0hz3OP+sR9i7vG6w70M8y6TCxp9d2FQjyrA6tXiTrr4R5Xpssf94Z4K+N/8m3+TxWIBQAiBv/23/zZHR0cXHvMP/+E/fHBHt8ce94B7UVDMXedlqpKUCyCd6MxtzwXufGF7WMXuYRbPu91atC/eTwbuuoC/613v4uMf//ju4y//8i/nN3/zNy88Zv9H3+O1wmVF7m4dl2dFHkDkgnOxBvlapVKnz6sKRRVK5dKLw4M6718LCd/jkF2+x4PDXRfwX/iFX3iIh7HHHneH2xW5u+0s5+76/NdLnTXf0FhNSJItYq0mpYLWUKraFf1bu/IHhbu5AD0IPKnUzx4vx54D3+OJwp35W27bWc6Du5gqxgClorUmxElK6M6kgFoplJkyRYxU7JylHT/flVf94KiO13Ih857nfv3gngv493//91/6eaUUXdfxuZ/7uXzjN34j165de9UHt8ce53FZkcu5EGsGFDArQnhZZ3lmjwcfMlortBJzmjEGmC8A0tkrFEpPlMmc+Jfrha78TsXvXovjo6A29sX7yYeq96gH/Oqv/mo+9rGPkXPm8z//86m18uu//usYY/i9v/f38vGPfxylFB/5yEf4gi/4god13ACcnJxwdHTE8fExh4eHD/W19ni0mAviXIjPqIyC0Rop3uqCa3L+vpgyYyiTVlsoFFAYLc9jjblQNGeKYX4drSDlSoXd5xTgrH5ZEbyVYz9P8bxSwbzd9+7xxsK91LV71oF/4zd+I//f//f/8alPfYpf/uVf5mMf+xjPPvss7373u/nTf/pP8+yzz/Kud72L7/u+77vvH2CPPWbcqllWVHIphFhIOVNLIUwFOqQsVMc55FLJ5zJNUpnNO4q2sbvif6tl/rwLU2s9dexCPczuy/MXifOvd96KLsd+ueb6VtzO/bnHHrfDPXfgn/mZn8l//s//+WXd9f/6X/+Lr/mar+HZZ5/lYx/7GF/zNV/Diy+++EAP9lbsO/DXHy4bOl7kvKXjnjvwzRhQStM4Q4gZrSoHi3b3XCFm6tSZ51KFPlGw6Cxzx26NfsUO+bLueD6++Xm0YnexmBFixmiFMXp3kbBGX3jefaHe4zweagd+fHx8IRNlxgsvvMDJyQkAV65cIYRwr0+9xxsYl7kDL9/5OMv/ACpU6YpzLlKkM4SYKKWI0qJCTFm4ZaVorKJtDOfpFnnulxfR873Nrd0xgI+ZmOSikrPIDG8Nu4LLB5Ol3H1nfrtjup+v7/H6wn1RKO9973v50Ic+xCc/+UmeffZZPvShD/Gd3/mdfNM3fRMA/+2//Tc+7/M+7xWf633vex9f+qVfysHBAc888wzf9E3fdEFrvsfrF7cWmlnWdj4Y6tZsjlk6GNNc+ERRos6ZbpzTKCVSwFqFp57XjtVaaZyhdeZCIb71mO5kNZ+RciHnSqWy9YkhZELMKOoFKzpUQizElPEhkXLBx8wYMjGVC7LEV/p9zccUU37ZMd3uAni/f489ngzcM4WyXq/5vu/7Pv75P//npJQAsNbyHd/xHbz//e9nuVzyK7/yKwB8yZd8yR2f62u/9mv5U3/qT/GlX/qlpJT4G3/jb/A//+f/5H//7//Ncrl8xWPZUyhPHi6jImqt+Fh2BdtMRXyWB54v7mWKb50Hg1pJlx1ixVpFMw0WQyw07oxHzrkIfz3ldp8/jlm9cua+lIHo+cGmVuyMPLPZJ6TMEDJaaVLJtEaxWrQ7SiaXM/mhDxml5IKSp4HoHFlrJ3rFmtsPLWXvZb2wvLh1Z8Fb56kmuRuoO6rplRyp+8Hp44V7qWv3XMBnrNdrfvM3f5NaK5/zOZ/DarW6r4M9jxdeeIFnnnmGX/zFX+Rd73rXKz5+X8CfPNzKac+1QrrRs6Ggs/pCIZwfWyuYc5x1mbJLUi4opV/GlZ9/nfMdd0wiPVRKXhugcWbK+JZOfT6WmMru9ZzV1AoxJUISXXkq0o03TrNsLX0r6twx5OmCcbY4AuT4Z25cKYVWTMXdXPo7k+5aDEfz7y6lgrOSpDh/XZ/j5efjmQvzrXcbt/t7QL3tcdwv9jz/veFe6tp9G3lWqxVf/MVffL/ffimOj48Bbqsh997jvd99PHPuezwZuJ2OG6bOdNcRS8cLZ6qOeQhYakFN3fjcacLcaZ/Z4hurKfXlqXoz1RBigUkOWOrZnYAxmlxEzWKM3hXvuXOXC4WiFEgpE0slpUrTmJ3qJE95KqlUdC07WaLcAUjxnetpKQW0QiM0z2UdsHwsRdlafWYw4kyeOGvIoZJSwU53IjOdc1kRPf/3KEU4/JwrkB+ICma/3efh464K+Dd/8zfzYz/2YxweHvLN3/zNd3zsT/7kT97XgdRa+f7v/36+4iu+gi/6oi+69DHve9/7+JEf+ZH7ev49Hj0uM6voXWGVIlpKRWmhOi5fMHBWqM8vVDhv3pmLhObl3Z9wzVK5Yyo0zlBKoea668BnKuP8xWWmT1KuUAtKK0qtpJRpnCOnMlE+ipONR2s9PfckY1Rg9LTGrRZUVRN/XzHanLtzqJe6JO10YdmZiKa7h93PqsCns6Eq1B0VdWdDkHD0eVpQ0VgNqNsex73gtYoGeCPjrgr40dHR7o94a/rgg8J3fdd38T/+x//gIx/5yG0f84M/+IMXnKAnJye87W1veyjHs8fDwWU5HLVWwrmhoDP6XDfKywq+cMYF0C9TeNyKW7XaM4c9Uxo+Zlorhc6HhFJi8LFGT7y3FDgzKV1mp2YIGZSh1kyMEWstFUg5w7ToYd6pmXLBTXryUuZ/K+JEwXS6os7x17Oz9HzXqpTw+z5mchYbvzVnVIf86KJvd+gpNqDshrjncb4z3nHrVfTt8+/ydsdxt3gtowHeyLhvDvxB4ru/+7v5qZ/6KT784Q/zu37X77rr79tz4E8uzr+RZx42FymQZjLL3Do8vLXDvoxPn7ne+flnyuT8gDLliwNMo6elxrWitN4NCWcH5kzFOCt89cZnlFLEXNiMAUrBOYtC0ThN31hyFprDx4IzikXnSNPQ0xpDygmj9aQbl4Gk0ZqU88ucofPPFJMoXUqVsasziq6x09eEAjlbzlxRyF3FrQXzvJt1vjjNg1tgd+G60wzhbnCnv8/DxpN8oXhNOPAZv/iLv8hms+HLvuzLuHr16j19b62V7/7u7+ZDH/oQv/ALv3BPxXuPJxvnO+O5mIDC2qmTVlWCp6biajQv2/x+u25+LthQpiIidEVJebcCTb5XCkyIohDRWqOKdK0pFUIpNM5iz3H1ZnLtp1IouWCUJiowVJZ9Q8qVrQ9oZYhZKJK+bYWS2ckFM9tQ0Kpw0DtAVCrOyrEWXXdhW+d142PIu2Gl0YqYKtYUnJWCn6cUxfn3as9Z/c+GvuVCZyx3FnJxSll6OTVx8vfSPV/2tUeRevhG493vuoD/vb/391iv1zsOutbK133d1/Gf/tN/AuCZZ57hZ3/2Z/nCL/zCu37xv/JX/gr/6l/9K376p3+ag4MDPv3pTwNC0/R9fy8/xx6PEe6l+5l58bmIpyQd4VxMdsNLLpoW5htHe0GRUnZRsMbIkDEXcBZOh0jJYExi2Vq0NmhthFN28v9UhAMOMU9DVXlOrc+oCmMMrcucbBPaGCqZkjPVNgwh7e4i+hacmQefFVMzMcrFYZYQznptZ4WHt8ZQar0QtmWNIhfN6BMhFvT0nLnW3cygTv+u535v83Lm83LGCmilJjWLuEMVcgcw0y96upDN1MorBWudVwnNF5aHvfDiTnij8e53fT/zwQ9+8IJ9/sd//Mf58Ic/zC/90i/x4osv8s53vvOeB4z/5J/8E46Pj/mqr/oqPuMzPmP337/+1//6np5nj8cDd2OAufXxc/FRkyJEVHfyfSLZO5MPzo+XcKrZDJN3rzuGTJjzu0ulTl3keozkXImlsPGZ0yFSa9ldLBTQtRZqxcckx58yIPkq2zHiY5LvySJPrFRyznTO4Jwhlip5iBX61tE6i7UGazQhJrZjIuTEGCKNNVgFrdOAJmdRfZzJI4USibkw+MhmCIQsFNPgAyEXvE+knEQ5MhVxZw1dYy4sZ5658DD9l0vZFfG56J43Ns13OXe7GzOmvKNvxGBVXvaY16p4Xz70npQ+r1PcdQf+W7/1Wxdkg//u3/07vuVbvoU//If/MAA/9EM/xLd+67fe04s/BvT7Hg8Qt3Y/KZcLmmLpZvWFQg/sisf55L6UCz4kKlJsnFFYYyeJ3nn+vJ5leE9d+OAzbSOKEkWhFkUqhUrloG8YfGIMCWvM1O1qYk5YoyZJod5RDbWCT4nWmklSyC7IavSRxjnptOvc7RlKyYAh50pKEdSU3VIqQ8ykMnLQ2Z3RpnGWUuTnnZcrGw1tY7m59jgrnWxM0yC3VrIGrfT0+Vkt8/Ikxpkzn3XkKcOilRnDZbTUjPPd8/zxecx/o8ELLeWsKHBSrlhTuZW6eS1wq8rpvMy01Mslmk867rqAxxhp23b38X/9r/+V7/me79l9/Na3vvWhh1ft8fjifPczb7mZNcVaQcyzRjtP3CgXirBS9cKASyznItez55L9hGo542elSBa61hJz2XVdYpSB1jlC9oxjZNE1nA4RoyopK3JJjFEkd27SPa/6BkUloim1okoVDrxUMhBzxlmFQoE25FKIOaHQaAPJR1atZQyRlPJ0FzBlo6DpG00tou5oG7ujLEKZjUyFPHXTKQk3XyrEmBhCogJdzfTO4pzdRQ7AWeSANbNjteJTmZN2SfPPkisYLlBD5/+O54vv7fjkubMvQJkiAcx0cX6l732l13w1RfY8735RZvr6pFPumkL53M/9XD784Q8D8IlPfIJf+7Vf4yu/8it3X//kJz/JU0899eCPcI8nAudNI8K5nplNhiD6ZRT4WFiPEZBiP3ezM5cL552EBquFq5XOfc4BlzdonqJaS60MY4D5DTvRE2b6ns4ZnFHijFTinNyMkSGIeHycddClsvWRlCshCbc9xsR6TKx9JOXMEBOjTxSgcxZtFDGUSRWisdbIsDILX+2spCRuQsYZTcgFY8X0Q5XO2YdIykx0hsZpcXGWCiVnYkrkKnciRlVy1Zz6hA9xZ3xS6mxeEFPGx0KIGapQRz5mNHJLMat8zt8BX5a1cms07pzXcub81KIbV7IkI0zRGrOR6bLvnb//steMKd9zuNdl56HczckFZR5az8fxervrv+sO/C/9pb/Ed33Xd/FLv/RLfPSjH+XLvuzLLnDiP/dzP8cf+AN/4KEc5B5PBubQqLl4m8nh58PENVcxzgxjJaREqxwgbyo9dcA55x3/O4aMtRqTCq3T2MZOg7lMLnWXOhhyYeslSGrVOzpnpWApTa2KXBQHnQOlSEXSCnOpFCopVhpn2YbEqjWEJAqWWgrrEIkFhpBxRtEYRWs0m5jorBVFSoaiFf2ULd45y9YHQCifmJOsYkuZ02GkdVY611KotRAnOshoMFlREXVJzhmNFgqpSJFbNHJ8BaF2ysTJS0qiPus6maio6f+NUWxSJBdYtFacnPZiRzxfwOaslVnmeL4Anr/IzpAhMviSsNqcMy+Jlf/8985uz7krP585E+IcZ6AfSLestdAmr/flzXddwP/iX/yLWGv5N//m3/Cud72LH/7hH77w9U996lO8973vfeAHuMfjh9vd5kpWiAFmA8ikilCFUqWb9iHTNloGaRNtYHaaazG2+JhFD+0mK7tW9NpMedvypq81UyuMSYpg0zg2w8jxesS3DX6iUJZdwzg936KRC0bfWMaYZFFxiZxu5Rb/eJM5WDTSnSqIGTqnSVEKzxAyq7aicsHXiKqaTEFT8DEBGp8ii8ZKFx5F8TIEj1YFo80u1rZW2ISE1hqDIkUZMDprcEZT0Ayh0DQGhSWmSCyVtnEyUNQKZy1WM+m4odaCYurEUxYKSClCytMGIYNRElngzv0t5f/sNg7Na+Py9Pe5rADO3LvWYnjqnKGdNOnGqAtxBPP3zsV75qfnIn8rhfKgTD9vhOXNj4WR536xN/K8trgsuQ5uP+AKUW7ljYaYCwqNMYrWqsn4UncOwpQzelJNnA6BmMXcYieTi6gq5LF5Co8aY+RklM7PGsXx2jMm6aRjFgv7ojGg5HucUbTW0jWGnDM3toHRF1CFxmhiVSxay6qxlFrZeKEESq1sx4jRmr41qFox1u7uOKyqFIQeKaXSGBlAOmunISlYpfC5oKk0zjHGTMyF3mliBYtiEyPXFg3GGFHYFKFMtFI0RrMNaaKdNE789Kw6i7OGOEkmYxJFi7Oa9RCnTlYTU6ZtLK0T+kZxFt07Z6GkzC5rZVYFzb/z8yaq89THHDwmOCv2MBupztbS3WnZRYgZYNfBX2bKejXn7ZPUeb+mRp493jg4z4nmLBnXs1vv1t2PO/v3VDBaLXI5keApQkzMzj+lhPO1RjEG4Xu1ZirqZsevz7SBbJZXWK0xSKxrTIWQ0xTLatj4iNZwMiYWDlJWGGXY+IBWliFWGq2hU5BFm31l0Uh290RZWFWJVbEZJcdba6jVkCosrGYImVwKvkDvKq2FzrWTpb6gqhh/+saJqcZH4hQla7RiGBPXQ8UZI4alCj4VlsaQq0gFu84JJaULV1ctPiRQBhSYqSPOpe6kfCDxAKUUWmeASkhSRVMu2PnvRKXk6funcC2tuSCtnGMLbpcn0zg9LdJQl3S7+sL5ALyM0pgzZ8o5uuRWU9aDMOU8ScX7XrEv4HvcFW5NrgvToKyx8saas7blfm5+o2rMRHvkqVgYVacCPuV/IzkoKVdOjz1awWrRyhBwZygpE5c9G1Dk9t0Yzao1vHgy4HMl+IS1sBkTStWJy828OIiBJhZLSAkfEouu5XDZsfWRgYxTGlULy9ZIsVYV6yzJZ0oRNYhPhVISi9ay8dKRK60hR5478XTOsmyli1y2DqiorC50nbkUuSuoirbRlCDdqtVaqJcCPiaMUqx6SykKtStuBWPs1J2qnVIlpsyYhAOZI2RTrrQGalU4A0abnU67a8xuaDpfGHORwe9cnG93h3Wr2mimSODy1XTn/33nIn+mYLldVMLrUUXyarEv4Hu8DJfdcs4SN1kmXNgG0UYrJdppHwutm3c/Ih3epPtWQC6JUhSpZHLJtM7iYyLEhLGWGCN1ohnUEDlcNiIPbDTO2UnPPHVt6J2lvQLLvkH7BKrSGcOJjxgUi9axHhKjjyhtOb0ZaBojzkgNa61pnQRE+RjIWdM6GEPEWkOpoh23WnHqM11jybVwvBlonBVDjlagZh14IZWCrVKM5O6jTuoMKV4KCc0yVtM3DVaL9hulGGKmsVqGkBrACGXDvKFI01iRAcrSioxPGe8TPhecMficaYzksdRSGGPBWYtSla6RoS7A+ZVzom6RAj67Qu+kD5/PAym+c3qjPvf1259Tt3Nmns9nmdWkt5py7ocXf5ASxccR+wL+OsT9nqh3c8u6yy5B8kBkUJmnzBK7c73Nb7YQk3RWFSqFMVVqqdQaUcDJ4ElpQGkLqmKoaG1YD3F6s5/xo+sxYrWa5IWamM6kgD4VKHAcI7pW0JVlZ3Gml+48ZJTWhJQxuXCsKtuQeWq1wFCoGhKKEqL83EjQk48RtOLasiEVhaKAMxw0jljkAoS2NG2DUyItdFqiX8cg1vVxDGA0jbV0WrH1EZ1FTaKVIuRMSJnGSqCVNgo9/X5z1lPsrPDTczPvQwYlihNtNCVkPJmcCtUpjIKKGJiMFrNSKtA40eCHXEip4pyRq6CelCi17KiqB2F8uZtz6nL7u+bW6OF7UZGcf12YnZj3l6x4/jkftwvAvoC/jnA/nOH51L475UjMkq+2saiYSEUx+EzQhVqE/92MUIoilkyj5bEhZcYgummrNDUXUpW8D2uEB97GiHPS6apaWfUtisqydWxjZqmk2El6n6hOas2kKhnYWms2PnGyGXbKDK0V2yEQasUpxTomYpFhYr9wlImS2YwjxliqMbRKo4xmGBNKizNyCBFNpTix2kc0SydKG60Ux0PCqMxB32CtwcckF7KkaW3Bp8rNUUw9Tx/0DDEz+ETrNFVBM0XCOs0uZTCVilWilsmloDBYK9kupUoHX1Wlcw6loQRoWkNJlaQqIcCiFVrEak0B8rnsc6U0RmmwckcgShexwhut5O7jNpTFfB6I3E9yYu7UGb9SNsmdYmdfjYrk/Ou+Woni4xyQddcLHe4W97vQYY9Xj3sJ8jkfQlRq3W2mmRUF86Cy6rOhZK2ZEOXWNqaC0mCAprN4n8g10zhLLTBmscGDIuRKSIVFNxfgTK2azWak1MpB33M6eKyzKA0vnqx55sqB/Dw5M0bQKCoIxaKgZBhiQikYxoAPkdMxcHVhSGhsrVzfelqjKVrRWIsu4pgsgKmwaB2bkDE5ctj3KKMIIbMOAas0ZdJk15wZfQJrsBWSbbm5zZJ1okVCNw8uG6tYOEMscLKNFCpjyJxsPUM4o2FMEc30MOnPN1lRc2ZQQK3SybtKM9FUWlVCrowxi7GyQsgZqxSFwugzjdOstCUrKFXyw2utKBSxJGoQOkXrSafPpDjhjFLR2u6y2Gfjy8s57TMKReJvzyiUW8+xV6JBbrW/n++0a62X8uqvhFt5+lcrUXycA7LueqHDjForH/rQhzg6OuKd73wnAL/8y7/MzZs376nQ7/Fgca8B+vNJWWGXwU0VNYM9l2qnpjdzmYr2fHurlXysjWXwksK3cI5aMkOI3Nh4WjPSTXK6RWOJUQw4Zi4oyhLyyBhHoRpixCpwTUOIkVIro0+4UlG1kpWi5sqNmLBV1BwVSeYruXDQNGQqvZ0XLWSctTgFi6OO49ORWDIpK1yj8anQWCPuyuBxSXNz9ESfyc5iFHStwwehFKxSaKvYbgOJKt1zhU0sXHPCV6+6BmcN43rkJCRSzPgQOVy2bIdILoFF29A4vVugMKaMrqCspA4aqyFEusZIPKyShQ+xlCm/e+p6S6ZohdMKM8kJS610Sk3JgxJhULW4RLWSCyhK42btuJqcrdPvUwa4cid1Jg+8eJ7dLe5UnM8/362d9uwJON/x3gtufd06OV6V0vdFxTwILv5h4a4K+D/9p/909++//tf/On/iT/wJPvCBD2Cm27+cM3/5L//lvRb7EeJu3iwzzmdw1yLcas4iJRMLtnyvs5qYYCxJbrGzDCeVEvffekzCz2oxjsxUyRBE4xyyFJCjhbgol86yHSPOWZqsWR+PYjMfPKFkVq7hYNXQaMWNdQDCbpiYS6HkStaaONm2l51DFhlD31vUEPG5MvpIyZFl32ImydyN9SgW61rIOVNxjEMAo7DaTPb+ypVFh+4rL60Da58xJtNYS0oQU6XVCp8rm82W1WrJ4VKkfSkXVl2DmWRx2mjImVCk4I5DxBhR5aSSJ4lhZdVZKRBK4VOmcUaUO9TJ9KRwWhOKqH4KEoqlFMRS6Yxm2bmpADLpt2d9vahVtIJaNUorVK5TgRZKoZu07LVKINUYxCAl5qpKrQal6m6xxvkOVM6tyzv1GbejQW71FMgseDZ/3bv65NbXP/+6l0kUH8b76lHgno08b3rTm/jIRz7C53/+51/4/Mc//nG+/Mu/nJdeeumBHuCdsDfyXMRlRpvbnWjnt+D4kHcnpVZiQ54jShsnxU3VOiUDQs5pyvqQRQKqSi5JyJHTQXhaayQMajNGVp3lsG/ERFIKMUOohRdubGWjDZphHFj0nYRKaQUFsoJlY7l20PH/+9R1lLM4pQhSSTg6XLBq5aLQWs3JEPA+svWBqjROK1aLVqJmfWK5aKhV01oJeQoFGhRNo8lTwbiykKUMx0Ngs/VTvgpYZxnHSKqKRsM2Bo6WS7TWtI2mt4anDztJRdxp3SPX14FNSKQo8sO2cVBk6fDVZU9FcsBzLgxJYmxrFf07RtFqzeGikbufWhh8wTlxSjb2zMJ/ZsCRzllPf88xJGqVYWZIhcZqrJYBYd86iTqYsmBizrgpk5wqgVpn1viyS08c/KS3txqq3L21l2z+ufXcPP/186qTszRFfanh53wRvmyofqdz/jIVyv1QMnf7vnoQeKhGnpQSv/qrv/qyAv6rv/qrr+vc3ScBt5NpXXbCzi7C0Ue20wIBBdOGmDrZrxW1JlStOwVDzWUne7Ma0kRzaA2NsaQc8KnST3b2ZWdZtW6S5Flc4yghETcJ11raXAgx0bctfgzkrqGrYkl3xpJRPHdjwzoG2gxbCtsxsOoaxiGgasVqiCVPFniFs44UI74orI9CO0xLC6zV3Nx6rBLtdagFFaHtG3ISF6gyQvnUnMWdaOB0M6CM5aBpGL3HKDNZzws5QVRwcytddk0RYw3GOFadQ1PITUffGK4uW8bJaNM1hlymUCmtUSXgY0QpTSqRK30DWjH4xLJ3pKSgRf4uE7sRUsEaocT61lzI9BZ6Qi6kZFnBhrwUWulz2SQi+YxJMlA6J6FcZ8VOOvb5dazR+JJ3Oze1Uq/YJd9OS55y2X2tlAr65XtQQVy1lw0RX4mfvr1c8e6HkXeSPz5q3HMBf8973sN73/tefuM3foM/9If+EAAf/ehH+Tt/5+/wnve854Ef4B73jztNz8/eALDoGpHNpczgJS51CGIjXzSW2ZgzeLHH11pZtHpnv67TG84XMXYk77l5HNBWk5Nw60J1JIx2YumOmbj13AiJ9TBwMgwcLhbo0RP7RvJGSqYycjp6aipEk4i5cBI8PnqcMYwxcu2gY/AFtCgkYs6sU+Kg6SRpMEfQ4rKsMUIFZQwVWYt2I2SuKUDD6As5B7reoaZOVe42RPeNgqIMRhVqSSjbyCafUuViFjLjkNA68tShYtF1coFJhb5rJFa3Qt80pPnuR2s6p/BKiZTQOkqWnJTealCKkvO0lUgRc5K7p6ow03B3dwd1rnjPOSZMi5hrUehJkjhng+eZd9aa1qmdFX9+jpki2S3JmO7XZ/OW/F1fTqNcVuwuunSnLUHT8yl1lqZotAj/ZrpiuiF4WZG+37nP/Q4jH7fiDfdRwP/+3//7vOUtb+H9738/v/M7vwPAZ3zGZ/ADP/AD/NW/+lcf+AHu8XLc7gS9tWCfT3u7TBY4R57Omcm2VkYfyEXTOrmtH1OWk6QWtkGGgoMX/XXrGloHVoEx4k6UTewGLMSY0Y2hICmDJ1tFSKKsEL1xppZCqhBK4XS7ITQNNka0NVztNCEkaqmchsjCwZAyRkHfdsLHZ9huA+2iw4fMOG656SOHXUcomZwCXdNRc2adMo0GlMa0RvZWpkKjpJN1jaWqQtconNGcDgldhe+vWuND4nBp6BpL1JVF26InLniImXHtsdaBs8QQIRe5S9EabaST9FH03mqaN2xCpnMwlExVisNFy3oIVBSnY0RRaBu5mHTaEHUmZo214IyVnJecsdrIBWp3bohaRCtxduapiFNlGXNjjVxss2wg6lpLShlrLLUqjJYLTYgSIeCMpBummIk5E2IhA50V05AxZ67KW5sG4GWf231+ok/mNMX5YqI5G5jOrlF4eZG+17nP4zqMvF+8qjCrk5MTgEfGP7/ROPBX4uLOD3/O0t7Ob8Q5K+BzfsZ2DNJpoggpTYqTijOWSmXrE1pNwUVTwuCc3RymKNPWiEEmFJg3y9RS2PggbkNrKTljnMFQMOosFzyGSFKawQeeWx9zpe1Y9D2mVA76lqqEF33u+BRrDOthS2stq34hXVxKHB2s6KxlEwLbMRBKpjeWxlpuDCNHXUujNWNKKC1LFXKGqjQhBLSqaO2mlEQ9dcqZkhJbn3GNQ5XC2geOlh0ocAqi0hw2lr5zvHC85XQTuXJlAdNsYWE1b77Sk4rIAAHGVFEUOmvwsktC6BokE7vUStc4bqxHUqlcXTi0VrJPs7FioMqyFk2UQ4pYCq3RLHu364TlHDhzgc5Uh3S0ouOWHJIy5aQLvaQ46+alMkgTMJ9vMWU2Y9oNSWutdI2ZBsovH0DOp+etn5u7/IsRs5fzy3fabn8/c5/LnudxwkMPs0op8Qu/8Av83//7f/m2b/s2QOJkDw8PWa1W9/OUe9wFXsloc77DMEbvIj3nW9z5jTkvrJUTXktSoIJuMnScDpGQwlS0K26SEdYqi39TgTEWDjqDNZat99QKS6s4HuXduA0JqyzbMdA1BesM2yFI3KmShb2lVo59wABFa4wynMbIU8sDTKtZh8DV5RJrDW+9eshvv/gS2hpOQ2AMnqPlAeuUWIZM1ApbRcnQ4zBGUXLCqYqmMk6SSVMrFUMhU1JkEyMGTSob+tjw1JUlPiZUzRyvRyKKQ61QWtEay+A9vbVsUaSYWDaGRWP4rGsLnlUDlEprJSMl1EqI8rPHIptrWqfZ+so6xWlBspZc8ik8qyi5gPaNpXNatN9jYpsyTcx0U563MwqVNUUVrNI72z6oaS+oFOetlwTDIYgu3E3rz0pRU7jU2QLkOTRMZHx1Fy87U2jz3MRoLT+jUrI1iLPlELd2uXlazmCn1Xq3dr7nu+3bzW3uZOi5F3769Rgve88F/Ld/+7f52q/9Wj7xiU/gvefd7343BwcH/N2/+3cZx5EPfOADD+M43/B4pVvA87ziBS6xVoKXxQizsaNOxQwUi74hhARTvGguImlbj2HKg9ZkoyUONUoHO3fYQ1CAl+ctUjyMBj/lh4jE0KGtZhwCbedIWbp6BTitGGIglUJnNLkkLJpYMjXKkNGYQmstL94cUNrQUNiUQiiFsh148+GKMXnyJkHjcKXSdo5cDadpTY4RvVhQswxcF42j7Rx1W8lkOuMoCk7WW3FkVrkzybmwWLSkVBlTpm8arhxZTk8DUWmWbUPpCpshse0yR53jM69U1rFAFfv7VWew1lJLZhwLsRZ8SjijGXOhqRWPRefKqrX0bS967CIr3sYom4yKUvTOUipsx8ThwiHLiStXFi1zGJRSCh8iuYLTmvWQibmiEZrLJ6FUWmUIKZMzWKvkgqr1he61pETOYrUfg+SJt40cQ0gJZNkPqRQao1DKvozSmHdS1irRsW5SyuhLuuTz3Pllc5tXKtJP+jDyfnHP9w/f8z3fwzvf+U5u3LhB3/e7z/+xP/bH+Nmf/dkHenB7nGHujubkt1v5PinMcvL7qSBLFkm+sDFcHi9JffObzBjp2m5sPMfrgTGJnjtEURlQIeSE0YZGw1HvcNZwOgRykcFdyJlUxXBzejqw9ZFxyGiV0TlhG43WBpULY4ziqNSaq33Hsmm4ulxwte1ou5a1DzirWFrDsmvYDh5fMm9aHlDRdE3DQb+kKhhjIhbFcfAQAv3BgpwV1lSOXEcwhjEKF65RWGcwpaJMRStDVUWWPfQLci5stwNWsqlwblqeUCvbENhuRg5XLY0xWGe40ve0rWEzBMZcUMpAzlMAlpmGvCKbRMlKs1Rh4zNOG7SV/ZizPM9Z0YnPpiqnJSerd5bOGfppe3zOlb5pMFrtFiEPQVasWSPdsY+zNLRSUqUgOS5GTyvkcqVtZO0cSu3OKzm3ys6h60OCeuaIdFMjMKcgGiWqGD8Nt89vs5eLjNA3tdbJ8FV35+pl7O3t1rjN74H7wa2v83op3nAfHfhHPvIR/st/+S80TXPh829/+9t59tlnH9iB7fFy3OkW8PyJn5LwqWPI4rqz0nX4WHBW3owpy2Z2rRQ+SlbHdkzc2AashoO+kcI+WbdjKrROjDl903DUiwJh59YrhYICpVj0LZsxUo0sFThYOJauYUiZoiDlRPQjlA6nDQtXMcqwWiywVMo0kHMLkfYVrThyDS+tT9hWRc6JWgJH/YpTHzhoHa11NNZBLHgKvbH4YjhoWiLglHT7MWgOrx6QSyHUgSFElDFEHzFGcTLIppzeNZJ1rbUEWilN7Vesh1GCuZxhUwsxFNqFoxY4HiIxKxZGDE8+VUyObGJm2Vh8iBSlaYwGCtuxggalE0EZXjrZ0jVOVqRpcNZJyiFglGaMCa1g2bnpbyihVJ1GBqOICkghBTRNPLgxipwyGMUYM4t25qsrzqpdLs3MCZ/faVlqZd7MI4VY4nKdNbs7NDnn5GLlrJEFHilTq2IuncZoai27LnwMCWvMhS77QQ8aH+cMkweFey7gpYiT7VZ88pOf5ODg4IEc1B6X404675kWkc5R+OaQC4tWnH7zKq85KtROb6hahdMuVZQofevkcxPXufFhuiUX9cnBoiVPXOuVRcMQIxS4MQSMksyTVCpGadn+vptiZRZOczNlOiNDzVQLjbEsDGxzoTUWnxN+GFmtVqgMN4eAKZptEfXD1kdyybx11YMpvKldYo3BKEWz6FAlon1kTJqusQweQgwYO8n2osTg5tZgVMc6RHFS1kJNkEzhwDhCDJRSibWQS+ZNV8S0U9GE0XNzXdFGslBKlkyTjc8UKopKGiJNY+mdRhVJYVy0jiEkjJYufEiFq51jCJHjTaDvZAjZTavfap4KZK3kkuisJirZbgRSXK2WC/Rsr5837QBTMFjDZghoo3BmKrw50TaN3D35hNKi/Iipyuq2VMgT7THPWUoRCWnjJDFRCrwMUks5W2A9F02lNMbInZ7ozMXxC3L8KYmjd44TmJ2dD9L1+DhnmDwo3DOF8u53v5t/9I/+0e5jpRTr9Zof/uEf5uu//usf5LHtcZe4jBax1tBaQ0xi8x5CIqaIj4XtGAnxzH2pqixVkCxqgdOanANaaVprRXnhhMNurLgca81stoEXN6NY6aes8BgiTLrhnAvbIfHCyZbnj7dsB0+pouwwSgqGz9AoRSWxDYFNyZQYxWSTNdUUaoFiHUujeXq1ZKsNOURaJ4sQUk48f+OY7ZipteDHkRAD63GcOsnE06sVSls+fWPN1hfGLFt5rJNs7mI0C23JVbMtlZwTMQeqMhT0VGQM2jpWi4anDhagZPvPJmSsgRgSPkvo1jgMDLGAsdIBK+G2Q4wopThwmlAqpSjGXGQmkGQJRUhTFJgWF+VmzNRp+9G87IIqtvyUJaEw5yx2/Umm1zRG1CpWS5ZKSpxsPNtQON16askTJWKYTU5x4vwV4ihVWtIJGzftu9xx0nq3wUcpzq1fu6gokQIvHfCsoEm54pyGScM+K2fOnv/+bO/ncVk3f/51Xi+45w78/e9/P1/91V/NF3zBFzCOI9/2bd/Gr//6r/P000/zwQ9+8GEc4x4Tbqexnd9QueTdSqxaRamQq9pZqDUSv2qUdNZWaxado9bCZgjEUuc96GyjoWYp7p0zbEJijDKsa4xmKJJhrRS0RqOdJcSEj4kKnG7WpApX+p5cC6c+YJSibxynqbKwijFEtJH0vFZVbFEs2xaXiix58IHaOpbK4Ywmx0TfL1l2DSmMHK6u0DpDmC5QFeFsY5U9msFnMtK9LtRCsrsVVGVEIjl4jDb02nK8XcuChBZKzIBmtAqrDEOKrLdeNOspsehb+n6BroVlK5G5WknXerRoGKLo29c+EarfrVTbDp6DRYe1QjHlKjsvx1zpp0RDVYWKcRqs6YQKiwVtDTlVYoHWyt1T47RktOREzBJBOxfTjY/UOg22UyFUsLlStaJBYay8npuKtrVqp1hy2siBcHaBvyyVsHWyvWiWGc61NpeyC0hTgLMKa+SxJU/dNuyoF20laOrsXH71g8Y5NbEUHkg3/7jingv4W9/6Vn7lV36FD37wg3zsYx+jlMJ3fud38mf+zJ+5MNTc48Hj1p2UM80xhw3Nb6jzkkFVYSHuFcYob6BMkvwJq1gPAR8Ty84yRikWFLh2IA7DG+stx9uA1hrvPdcWllQqIUZyUQxRFBsoyf5IMfP0lSX1ZmUTvKQdomjMtFk9ZzpjuH56TEFztGpogBAT62mxsdaG0QfQoIOH1tEag1WVVBM5alzTSgaI05QcKQZMUfhJ6lhiZuksB67h+rDletkyxsDSSS6LUpbWNdzYbFm0DqM06+GEmFt614BK9LalKIvTBlUzISl6Z6BkhmFg6wulZK4sGq72Dp8ly3ucttEXFCUVVCNpgqeh0DeSy33QO07GRCoZUwptY9mMCa2lmCuluXG6kZ33FVQt9AcWXTW5FrQSzbpz0lk2VrbPh1jIk5JGSitk4LA1bEJl2YjdvnNGaAwqStXdhd9URZ3W4+UcSTmTkEFw5zQSICwQXtzstNy5QC6iWDHTsFVraCcJobOGWhMgO0hTEpPQZVrsV1Nozzc6YhgTevBRyAYftuLlvnTgfd/z3ve+l/e+970P+nj2uA1uvSWsMC27rcQk3ZKzehpuSUCSdqJSUGrO4Zao2K2XtMCcMz4mTnzh6qLBqUrUUJRljAkfMyFBKZmjXmMax9oHKpr1mJl2EnNzM7IZB+GXnXS3Fhh8JMTEsu25MWyppWBThFpIkyloaTWrRc/10zXr7ZZrqxWlKNZx5FrX0Pcdm81IApwxHG82qCW8yfWs/Zb1oIlA9IGgFaZIR56MElonR5zSrL0nZckgubHZ8vThAcrAqmvo2pZYKgchUJWiKMSRmgtPHRzStC0xyR2L6hzeR9aDDDbbZgp8qpNULyda56Rw6UJxotvOKtNbi88iX3RO0hkBTreZm9uIM4allXRBUIwZasrTphxRcTRW0VmJmQ0pTDruyZRTZRH0GPN0QYhyYTfiumxMZhszB1qG09YocaXqaVCJdL/SLdcpgnZy6RqzK4y38sjnjThz522NPG+5ZSAqZF+d1Clqd+zzOf4git1cvI3RqClL5bU27LxWA9R7LuDGGN71rnfxEz/xE1y7dm33+eeee463vvWtlw4497g3XHYinx/wzJZsUZDMXaveTeznW1oQxUCQHFicrgxjYohZ6I5peFcK3FgXYq1YpVC1EKIhxkTIlb5vSCVPPKLhZDtSlCKHIkaOCo1tQGkGPxCTPNfp9pTWStRpQ+UkRk6GhDaykmwIAy+cwFAqp8PIla7FqcqmSmb1jcGTK7RNix9HrLG4ppEo2xghJzYlQ9Fsk6fEKF9HEUMlOnEwDimzcC2d02JhT4UxSMLictFRa+WgMYR+QesaQk6MUYpfo2VxwligVQpTCnrRYWPGOUPfNmTg1EvoV9dYfAGVC31rGULmePS8+cqSxWK+y6loLbRWLoasNIedI+RMzFJctdH01jJWsR1pNClFDtoWpabsdGPwKXO8DSw7R9cYtpNqKOVpgDkGrBHDVmMrOs9yUlGulCm/BtglDpYqd3SyJm9yTE5T8hDzpHYxu3P1ooFM7RqLuWgbpacdqfJ1M81s5uJ9p2L3apY5wEyf3P3zPOiLyMMeoN5zAa+14r3nne98Jz/zMz/DF33RF1342h73j1tPZK3g/HLZWUYYk7Q8ucjKLqWgbySjQ06WvFMIiIZXMeZMrlAUWFUZcmaICa0scRyofUPN0vlSCto25CQ5HXGE62NAA6u+oWst69ORhPCrpWYWXcOb2hW//uzIzRRkuYIyDDHQdx3GtvQx4toWtGGbMxbDWDKrLANGHxPrlIgpkSsctC2nMTLEiDGNKDFcQ82VYhKbmPA+cfXwgKLgU6enHOSIdZ0M4XJh1XdsfeB6XNNax0HX4VOklsLT1w4ZxpHNGNmGRKqVXsPSNrypLGWTYq3kWmnMtJoMjZroiZwrw6S9NkCu0KChJG5sPQd9y7VVQ61iaDFawqpiCjjjUGreHm/ISnJQXjgZoBauHfQUCo21VAuqyIByiAUVC6mALZnWmZ3UbxglcjamItQIlmVr6azGGMuiFbPNPAQtpe5kfjJMFBeoFFpNzZU40XS5zHSLJqSKrWehV/PQcU601Hp2cNYz+/6kQinCB4nTsxbOauXFzB6jX56fcrdmnftRsjzIjvm1zF255/sKpRQ/8RM/wTd8wzfw5V/+5fz0T//0ha/t8XLczYXt/AkEwmH6SdUxf79S6kxh4Ax1OunnTseHNBUK4cV9yPiYOd36ydUnn5NhY2EzRG6cHLNOhWFM5DjijKNbLglhYBs9sRhePFnvtMDHm5Hnrm84CZGSMmZy8pWUOV6vsc7QalFrXF0c4JqeUiLrYSAbx431ho0fOWo6XNegKhz1Pa2zGA2D92zGEZUSa+852QycjoHNuGEskc5oYq2cDIHN6Ak1czxsGYKn1YYhV6xxuLYV2V+taDQnmw3Pnxxz6keO1xtOh5H14BmimGAaXTlsNEMIEm/rLAdWc8MHsY4jyX9jrJSaoWR8Stw8GTG1UhCZYK0ySVQoWqdoG8dTBz0bH7lxOhJK4dqyZdFYusaJRh9xS25C5qBzLFuLMYrGSOdai6iKlNbkXKdBrEgRYy5CdWhF4yzLSeOttOixW2tY9C2NE9OOdNyS4y6LPCo55x1fPatRZuu81WrqzKdipJjMYpnNKJJDKVhlVzTbyXDkrLkQ4zArVtIkLayIWWyc8ujhTC1yPrfkVkPPK+F+lCx3MhDdK17JdPcgcV8duDGGf/yP/zFf+IVfyJ/8k3+SH/qhH+LP//k//8AP7knH3VzV58fMXKFkJJ9JqnKWENHzgfZKQU51xzPKUgZJRnJGirtIhcXQswmFzlmUzkDl5jawHgI5JUJV1BipJYHV1BrRITHGyjqMxJRwroWcMM4SsuJ49Dy16OkXDZ2BGylL5KtWpOShCvVwM0RqSkSk+8sxUZSoP5yxrJwlUbix3WJtA6XSKY1uWwqaFDy5VhZGOOzWGF7wnoOuRTlHpxTPbTasg0eXSiyR3vUcdh1aa573EkPbWEXjGvn9TM7DU+9ZbLZ0Xc82ZSgFpyub7Uiewq9yKbTG0BiFweCcwVglNvoKi85OG2xkvVpFpIfOWQ4WIpcbggRZ99ZiG4ObtshrJZZ0raZsmpqwWnGwbGispbEyeG5tZkxCQ+RaaZwVL8Y0o/AxsXBgtMX1wsVfWbaiLJkoCq2kwx6ibPXRSnLa5yFfylq20KNhKrQzFeKsoZk/NylXALTR04q9eVQK1szNw9k5Pt81qiqd+dSh7Aqlc4bRJ8LE288U4dyRz4+9lw72XpUsD6Njfq1yV17VVvq/8Bf+Ap/3eZ/HH//jf5xf/MVffFDH9MRj/sPfDQ92fuDiY54GjWZKEyy0zsruyXN0itFqkswVjJ1uEzX0jWM9BE59pG+a3TyiMZptiISQON6OpFQhFQLwliuH3Dw9xQFZN3g/oGuhmgaNkSxpKkMpbI6PScrwVL/ENZZhMzJYzRjEGNJqw8oZbqw3QkcoxaALVSs6a9nmwkJZXiwji3HgetAc9S2pZMb1KWGKQG21ZutHGtdjTaSWSqMNPifReCdHbzS661jGQAmBRdvhg8bnxAubNVcXHZrMwjZU6ziMmRvbDdsQZD1YirTWYINY+2OpQj/khMsWbIM2moUR2qMaQ9c6rvYGtEUrOFx0DD4QSiX4QEryt1NUri4a0XRPF4HV0uC0xllDShmPZNb01vJma9n6MBVbIxe7Unf5IbUkMKK/jykTiljaF0oKqakKY+V2WmuhVJadke1GSpqGkES50jeQCpMrV09Lk6FW+b6J8Sbn+TyVpcjz2r08rWKLSY5hpjvkvOdl5/iumOqzbTgpl510sZRK48ThOcsYZ8rmfKaKdLD3RhjcbfF90Aai+Tlfi9yVey7gb3/723cDDICv+qqv4qMf/Sjf8A3f8EAP7EnBrSH2ZzRI2RVmuPyqLg61OtmM687GXEqhUNGIA25WGKjpe0uVAZRkYWRiqSJbmzaLlyz2+DopFEJKbMfI6RQD2jmNcT1uSLx0vMYZWd+FP6UWy6gdfrOhaxtaYxlTIPrIaUr0ulD7xOnJwA0/klKmbRyr2lFsxVSNaRraksmuY9l1jH4glExShmIVV+mozqIp9K6lM46bNaKtJYTIzdMt1mi2/iYaEMe5FJDDRSvuPV3Fht8v6V2DbVpy7rm53WAV02CyEXrGNmzHgZgyvioOjSWVzIubgasLuaUPOdNaS9YGlLyWNRLV6rSDmrm6WLBsHc8db+X2P2VEayxFxyhZtmC1wmcjKY45kVH4IeNNpXVOsrVLFau8EqVHqbJqzZk5l0TRtY5aCkpPPamSWFqjKkob2sbSGFkH11o9LXcWOoM6W+XFPZ3O8fZirpFNHFXNRhvpo4WXPss9mT67kwv6mCdtNZRcRA01LeLaZevcgT++zLOgUOhziYggOzlTloUXuZx5Hs6rVh4kHlbH/LBp5VeVB34e4zjy3HPP8fa3v/1BPN1d4VHmgV+WQ/zyjlsGQHfKMT6/D3D+t3DBYst2RrjMWueTd8r1nrS1pRSO1yNaS1bGxovdubeaISasku85GQJjTFAlRnQzBMYQSTFStOJ0DKhSqVqzdBLHOowenKPXsuIspMzBYoH3Hp8zRimUMRyfrklK01lL4ww2F6KqGDTGOVIM+JwJIXBjHOmd5eYwsDAit2tsg3aOhsJ6DJJmWAubcWA7FlarDu8DR4ueXKG3hlXfc9S25JLxk8uwdQ0G6BsrhcQqGuPwMXIaAi+cnNI1Lau2R+mKmuz825jpJiNNzpW+61kYRa6FrmlpjONooXnbm67g00xDwMkYGbeBw4OOg0UPCk7XW64c9NO2m4xGCr3PU/qfURz2zU5B1E8Lid004JwpD2dlE9LGJ3FlqopTCm01bpoUpoy4O7XGGFnCUaZh9dw1z4aZ063HZ6F6tiHSaMWicygUzhnitKjBar2jSeYuUk3nZ6lnIVVKHiAKJyRfPETplPvWXsg3uSyve+7EZ8XU7XLAQ8wXtgzNUtmHhVfTMT+obvuh54Ffhq7rXtPi/ahxa7GeT8aL1l3pXuYO57LwqblwxyR7G+cg/YrItvSk2ZUhldqlCs63rlsvq7aGMbDxGaVEanIyZkou9AtFqbL01maJKD3deBorXVvjevwYOGhaTnOhpUh2SHVEQA9rTl1DLYrWNtScqYqd66+Uys0YCOPIqm35zGtX2cbExkeMs9gUWbYt2XtOtms2IXNzs0ED2xJ4arWkUBi2a4I2JK1YaAlxcktL0QMLa/E5czpGFs4Sq1jIcy0oY2gnTXkpmcY5hphx1hAz5BKxSnGl71FVpHJd00CtLFqJA2A7cnPc0ruOpdMcOIPWmsY6GqNoGwva8P9eOiWGxMGyo2ojOzR94GDVCQ0TMgnF8drTtwajhS7JpdIZy7YWVK2yLixXYqnUQRZqFAVzpzuEgvYRlGLtM43TOKVJVGwG01rhrHUlJVBGuvI8n4NKzquZPklplpFqQs5YJTb4Wipq6viFCxf6w0eJ+9VKMQbp2Ltqds1ILvPSD8kYV1rO4dksMw/vrLkzjSjGnttvlxJKQ+/eU6VMa930w6MlnrTQrLsq4NeuXePXfu3XePrpp7l69eodD+769esP7OAeV9xOazoX6/lkFQOEftlJeuv3O6unTkbvCpEzBqWVZHVPt51RWi5qlUztMSSMkZD+qjVGZyqKzRgnJUTldEg0jSHFQpooFqUl99sYLZruqmmaBrNeg7MsGkdIkZW1eCsdti+Vg66lWMfpsEFbS4yJIWcx0cRIsJabG1F4RIAQudK3HK9PpNPrlvRli0+yb7OzYlNXqtKgiTUzbgPLoyMcluvjwNOLJWhFExKhBnLVXFt0qFKJFZqqWDSOK13HkIXqycjvTVMYQ0BpxUHj6K3mJFa2wylXFwu0cZyOgc45rqkVxmgWzvKZTx/K30OLs9U4u+suN2MkFlgterZRNhdto8watjHTGk2xipShM4px1tK3hnH0spasQN8alq0DVfE+MdTKyRjpnBVOeLrqa6UYxkh2FqMUpskY05BiwSjNcmUnCqZOW3okr30MeRdc5ax06LVUuWuyCqNE1ler0DK1ql1nq1FsfEQrRddaVJWVc10zyQmV2jUacp6dddBKne22LKW87H2ScyFWOY/Px0HcCln2oESmWs7eN/ohUSivBo8yNOuuCvj73//+XdLg+SCrNypuN/Q4P3w533HfyZSjtXTV8wkr3ZBCqSI7DpUUo1oz1jhSSbtCHguUKpyk05qbKVFipRhNqyuts+J4TIVCkYxqp6Y9iUWCrkplG0bwI1ZrfAwYGq4uFoRSML7wEhpVPGtfOdkO9FZTgufG6MkFYoooo1FUPvHSDQqVN62WbFPkN144oQWWrWPZ9hweHLCNEqa1WvWs/YhPBdNatqOn14r1ZqBoIGaU0WgMVhW0tSz7nlpEeqi1ZsyZpdYce09vDN4YugrFClVw4gPLrsPahlIL1/qGRevwIclFUhlQis5Ziq5i+S9ALVPHDi+ebHG1slr1WGvZjIEycckHywZF5Xgz7GR8W585jZnGqp1+2odErooUI01j8FHhrJiQilZsN5GsNFpXjKkoZdCIxE9rw2YMKFVZNAuONwOlKrrG0CNdaooV684KZUiZ5OWCLbncZ+deShnjZklipVah2RojJp5UCihR2SikW9dKEWPe7b6cC3VNZxLAeY5zfrdlOScvnDPGjdKvWOzmbPFqzlRZ8+agWx/3KAv6o961eVcF/Du+4zsu/fcbGZcNPUSnLV9/pT/e/P05F0oRRUKcdLIxZcnh1qI9RovJotYyBedPtnkFQyqUHDkdorxBqLQYihLdcKuFxlmqhjFndIKTEAlTxnXOlZIjyjgqsLSWxjDpoQt+VoC4hhjElGO1lQuKD2RVcFZMKaejp3GGm0Pgxc0WVSV7pTjD8RAZYuJwWahK9MSqFhptSdOA9sB1eAqr1pGmICutNLEUGq140+EhY6mkkrkxDLuFw8+GhNOguwYHErkaA6UWVn3PyjoyilpEDdE62Q5vDHTWchoTIUUWxrHJnuVoSRkWC4OpmZplC1CbMn3XUEpmGz1L01NL5XDRyAJnrclVMaY0/b0qrTOM88YjJRnfjkpVheATvmQsmr61orLQelJjTAM+pckU2mkR9Asng+irlSiRnNEsWtH9zx6CPBW8UqW4b6bfz6pvpQPWku9ujay3U0qyVDZjkiizUlg2BqpCGWCmBqY88Lm4hunOwyhFY0WvMh+DOaeYmt8ns7FnF3erzpIIL9/II3OfadzzsrvYxyHr+2EoWO4Fd1XA5+XFd4M3wnJheLlMaB7KzCfwK03L52I/n4hjjLROku1UlW3xpUCmTBpjkfNpYBNls0mhSu73tB1Fa4OdtqWEKJkYTkPfNLSNksFmydLRUwmjl/B95TiwlpoSWEupmk+fnHC6GTjsW5LSxNFTrUHVSs4RHzOblGm1Zh3FKPSmgyUn40gNcBIzwwiLFt5y0PDieuB4rMS64dBqzLKbuj3ZqG60QTkjsbK1oqzjoGkpWmFypnFHhFpojKZtWsawliXAtBgrVEbJsOhb6hjwJZFSobOOrm1YbzecpsRbVoe8dLomlMLh4ojWZMkc0Zo47ckcI8Sa0WPBOc3RsuNk8DI81sIzW21ojZwDp2PkcNXhY+bGeiSEzNFhxxhliNm3jdw1KcXVgwZtDOMwUltNTXBj9CxbR+MkNKsaS2tF2VKp2CrceAiR4xRpVANKAgOHINb2rnFT1ouch4NPNM5SgdZaYso7ZY1P7PjsebFDypmqJpv7pHCa5YJKSSTDTAeWyoXh+0ylzDszQe1mNBffJ5LTk2f1ymQesudUbZfTES8fWj5OWd+PctfmXRXwK1euvOIVZad9foNlocy/l7mbRokBIk825zv93uY/eq6VXJANOVphrSWXQtXQGMc2BMiV1dGCkD2qVLRTbMcpztUZGufY+ohRhpFKCp5GN/SuJZRMGSpXDjrWo9zGlpjxOXJzDDgqp9tEUIXDCo2rXO1lue+QK52pU363dGc+ZTYx8vRiQcwJVRusLmxC4KjrWbrECycjjQXbwrGPtNZSdeItV66yHTd472kODkThMg6MyXK1bdmGATAYbTkOnitNQ9st8DlwYz3SOUuvC5vRM8TCslMscTy/2fCmoytcM5bkIl1tWbWGlDOKTCiZRilCybIaTilSzTTW4FIGk4gJUJpYwZTKC+s1VxdLlgvH1UUD2lBr4eqVFb3TUCBTGUKCIpnq3if6zkKt+ATWQK8KCXmzbWJiUSUh0IfMomspqElWV1m0LYvWsGwkUGxO0/MxsvaJVltSLRx2jfwdc6ZMGu6Yziz7MWdClrsDQKKFJ9VTTHmy9FegiM9dafpGslHc5NDUStG3+kImyhwvW7TaSWTnYfb5Qf6tRfVMHjgv1T6Lm503+dwtHfGoaYtb8Vppvi/DXRXwn//5n3/Yx/FEo5QyudLkNnF+A8wn5mW4sFy4KtpGU7LYtHOeOptU8CGQY8ZYw3rrMQqWvRM1SinEacHCxkcJR6pFAqnaZnIMFsgwqMp4fUPbNTxzZcknXjjBaINBMaRI6xp0jLwQTnlmuSJWWXIQk2SELKfBptaGAhwZuU3PuZDQtCZDNThnKVrxuW/pyblwczvy3Kmns3DYaNbDRiRtFX5XhW65ZOss1EKOXm7bVUWRyd7zbAg8nTO91SzalhgjL2w2VKVRVrPeDNxkDVXTmBMaozhoe1YdHC0daMuNkzXXVks62xCLdIKtURw0lhdHP/1BDGMc0UZRUiRrjVWamANWtxgjgzxjjcgt5ZaIcYwyrGtkK5DPmbYY+d1l2fzbdw2xBLSzXOmd5HenwqJv8anQWcN6TChn6VvDQWvYhsSQKn3jGLzQY6u2oaoqkQgpo0rBTfkmY5AQK63UtPbOsfGybahrLEpL8XSTmzKVSusU43TeKMU0+NSknXv18gZkN2A8t0D7XtyTRp/RIrlUYpRu/rxM9k50xKOmLW6HR/H6d1XAv/Irv/JhH8cTjVIvdgUxlZ0J4lZ+b6Zb5sD5ORN5GCNpWibrDKRsyFUySorWLCZOcNrTgnNmUqoIh66BIUYOGofrLSlBVYqTTaDvLDlJTnTeBpISPvRknWitpm0WjEFiXrNP/Ha4QWcbDJWiFAd9S8gV5xyNMmiVsabl5mZDLJXOGIqSgdPSGlnM6xoOGkXfdzh1nWQNrbZsvSdrOLINx36gGIMv0FUJ/o8oWmsIU7Jg3K45prA1LZ2B0+2WrDQhJ1zIFK3JReOUOA2XbcuYIsumYcwKnRIHy55VzhIEVSsn48C1rmHtZffm0jlOimytP7l5itIKpyzXlh0LJyl/uWgOW7W7wFw/Hcm1UpNI7l7yCVAcNGYqJgWrKm1r2YwZoxUHrRGaYtJNb33EWcvNzYDSmoOFwcfCc35gzLBoDBRxS/qkWLZSUCuKFBOukXMg5TzNMzJKKzoneSgr6rQVPk9mIyhz5jqF7egxRuJ3WyVUxugTSlU65y7QIOfPY1GX1GlAmqcI2pe7J2+3fX7m63ORQf1ZfES58Dx3oiMeJW3xOOG+deDb7ZZPfOIThBAufP6Lv/iLX/VBPUmYC3fjzORSm7qRKnK982aGeQq/S2irkvYmOyYvduw3NiMpVoKGQyeqAjHwiGW6VsmtWLWWk62nloRF1m+pBIvGsvEZY4VLXzaGk23iOI7ooliHQC2Fo9byiZtrubUtGusMYfT4Itz6srF4reiaDqsMN4Y1V5YLToZRNMVatuzc3A6oWhmMpdeVYXtKbnuo8PSVQ0JI/PZLx9i+pUfULsMWtuEmh22D6RZ4ZelN4eZmzVAUlEwucGAsfd8R/ADa4KzD5sDGy1LhReO42i+JpXCyHak10RiFCoraGGqItJ1jDIXtuGXhHM5YNoM8X0TuXKiVru+wRWEb4ZjRmtPNSN81NMaJ9lwZjEkcdgafGm6cbMm1ctBb6SJRrMdIZ7XINTWUIsNoVTLHMaNy5VrfcDpGCoqnDzqMgjEmToaE1QWtGsp0Yekm27s1BmqlXTayfWjaZzr6gNWV3jT4GHdJgz4Ipems8OG1VElfjBlnNCurKVWBmlar1UKtesdzl2lf5uwuBi6oQmSIeDbAF/ONPG4+x1/egavd47Q+W5YsOnR2XLs8x+1lhjNtcafHze/R22nNH3XX/mpxzwX8hRde4D3veQ///t//+0u//kbkwOeOorGaYerE5HZWHjMPXCpiRlCG3bLXZsoSSVWMDVYrUqn4KJrXFsXxGOiNoRpFGxV9Y1G6oErm1AvXGWNl0WjaxrEZA7VWFm1DSoN0NVVRyOgCaM2B1Ty/9ZzESMlRhlXaYZWldRKaJPsaE1oZrix6Bu9pneN4O+JTwsdIZ4SrPY2BRePwIfDCMPKmgwMpNK4hhcAwBR7plNCNY4kilJFWK3mOAmG9RtXIjW3i5gksDuCgk43vJo0o7chE2prYpMh6BBWgqZEXq3DRIYy89emnGVOh1YWDdsG6Fo7XA+Okmlg6Ny0VcOQS8bEy+Eislc86vMJYM/2krT/djnRtgzWZ5+NWNgNZJVuOqiKmJPs6S2YYFH1naXQhV0MyBpWyuEWTbDoqCsiFrnOMubLoHK0ztEZTlWK9kVzz7BzXjz2NC1xZNhz2LcYYYi70TtyI21KnpBLpZmuG1sqMQgw9aqeMaaZCFVKlUumswTorcbZOfhY1rSBDM6lRhDPvGjXdWZ5RInniuOct87O5Zi7kM7VyPitlLpaznd4aibVV02xlLsbzhp9XUpi80uNup1R5XBQsDwL37En93u/9Xm7cuMFHP/pR+r7nP/yH/8A/+2f/jN/ze34PP/MzP/MwjvGxxxxfmab0tr41Est0jlqZJVNzVOc8zQ+pyHZz6mTTzqzHSFGzbTly88Tz7M014xDRRrMZAy/cWPPpk0E2l9eCNpYkekMaazkdAqdbTyqw3nrCtKBAGcPVVYOv0GpD27RoYxlShpw4jZ6bmw0+ZTqtcUqxyZHNOAhlU8WgcdT19H2Hj4HTceBKv4Bc+PTJhqIUBcXxdmSzHXghjCTvOVx2UCTOFg0LA421vDR4Pv3iDa5vBp69kXj+BfndKQXHp5EX1huOfWS93VD8yDpkUlHkDQweTkZ46TShCjTdUqSZKBIwpohWFqsdxhgWXc+Lmw3Ho8fXjDWGVkPfNayMIalCqw3PbzeUXFj2PRrFdgwMg0SohpAYYmIbE9sh7sK6tIXtENhE0EbiDIw1ksNehY7qnMU0clFqJsenMyIJHEJkvR5IpaK1QRnFZggYY3DWSg6Klg30Wx+JuVJLxadEYx1oMYFpNdN3MuCOpYouPCUqkpG+7Bs0larAx0wuiZTlHJxpiZxli1M+N+MR1Uredd4xZtm0MxXGWrkw3AwxM3gxFsWUL3TMUvwLPqRp6XZmDInBp52kVqiWi2kfs+JLvAy3f9ztImIfZHTso8Y9d+A/93M/x0//9E/zpV/6pWitefvb38673/1uDg8Ped/73scf/aN/9GEc52OJuRuZu44yFfIwu8dSYjHzllNBijFjreRGlEkiNYZMBpyS7ltT0VWW5J6sPalmFlYGUeshcnMzkqK84czC0FnNyRjZBCRmNEScsxxvRJedUuZmiBg0sWQ+7UdeWg+yUUY3MsSqCoyRaNlaCClIJkuuNClwag0hBV46XbPoesacaSvQ9xg/EMNIQd4Yw5g4tp4YPM8fb3lq1VCsw5TIcrXkuesbUsosG8MQI8ebijagsqg2fAKzgJwgRdF1pyLF6Ppa6KAwRnySjjZ5OOjBOSUZ28ZRcuD6kOgbiw9JMr2t43QcWPvIosrvWLmG3oLzkdg1qFQ4jlvStDFOqcqYM85aDpaioxZ5XZr4X9AJlFWst55M4cgZhq3H+0jTWEafWLSOXDJrL+mEAWhK5bB3gGEbMjFEtDGAhD05rVgeLsilsh49jbX0jewkFTu72N8VGqVF812VwaiKAUKWzU1umstgxbWbi2TirH0kp8qVpZvu/MrEqRe2kxPTR4m8bRtLypkQq6RllgxF1tzNrktRqpwtEp6L/kwLpiyZLrMyZea7YyrTdqDCNiQ0GmcraqIUbx2GnnHfZx/PBqJ6y8Xk1qHqZe7QR6lgebW45wK+2Wx45plnALHYv/DCC3ze530ev+/3/T4+9rGPPfADfBxxu1swrRWDl63ssyszTreoKcv6sVIhpSymjsYwhowxil47dAs+JPq248XjLWPKXDlaEEdPqIptqJxuTrBaY9uGzlVZewaQC957UrZcX59gdcPBouel0w0HXYczmht+wCLLh0/9iPKV1La8cLIhKzhSoPsOEJ15SJmVbfBZIgI2RXJYbm43HPUrci2E0ZOquP22Y8JHeNPKoGtmPWaUAR8jKieqgmET6BqwSnPsMyVATaAbsBVuHsNyCZ2Debxy9bBh1UnHeLhssaowIBLFkKGzsg1nDJXnrr+Efuopri6W4Ef8tIn++nZLSolUoFIYQuBqt2JMmZubLau+40iJdDHGwtMHB5zGRC2ZOkW8ppDQBl469lALbee4suxIwHYz0LSO3s67KBUqZQYfOFz1+Jhkr6eCRKZrnaiVamUMmVQr1w4PaNrA9ZMNBtBWo2qltXbipMXdmbKSPBUxUpJrwVlLoxVDSCwaM+WtzJGxUxbOtOBi65PIKrXG9vI8myBmIWcVOQpH3RgtYWpG78xBkvctdKBVZ1ERsrdz3n0pRXx2Zt4py0QrNd2JTLkrk3OolEoCtLo4DD3f5dfJd1ErLxua3k6pcpk79HFQsNwv7rmAf/7nfz4f//jHecc73sGXfMmX8KM/+qO84x3v4AMf+ACf8Rmf8TCO8bHDbU0EVW455RZWdh7KSTtLDEV9QK07yVdj9e7NKeoSS0qZw2XLqlTWPlGc4WTj8Tmhq1idV046k5wz0XvatuFo2fGpmydsQ0KpwjZ4Yi3kkrCuwXsviXNNiymVqhU3tiNaKw6NYcxSuI2y5By4Po4cdGK4CSmzahqMtaSYGUvk5OSUVdtI1Ks25Jq40oLPBZ0DNcNhB9Yarm8SFOg6OGpbhgo2e06Rwr1dQwywHuDKApYOgoKQpON2xvA7N0843iau9ooY4eQYjg6g6cEP8v/WiCKl1QbX9by4XnOl78k5cX1zirMN21E246RSWFpDUprWNPjgMcrS9gtCCiy7BUVrGhILJ9K+F089PgaU0hxMt95OC3/dGwkLO1z1rIcRVStHB0ugYp1F54KzilVrp0hmkfyFFLHGioLEGg76Fh8jpkqkrDZiHKoIbYCSxMBF2xBiwhSR/40+iaQ1aw4XDU6rKR9FXks6bE3rLE0V/0GdZhPBR5EZzlvnJ4qkbw2SkwKlalonyyh2WSiTbHYOYzu/SHh2F8/hVuezTGYqRZ9Tk8i6NZkl1Xq2yea8wOR8YTbznQVTLvotSpTbKVVeTwqWey7g3/u938vv/M7vAPDDP/zD/JE/8kf4l//yX9I0DT/2Yz/2oI/vscOdbs1QU7AU0qmEVHYFejYuTOftTomilEIjXXrMcutbjCZH2Tl40GpuDJmjZcN2W8mdYztENtuRxlm6xrBwPVkbYpAwq1gKnRO9cUiJ6yXzmc7y/07XZOAZ6xCtYpWI1tyQciKnTDGKtsKgDIrESycDIcOq15yOI84YjpZL1psN61A5Wjn01Fk1raWUhMoV4zR9U7mxgeUiEbN0nwAvbTypQs4QBri5htUKmg6OtHSEGjANXG0h5goxE0vmag85Sgpf1yE8R4LPeEpz0HQcHRxSlSHEQKyVVBWbGHDGULWsKlsuFhACNzcDq6tXyDHxyRs3Oeg7xigZ56vVITlnjKpcu3ogPO0oyp1V1xOyJLbHWMBWjIKiKq3RDNPC5INlR4yJftFMTlGhdGKW+PVVK9RJxbAOiSYkbGNZdo5rqwZVFcpaQPabWmWnyFe5KFKhayw5CxfdODMtI54VHYZUCjVlrDXUUglVCl6dZizzLMZO53OYonLb1soANBeslWRNo88Cs0wRPlsCs6YY5AvZ91J47S1ZJlpJs3K2dYpp/yW7YecuJsCpaWDKlL54sQDXKn4JrS7ujp1xO4PNvURePO7UyqvOA99ut/yf//N/+OzP/myefvrpB3Vcd4VHlQd+fl9fzmUnDZwn7nGiHKDSNyIlG2OeOECpOV1jZMCUsuy/TFPGMsINasUuf3nrg6Tg5cL1k4FUCzlkFssWpxHzTIFPvnTCZvQcD+O0yQVyjSxsg8+ZdYg0WhNCoOtaQha1hVayLux4GOi0LM71wXMcZXCXEhwu4MZGbtmXLTS9ZbNJWCvr06ICqnTRFVg5OA0QRhiTUCKHR5qV07y4TtNCADEBvvAidD0cXYXDBp57Ea5chTcfSoBarYVNihhlMcDxdksosHCGkyFTC7z5SsNnXbtG61pujCO1ZHLKaGtQaHKRbJeqFQdtC7ky1ozThhQjQ8xoq+kodF2LcT1NLbzlqSu0zlKp3DwdZGlCka5W1YIzFWMdrdWUoqgUail0XSeRrbWy7FoKhWXjdgmBtU5Lkouswht8ZOtlF+dTh61E3gKDT7StxSqNEZUfqCp54bXuJHkxF0pVMoTMmUVrxX6fikgqtd7l6Bz0lpgkvgGED3HTuWi0YtXLa893l43VZ1GxE2XBWWr4Ti543oWp1MXse5iCtPI8eDzrwp2V7vl8Rr4UzXohT/9s3+vtg+Jm3Ek6eFk++f0+7mHgXuraq05GXywW/ME/+Adf8+L9KHF+aer5GE+QTqJrLM5MwfaT9Gvm3Py0R1Ah0aQ+VkIqbMeATyIJ3AbZyt63FmsUy1Y0vD6DsVoCrqwhxUzXNuRciTnTGoPSsGqsyMtqYWEbQpEh3mFjCaXQNI7NdgM54FPhpWHLS8drsXqPnudPbnLDe+l6p2FeLFK8U4S2g9ZYOgtOw/PHsFnDwhievtKLhtrJm5151ZcFq+SWfWnBAEdLQ79QLJdTIx3gxRMIQEqyIu7KYsGnTzbUOGnSk6g8GqPRFJwksuJjYBMiqWRK8JyMHqs1MUWGGAhZ+FRVKxsfiCXRG1ndVpXiLdeu0KqKaVsW3QJHImtFjonRJ2qp9E2DUZoheUpJoCtjKvTO4JqGtnOkkGi7hlVnOewcV1c9RgnlZYxh0RiuHSxonUS6St57obUNq75BG1ERpSJKi8ZpSi6kktEIpdFOa9nm4rkb4FHpnSFMsxetRW4YstwhGqVoGyMhVArhxEvBWtkKtGidrGHjjCJxVk//md3zzQuLnTU7E895F+WttMRZ/Gzd0Sll6vx3ERSwkxRaoyeFCsQsg9qYC3lqgGblyO0Kb5q+5/xC8Bl3q0B5UpQq97XU+Md//Mf5+Z//eZ5//nmhDs7hJ3/yJx/YwT2umG/Ncs5wLnB+zvX2IQnVkjKxygZvPXVKbrpdXI+BmGUTyzYWwpSfonRBoahFtqPDWSfkQ+TGyZZ1jCxdg1u2nKxHlKpshyTW7Zzpm4aFVqzHgc46yIqbo6cEyb4eckYZiwOqtSy15mQcMLGyyZntwJSGNw0SC4weGif/nZzCchlo+xYfPZ2Roh5rofiR4uG5m5VmAUYWuJMjDLGSUkQBB63Bl4IFnDR8bNfQLYUDTxleON1AiaQBkpOPtakQwFPYyqGx6uHK6pDTcWCIkbZpaFLCOYeplpPtFu0sC7ug5EjbtDTOst7KsBCtUTmzWq6EftKycu7GMPDcesNR1xKSobeGrnFSYBQsl47TdeB0TCwxopm3wgHFXGiahjQtl3BNQ5m47pBEbJ1LZPSBbSws2soYRBL34qnnmcOOUCqt1lgndFwqBZ3lTk9rRdcIV3y6HTkdxX9gNHRTka2lUGsRU5GTBEmXFbEqjC7SGCjpblsnDYidImXrRPlJ1ji7dX7z+X/+vXD+PXEnY8086PfTFh+tJce8clbgz8sQZcFyxTQSH2DtWeb47ZQjdwq5elKzVu6Ee+7Av+d7voc/+2f/LL/1W7/FarXi6Ojown/3gg9/+MN8wzd8A29961tRSvFTP/VT93o4jwTzVb5URS5l10HM3QeIESKmKuuttILJcDHETKUSM6zHyHqUjdwpVzYxoSf78xgLYxKr/fEQ8DFy43jNp7cDWy+6bFXhdIw8dyxFPcUAxkoeCoqFa1DWsHIN7SRzzGh0rRx0Hce5UGIglUxjLC9uN6zXI1XDyRbGIMW0Zglf0gpsJ5/fnhaON14GXK10zKOvPPt85bnnhfOvQYr9MMJmAyc3IVZ5nr5riaFyuq1YDQdLcK3IAXsHxsHvXPccDwXjppmBseRQZJtQAzEDSdIWjRb7vbWyTq3tWihJPmc0FkXVmsY1PLNc8NTqgM96+k1cXS7prKFMi6Q1Il07DYlYKlf7BT6LTlm7htYZ3nS04LPecoXWWGzjaJ1l8IGTzSALHJIYd47XAyFlnDMMYyBVeOF4JISI1sKDD0E6/OPTIF251qDqtOdS7ryYdN1bn3YLIlKuO6VQVZrWygIQUY1IoFrIlfWY6JxBa9iMiRtDnHhuKcxu2qkpppizXHuhlNUkHcy7TVBzgb61s5WiJ8d0u+6X6Rya72BnI5tWZzz1+eJMBWvlvWOtmgzOZ8PHW4vpZYW31osUzvz859+vl9v9X/lxjwPuuQP/F//iX/CTP/mTfP3Xf/2rfvHNZsPv//2/n/e85z18y7d8y6t+voeN+US4eHs1FfHppEu5nG02mabk/SQXnE9Kp0U+Rq2cTquzSkpopTmpkVXrcJM7rip5zuevb6jacK3p2JYEtfLCidAejZPgooqmpMRYM52xDCmhUmLRtoAh5YFV0+J0K5I0rTj2npIisRSun1RGD30LBys4PgGVwHXCbcsGHFj04CP4G9AtJkOSKOswTvhsgPVamNJYZYBZJ/lZ4zQZxdVlwyYEQoSnFj3eD/zOc/LaTQfWSu1qG401DoviBOh7xWqxoNYNqcKYC3rY0jhHD8QpP/00BrabDUeHRxy1HZsYGWrlNERsSSzdkkXb4kqZLhCahbGsg6dUuNYvSBV604j2uWZWXYvV4H1iLJUry5ZtLORZwWMqrmnIKRNyZnWl5XjtMc7QVTMt5KhoHLEqrGs4MoltlNv+EDOLtpOCRsHnStsolFbTUmJF42TP5ovHQTJqjKadqI5cFYYpi2caMjZWtvRgNEsnuzZLnWYsOeOMFEkz8dzSlMjqt61PGA1Hi4Za5S7yzNdQd7MaoRnKjk68XcSr1qLxPt8ln5f/aSV3VdKJz25ShVbTncE5TvpW3E3I1d0qUJ4Upco9F/CjoyN+9+/+3Q/kxb/u676Or/u6r7vrx3vv8d7vPr6XnPJXg/O82vnBi6gDRO+tFRhrCClPt8jTmEfJQHPROUKIuxVoaTIf1FjorWYscgvusKBgM0T61jL4iPeRqhQqVxatoy2WbfL4EMBZ/DCSJ4fc6D2dazDOEY6PGXLmxjBSc4ZUeGmzRqNYNg3DODJO3OgwVmKAppXjPn4RlIMxg6myhXy5AKaPFwsprjVJ8cZObywFVUvxnW4IODKQNYyDPPZEFQ7ftGFpYBPkzXoaPTWDMTCOUvSPFjIADUMhHwRWjeXNqyVhCu/qG0PIUrB62xJS4vk84KzFasXSGcxqJQ7AhZWgrZLBaCqaddgiywkMISeOupaubckpESo4bYklE2pl1ToOFy2ucVAkZz1Xy5iyKIdKYUyRVX9I9BmfAgrFyTAQIlw7XBJLJobEOiqWthAzHLSWbYA8jByHkVUn0sDcGLK205BSVC5WyyBTISqTgqzR81E6/sYaGlPp2pautSLbC5mQZC0fuRJU5mjRsPUJq9jpw50zsrl+GhT6GMmFXTrhxouCZjafzd1tyGU3WBQbviipLqMdzg8Gcyliltp1u+dt8aJIEcPQWbF35yJtb4f5AnC7wnu3GSqPMiL2XnDPFMrf+lt/ix/5kR9hGIaHcTx3xPve974LdM3b3va21+R159tCkD+sT5ntmGSiHoXvngt5KZWNj5P9OKOqhNanlDHGYPWUWzFpcg87qXzWiLKhlMJ6CAwh8MmXTnjuxQ2xykbyIcnnu8bQUOkbOcGP/cCzL73ES9sNIScKiZQi2jXC0ZeKz5VqDEddy9aPnHpP1/QsbYOPmcNlw+EB5ADXb8KLp3ByA/wGtBHK4sZ1+PRzUnTTKMND5cD1kD2EKAW/ToMm5WRY6Vop5sdryYHZJghbKc4AL12Hm+tCt4JrV6FfwdOHhm2GRoFbgEEWFnfW4komIT+TVYU3HR5grKF1Lc8cHlKqDImt6ygK2saQShY3pnNc6xe0xspyjBBAVdlwryUq1jjHwmhKlS6aHOlaudUP48jgI6djYvSBzXrgZDOScuGw77AaQk4oDKtlw6JpaJw4TnMqeCotQrGlnDkZw7SYotBoUQNVJB62VMk9KbWQCygKKSWRMJaCpmKNlZTJnIkpTZ21BHNZIzZ9hcgMnVM4o6fdm5qjpWPROoyRO8WKFL4QI2mONC4VbRQ5w3aMjCHJIo5cd536rEip1MneLssjbu1+52IsHLd8vnGiUQ/pTNlV6xyloHZD03lByp1UJzFJ+BnMF4DLl6rcDdUz43Eu3nAfHfi3fuu38sEPfpBnnnmGd7zjHTjnLnz9Yboxf/AHf5Dv//7v3318cnLy0It4rTIlP8tREEVJoXK69ejpJNtRJ0rRGDMVCz3pvmAe2uiimFdSyRmrWFjN88ceBTTO7uReVmm8zpSiWR32uMaxGT2qJJZdx9onao2Apu9blkqzKYXrpxustvRO/rw+JhZacTpE0RtrR984Ui6MKaBRXN8E/Bqil8GlNeADMEBzAERRiaQCx8fSkZcIi0N5K2ojlvZUxCF5sAS7nVx+GxlitnYK85JcJ0420qk7A25yXl5ZOPqY8GSutprVouWg7XCNwcdECImbMeJSli3rIfHiyTGL1SGd0dQU0LUypIy/eYOqNf2yo6GSwojpFoScOR22+FLRxtAgkj6rNMVq0hhAK5x1sng4F5SSxMIxFU43nq4xnG4DvshWomXnGMfEqQ8YJX/7Z1Yt2IZcBkKMjFjCkDg46rBaEwzoCsoZSmkktrdUnIZYZcmHT/N5BUYbKYBa45UURGcUzlpUzRwuOjHS1GkPptY0TrbrOKPIVYGSKNq+EYVUSGW3dUfOY7kjcVbW9ykFNYswv2sdQ4j4kOk7R4yFkBJKOUrNwlkbtevE5455fh+VIo3O+QiKOvHupbDLCL+1e7+M67516ChJoHIHJymS6rbd6eO0zefV4p4L+J/7c3+OX/7lX+bbv/3befOb3/yaXqHatqVt29fs9UCuwLMTUSmxKlut6BpLSgU18YY+lYkTVDStnIniFJOCZaekwlLF+1ZroW8b1qNnDGmS6hWSjzijZFWWVnifyAWOupbDg5arK8cQM+ttYrVocMPA8bBl2fT4MJJ8IGvDS+tTnIaDxQEhVU5ON2Sg7TpyTozDluubxDoIJeIMbAZoe3hTJ/y3sTLATIN01WrK/ahVinvVYDdw5QrkRr5uK9ge2tbQ20yqUqRP1uAOxbxzOoj1vevl/4dXREteNay3kWWveHO74NiPWCqLrgVlyKlQW8c1dcgLmzVthbGCH6FvRk6q4tmtp3F6snlbeifc9fEwUrTmGoqT6ElTYiS5sFWJ6JMEexVHKEWWOUTPdqw0TUs63sp2mqalAi+djhOnrzDGklKlWsXKtFRT6K2lKI2tha61dJ3j+GTENFqkozqgq2bV2d25sk2JzlpiLixaQ+ssPmXitAhZulfJ/zZK4RpZnyd0jp5ci2q3eNhMg0jQaG1wRsKjWtvsOF7FWdebsoR7KaXopwXCo5eoh0Urx9lMX08pi0mowhgCucpFYuHsufhZwVl2uCitJD52vqPVE2d9Rp/caUh5WYTFvOFnDopj6o0uoz9ejcLkcaRT7rmA/9t/+2/5j//xP/IVX/EVD+N4HjvMf3A3USS1SIIbtU66VbkldHLeiKMy1elNIbexxmjGOT2uQiqZ3lnKdMYOPhCLrOMKYyTUKvI822CsZhg81MrTtiOUjFaWRQcnp1u2kwa8lg0+get6rljLJgXGYcRokdZVBQtrsRWGUvjE7yQ2o/DaFXnjXDuEl45Fs50KjFuhNNoeTo+FIlEaugXEDfQaupUESsUsJ1Mx0+qwTebKymBK5SQX2lakgTnDYjk5LQtcWTluriPOKlSFdaykWNELQ42FT/uRwk26tsO5hi4XvMocdQueu3nKOMqF4HQM9I2jKtgMhbc+tZLcmZLJKWG7HpsS2+gJQVOMZmUsV/qWm6PHuYbDpiGXwqKVlMUXTze0/RKVIkPOhKjpFnK3Faet9U7LNqFjH1g0LaaBZeeoSrH1kYPO0TlDjAXXGmqBtY/oWrl21EtRRYbDzeSW7Boru0hTxodMpuK3srOyb+GgaxjjgAWuLFu5M0kiP7Wz9K8UfKzUaQGF0fUsL2RasAySkVLJkyVdE5M4gK0ztG5OSlQ7J7Gpc0c8byWaBvk5kfJZAqKzGqVmb8SZa1JWupVdxzsX6zPH8u2Hhpd1zvNFSuuz4WVKBW3Zvf553M82n8c5fvaeC/jb3va21+3i4tsNNuaBhtZVtrNMfLhsQIHtWKYN4QqLoXFihjBGk1IixsQ2yLCpdbKqa4iZzk1b4Y3hwBqGMRGp1FoIgKuVThvc0mAq3NyOtMbRuMx66/E5sxlO6RpD8BEfgwzwrMJlw0kt2BzprGEMsr+xmbTBpoNrvVAbVUkolAX6Doapyzb1zOYc/CTbA65vxGlpFtOg0gFFAqlUka5aVXGfDhOtkia+++rRZOxx0BlFzVFs5f1S9ngeKSqGqhVt35G9R2snjsVhQPctJlRuDBucUzS6MiZQvSWWQoxwtGolnjR6QLF6ZsVSW0wvdy/eD4RhgL5jEyJXOse1xtK2Fp81tUbG4KnWoisS2RoDN1PiWpU8j5gSrbEc9Q0+RawSm7iymiFCrZHPuHqAayxMSxycdfgQsVpklO20yaiZTDBWKZhUHSHJQmStKwbNmKdfbCmcbL1wuJP0r3UWZ/JOHVInKaqqelpyXSb1x1lCoFjU026h8MQ6oKdhuBRFuajMXe5chGWoPxXx6TwfAlg9c/vzRqqXd7yNM9Ny5bNMlJ0ChTs7KG/XOe+4eFXJWS40ly1CnnGvCpPHmXK55wL+D/7BP+AHfuAH+MAHPsA73vGOV/Xi6/Wa3/iN39h9/Fu/9Vv8yq/8CteuXeOzP/uzX9Vz3wvOq0yAlw1NrJGhEijpkmydtncL1VGRk08Ku6JvLYp5O7gMwoSvlJOqUCi5Uo3Iw1ot3+sa2R7umoYmGHwtxJTomw5VM51rcI2ZomQTp6MnVUVOmcPlkiEETscNCtimkZIS1TlOfeR449lO3WpOQoUMBWKE6zfgylIUKIsV6BF0gc1ElTAVcttMXXiC4wiLBM5CGSEhnPbhUgKonIObp1IUlJZCjxbuuzOwaB2owjhkVj3EnLmyWnFzGMkpk5pGFlOoylgytipKDGilOFwuyEmWYKAU4zjwqZcS2cNyBWOMdM7JDknjUDFxXCrLIgPCXmlWB0cM48BQAp0xnNpIUopV3xFGUXKsT7asy4ahKG4OW+HDlRh1ri4aTIUUxZClFfgUcKNhHRMrqxlDZIyZrY/kLFewMTBpoANPLRtiqkQyrZVhpEJx1AtNcmObdtzwQWs5nYaI2sj2nNZZtJqLot7pv2uduvGpiM5FfO4kd0PDUsi2opWWBdyTP6GiJzpQT7k0F1cBSnGU2QylMPgoy6GtdOzWmAsUxq0d762pgedxJ1XIZZ1zqZNHwMrPrnR9xWXi96IwedxNPfdcwL/927+d7XbL53zO57BYLF42xLx+/fpdP9d//+//na/+6q/efTwPKL/jO77jNQ3GmifS8x/k1txio8+u6FpLbkOeptfOGHIRt5s2GlSetLFiZ5YclIJRog+OqaBqpm/EWn3YK24WmdhLSrRod4cQ2A6e4CxpI8XjJHjMoDDWcjqOvHh6yqpb8OJm4KXNhqurBSena569/iLLpiHVzPPHxwQlfG8swABXjyzjNrHdIBz1FCjkOthO9kZjwUwGHR3BI4oQpWH+izcWYoIbgzyPUbA5lUyTGIWK2Y6SFGidFK7NCRw+g7hOS8EDJQHK8+n/f3tvHm5JVd77f9ZaNe69z9AzKAhcQUCcAKMiUdSLkOEmGIeYR65K1CgRAaMmRn8xaDCKScyEwSFBUFHQXMRorrmGmIAkxKigMU+QIQoBGWy6+0x7qqo1/P54q/Y5p/s03Y3dHNre3+c5T/euXbtq7dpVb731ru/7/VYlmVIkKrBtbp5hKYFxq+/TSWKMEsZDohTrp6aY7XXpDYZUgHaix6K0aKRMtTJcgHV5gtcxwXm29hYwzpO1J/A1k+WxE1O0sqzmUShMcOStlN7cAkqJ4Pg9c3NMJjETrTZKQWxiIqSkoeOYTHm61pNGKdZ7ouBxRDwwM6BVs4xcFVCxIcuEETORxQxKj1aBVMfSKKWFz621IdGaPJayRuk8C4OSWMPCULTFG/3sQSlPSM1kZQiBohRpVxdCLXYVAI/zCqU0gZpVFRQ61JKtShhN1gbiWI/mfpxdpM4msalr5XLuN5TZEGrd76DqidZF1UHYNbVvd7F95qxVLYJVX5tGh2W1911hdwLwwym5PJLY4wD+p3/6p3tt58973vMeksLzSGCxs2vRUXt73eJF95AwalLQtbCPD55eaSl8ICFALIYOReVIkwilgjSblA6o8Eqhg3RlJpGitJAaw0I5lFl459nW7ZJoTZbGJATiOGF+MMSHQGJi5ucXmOkNyKOEe+fnqSorNxgfWDM5RTYcErTB9nssDB2JCTglXY7WQ7dnhXtcaxm1c5lATLU06PSFhEEcwGtY6AtbYujBF7AVWAPMzMgF1GoJH9xrccexFtoT0kY/OyfMliiFPIJ0AuYG0I48/Uoyc29gIvM4ByGGditmKjP4qmRhAI/dlOJcoDuoSGJPKEqCd2AtwRgiYNMmxdxChTYi7tUdDujEMdOTG4h1RL8YEJQDNEYberZAeY9TijSK5Xd1FSoyYjDtLFmcMnCOtVkKqs6orSdRA6bzlDhKhDWEx1QO5ysWhoU0oFSOPE0pKkMeg84jYhWBDmSktXKglORQ4tRT1t2OCqmWtLMEK/xBnNP1hKyYKyRxJNk4yARjgEFRMaw8oIhq6uqwboiJtKrnYAKlFb9WsZVr2CDNRKAaTWwOC4dWAeqJRh8saSxNac01I7VuI2W5+vqJ6gnQHQWhVlYNXHot7mnmvFTbu9nP3g6uj+amnj0K4FVVcd111/Gud71rrzXzrDaawO0aFx0WdYthUXkQGrpTqE92mYwZFBW9oXRR2uAAcRa33kPpSBJDohU968lTSLSwBEoXsMNKtKQBZQxTcYzShtnZHg5FHAILpaWjSgaVJdUaqx2RkonL0jrSEJgvS1DUpRgLWhOblF5RsTArXY1pIs00TemuLKVcQoDS1xOMHqamwM3B3IwwU4Z1qaUEJhz0gRaSUSlgIcCgB2vbkrU7J2WCuBC7M1eCiuSGkLZEF6W7DaoM5gdyE5mYgK6HTgsRgcozbECyzgi6XXGyL0qY7/fQShQVO3lCOwSGVUTQgKooK5FEzQ1MtHJiGFmarWlNyIXuPbmL+GFZ0e/36MUx2nuMUahhjKvVCYOJUUH45wMrpgvGVqg0Jo5Fy7YYFgQdkyQRg0GPoBWRToW/7b1IsCYx5aCCxJGbiDQ1eOtIkoTYxKLzbcU5x9eP6xp5EtRKYa0liyOS2DAdaSonzk7e+fqYeyyehUGF0ZpOHovOd5BJviQSUwYfLJWT+RpnPVliRk+WcWRQyhNC/bRWUwhNrXHuHHgCw6Iiqs2Vgw8kWgK+0VLOiSM9CtJLVTuFerty48meThI+nM7KHweP5qaePWrkieOYa665Zl+NZdUgJZJGTEdOenk8W1r/kh8uBBHV75ciz6eNBGitpPQxP6gwOtBKDANrGQwtsVFM5wYVFC5Ihu68ozcomR+U9CtLpI3MmgdI2zneOeYHhfhfDgYMhkMGzjEYDOk7hMfbBO8A03nC0JZsmbf0igqPY1jXryMlAbvoSclDBal5+wBWQdWXMsfsvGTgvpQAvVDCnBcdlByYl82RAi0Nsw4GwAJQDetWei376/aELqgiKZG0Mpns7PalTLPQkzEFJEuf7wodcPO85fubF/jRQo+5HvQHsGWrrNPvQb8A5T1pOydYjw4icrRQN5ZNtzTTWcJjN2xCRzFDW1FWJUpJ6cIHGPjAwnDIdJqgk5SFbpeFqkBpjXIV1iuUiSnLUurC3tPJUiaiiCyJ2TgxKZO0xZD5omK218XbgjRJWZe3mcgTIq3pVyXzgyHDXomJAtp7KmeZme1TBLF0K21FaaURh+BJYkNeSw1rBUPrpQHMMNLI8SHgnKVylsopuoWjNyylG9hoWcdLY4tSi0qZSSzGGLFmxFYRplQz16PrtnUxHmkYVQqZXFUBXN1yT31FVHaxEcYsKZvsSpdkKX4c5b+Vmn32FR5twRseRifmL/3SL+03olO7C3kUFNpUI4Y/LEXEp/nNdN3S3HSsaVXPovtAFJu6jVk6D+WHFnZBvxSH+CyJsbVxbGUdM92CwnoqH2inMYW10nmXxgRrybKUNJZH+ygoKhTz3R7zVYmrSoIP2OCoCisypAqq0hOn4oV4/9Y+lYeJSXGqaecQTF3rTmRiLK4pf0SQGsmgt22TkoYOsA35PjJlJYE7Q7Lwroc2sA5Yj3RgVkPJqPuVXNyTLXntEF75sCs3B7RMhroSZnviwlMOxWFn6zaYmYVBISJWeQuiltTbTSSff7DfQxUFc2WBU6BVYEMr5+DpnKl2Spq3cL4xzdBE9Q05jYQTbkJAac1kZ4KN7Q5Oa7TSOMT/MmjFZJYynWUordk0OcXaXBQMlVL1b+oJWrLNNVmE0VqYJZlwz7tVhdGG6TSm00noZBl5nmJtoNVOMCi6pSMgwlFaKaLIoIFB6SgqOc8MQhXU2oyaxSIVGFQWKQdJQlDVmjyhbhwrKktkxK5s0RFHzuM8jetzZlGOtrkOmmRGpGI1IFo3aWxEwz4yKBqOeUBRGy3rhgwgk/eyvV0LQu1JoN/VNXwgYo9r4EceeSQXXnghN954IyeeeCLtdnvZ++edd95eG9wjDeelFRgW9RmUUiNjYGmZF2f20ovBq6v5wK0spqosSWzoFZ44qiU/4wjrIY6k+ac/tBRW6uaRVqTO0x8UaKPpDkq0Cqxpp8wNhFfcLwscUsO0SUxkK0otLi3We5IUUTsMChVHdBTM98WbsirFXzJPFNtmAlpKpcwviH53aUXCdWpa2uP1rGTkdiATnm1k8jJGgniMMEhMXUoxwIZpCcaRlqwbpBTiNWBrbvm8zCv0e1LOKQfQmhbKYn8GMi2ZeinNfOR1uSQWkgNZKqyWqhBZ22gIZVox1W6hfaiz1gzrK7YuDBgM+iRRRKY13aLk4KmOKPkRSNH4yDIdtUmNoXCOTpbJI75zWJRMOCvFVLtFXCgipUjjnNnhgMI5MmcZIEwk5T09a/De0Uot3hkKpciNIUkN3sQEr6TjVWmSNKGsPJUtyeMYH4ZEQTHRTlkYVnTSCOcbgp7CRJpeYTH1eSi1bAVoPIHKSl+CDnXQ1cJGSWptb60YtchT17ylpCElI++l1LHUrGFpvTpLDIPC0lisxUYybVNrgzfljpU52rsub+yrScJHY7ljX2CPHXmOOOKInW9MKX7wgx/82IPaXexNR54QAoO667Hp6PLej/z/ljYvKKXoD0sWCkva9O76gFci0t8bWik7xIYsEVEh7xz90mK96INXQZTnEqMpnWNNnpAmUkIZ2oB1jq1zPbZ2B1Q1z9W6gpnegHUTHQpr+dHcHAaN0ooH5/vkRgJer6YGtlJhf8SRlC7aLbEh6y/AzJx878pLKcM7yXCHQ1mukfKIRwJ1H8m+D10rZYw0kqy5X0iAzdsiVpVEMqnZL0RGNqlvGkndHOSqehIzFt54Vd8JpqdljKESN54oltJLHEnQn+wYFvqObVvkvQ3rYNNUjtKGTtYGFSjqMpNznk6c0G7lQCCJYjpZBt5ThMCaLGNgS7wPWA+DqmIiTciThK3dLp00JotiSu/ABZIkpqhpNTEeHcV0B31m+0NaWYoyMbiKTmRYu3aKonTYsqQz2UErmFno4SvH1GRbKJ5lSWxi0SxxjjXTbRGEAqZbKcYYkkhRSSRH1x2U1nqSxOAczPYGMqmbiotlK9FM5CmRMSR1E0tg0YS4OY/FOCSMBNjyxBBHEc77Ze43cq4v1wuJa6rg0oy9uXasC6MsGqhFr5a2y+88mO5N95vVdNLZW9iTuLbHGfidd975sAf2aMfSbADqR866VhjV3n/ymFo/gmdikQVi0IAPBCW6GDO9Ah/JI2hRyUTnsO6EEZ6uJo8184MS5WEmlORW6p/BOynNRBGRkgmmvh2yZTCkCp65/oBgLYkxBDRpFJFHfaEAxhLgskSCdaclgTRUwg4ZDKTbkkocfpSGbiFBNrKixT1X0wYDkCAc70mkFPLgNlg3IY04lDAEktqwQSmwWiYvvZcMetCTIDxfSlmmrOSkU0l98mXCTc9SydBVJHX4dkvKJ61UVB67pcNbabuvLDw4A6UdcPC6FjPdBQ6ammSgDEZDJ23Rq4bYbrfmlheoEKh8II9jMJo1Ud3U46ThxQbP/GDIRJJgtBbuOYY0DSwMSxaqirWtGIeuG5wUXkGkE1TwlN7jo5yiqIhMIG5nxJGm1yuZbGX0hyW2Kigt9ApLEjmmsog+ivluyUSeoDUMrWMq1pRW0uEoMmilyBJDoYCg8MGRGMPayYhBYYmMuBdJ05WjqGTCMqmDbQiI4JX3DEuhF4YANjQZuSQIjRaJUjAo3Ih1FUemDuB6dL7v7Lp5qCx6Z4F8b04SPpqbbvYF9jiAL8WuJBn3JzTaEaFmLIjrtbQiB6VGj5lKCf2r+UxAHkEToylcLdsJ5LWQlUYohCYyrEniWvsk4JGZfY1iWA3xZJQusG1uQJ5oojQhjg1JFDPb79KrPBN5m/5wiPKWrnWUrsKXjnhqgkRr+pE43AxLccgZVhC6okWiDSwsCNtkdk6CcieGHxWSbSdItv1gJf8OgAoJ2tNI+WQIzADlAkzVeibrcyl9WCVBd6ErwXmqIzX2hZ6YQ9gh9Or9ZJGceGkLMidqhbGBTlu2k8eSxbdTw1SWMXAOUzoxOcjEX3PWSTnlgdk+6/OIbd2etMenKf2qoD8spT7e65HlOQvWkpmYIjjmFhYokxSlApNJxFAb5stK/Ey91LbxgVIHet0hXVuRmoiF4QCjNCZPibXmoMlJumVJhGKmKEnjGJ1GZGnKoPQEa5meiMXzVIlxQq8cEmmFUYrC1xKxkQIN/UpKJenSgGk0ioAPqs6UHSkashjvAp1J4XlrrcV9vtY3ERd76gCmpSXf1ROiqq6Ra6EwWivMFO+l/FJWEryjaEmXZq1vsjN9kZXKJU02vNR6UCZJV6YT7o2yyaO56WZfYI8nMQE++clP8uQnP5k8z8nznKc85Sl86lOf2ttje8TQdGJSKwbGRrwHm0krWYfabFUEhYQXLrP9ob7LJ0lEVNO+lBIZz7Kq5GT2nm5hqVxgbqGPsxalPNZZBoWlNywoi4pBWXLv7ALdhSG93pDKVlReUboKW5ZEWtPzCh0cqqwo8Nz34BzdUoK3DfK4XFYw7Anjw3oJ4kUpXZhJJIyShUrKIgVSh25H0EWC9RQyaemRycwH6v93gAeBLVZuBpUV3nh3XjLodlsEsJSqbyAAVvbRRyY3S2E6Mj0JB28SHRAViZ1aZiDPYVBCd+DoV3JHiZKIEGDQl+YgVYtfeQt9Z+mWBYO+NDQNBwVDW5KiGCqRM4gAHyrKouK+hR73zM7y4PwCWwaFMCwItQSqprSOobO4qmK+sjivKKzQOL33DIshWscYPNo7KmBtlpNFGqcNwwrWtjTtPMY6Kam1sgilDe0sJdaGLE+lC7MssZXHBVH984hLTRJHNeVTuiNLW3Oyg5KbjHW1Nrh0XLZSU9elpUGsEYdyzmNrNkocS4dnUTmsD7WCYKh55oFhaRkWFSASvCMDk9pTU29XjljawdzUvJeyQZpsWGrwdXObFRbXrmRcHw72JyedvYU9zsD/+I//mHe961286U1v4uSTTyaEwL/8y79w9tlns2XLFn7jN35jX4xzn2KpTrGq63+NtGYcLWYWIMGxOfGaRp4k1niv0drXOs5SdGynBmsDlRtSVB4d1VKxKLI0xRjN/EKfmcGAVga6KOhXJcoH/rsoUUH0KHTwpMYw0+vjAELAuQqVJNh+yVx3UUgqVNI0Y5RIa1okyBUDKaXEBrpWuNwaybIngVYCgwoOUVLyUBpMIUF8Fgm+MZKZt5BAvA1oV4vLUwtT6aKkZxQLNbBnZT/TyHgi5KIuhrXucwp5Upd4guiuxInU0Utb0kmhk8TkMWydEU2WPJObRJTLTWpijSFWipnBAG8M03GGU4HcGErnGBYD0jTF6IQkislNjMOyUHuTVrYkiQyRiekPhxACcRqjUMQ6UDoRASuKHnkyRWQ023oVcRwzEUXkUUSII4L3YBTKZKRGg6kIWSxm1mVJnBjiVITM0sRgdITSiohAnCfkSVSrBHrmS0dWC6NFRolgWGQYFBUmUiRRRAg1M8WYml7oa162oqobnXRNc3UeYqMonSQdcS1YJTd4U5sj+xGVMDLCqVd1GW/7SciVyxXLNVCUEnppVPvFNjXp5nra2+WNR3PTzb7AHgfwiy++mA9/+MO86lWvGi0744wzOO6443j3u9+93wXwlR+75L3t7+amPtmaE6SpDWotgbY/tDJhpBuOrZJSiXXSgek8eaygnQkHu6gorGRI/aKgVwwJ3qGVIo8z4SY7h/KWQQj0q4rhsCBTMFAKo8rRpGFhpdOxiqE7I8tMKi3mQyt16dLKn0HKGQ27PUY42i0tZYkskonGIZJxV0gGva1+bZHGHoOsY4ApJdTE2TmYqFkomYYFX99E6uMd19uLkNr3yGYtyLasFeXDVi6qhUELi6WbVExOxHhVsTAnATyOpXFIaSn1ZHHCwXnG1tlZ4iyB0jLb7xKHQEGgtJ48c0RRRprn9CtPYS0tYwBDr6jIjWil9wZDiqqgExkWSikmLfTF1q5yAessU602/dpgQxkZRJQY1nQyFDDTLwgeiqoSKl4WUVUWR2CinZFFmoELeFfTR8OiU/uwrORJL44oigoXFHkswdtrTayktGKMqXV3RA/bOZlnGZZSgmlUCL33WC+TmnkCE5nBh1qbZNRRKewWVTetGaXJU6EWbl/y2FW5oqmLN0G8qud/miy56Wjek/LG7qz7aG662RfY4wB+//338+xnP3uH5c9+9rO5//7798qgHkk81ASMcML9SErT+1Brejfu3bU5rJdGjBDqZghb6yprTTHwxEnERBzTK0qGhVxUsVHMDiwOxbp2i15RUVpPaUtaUUQZOby19IohWmvacUzfFZhI4xTYoWduKI7sPkBioJNrqsIzH8T9RgdAS9nBewm0ASmfzCKB9CAWlejak+C3QM9JMI3k43SQDLusj1kX4X+HehsaybYXhjCVg4ohlLCgJBC3ezBfKxnaev1aWA+tpU4+jOQGoJGbiU5knTwWAwmUdAJPZhHDoaWVSZlFa1nf+UDlKiqrmGx3KJ2lCJYoKKI0IQmKXlVS9Pq0UkekPUbFTGUprTTFVJahVjgFWRRDFiiKiqG3aKPoDis6SUqepvQq6XhMIs9kGpMkKf1BSWQcU1kH64NIACMTndZLHSFJIzppxLCUgK6NIfYWV4uZGaMIwVFZRF8b6RnQRjMoKpQPxElMpqGwDqNNTX+UBiBRzIxx3tW/DvQKNypvaNU0rQkzKokbZcEwqm+HEMRmbWS8sGOVdWciVduXK0aa42Hx+mkklvekvPFw5FwPhOAND6MGfuSRR/K5z31uh+Wf/exnOeqoo/bKoB5pNC7ZKz12Ga1FHlZJFhJQtaWUr6U3pZ5njKGVSd0yiyOUgrKW8ksjQ28wZDis6JcVeEd/WBCCJzOGvrU4rVmT56RRzPywYGEwkElRICgtetWtlNgkmCgmiiRTLp10WPZ6MNf19IcS0JJEAqktJNANrGSp88DdSAZex1Qma1edYgjpJEy1YWNHAnemJHtuA0cAE0jdPKv/b+ptzko3Pw6xSyus3EB8AOVl8rJLTUdUEnjn50TcSiE1+6KQlv+DNtY+m0Zq7O2WZNzOSb3bOpkYLWqHIBOglSYMyxIzetyPiLwjGM1wWNGthLo3dIHZXp8siliTSzerB9AK5R2Vl7mLySRhop0z2crFPCGKiJOEoixRwbNQFCwUUtVXwNqpnLWTbWwIFKWlcJ6iqqQMZsRdPjWKLE2YnGgxkccyqWeMmDHXNew8STBajIgrXz/tBdGZj2NTK1oGEqOpfCB4T5pE9WR6qLNeOUe7Q7Ffa8wUpMyyWALUilEX4yh4myWdltvVu5fWvOX8Z6fXTfP5yIjZcpZEZImp5WhZcf2d4eF0aq62xtIjhT3OwN/znvfw8pe/nK997WucfPLJKKX453/+Z7761a+uGNj3B+zssWtplrEsQzG6Ni72o6wmjhcnfQKKCIdRBgtiqou0N65pi6bF1m6Btp6JzNCrYophiQ6eda2c7mAguhJxgjKGxIi07PxgSGPCG0cGFzkGfSklUEmwDpE02pT1BN/WgfzIiYYH/OJEYkAyag8szEvG3Yokk06bbs1EbNQ8Epg9Uv+u6s+2kQxgrn5vXSSt7wShMOaJlEzWroEt2yT7nqoZKiAem501EoDRUjsfWGn0yVLZt6kZKr6uj6PktanHGtVmyrrmMcdRhPWBTGuqJGehu0DfSfCsIvGdnMjbDCvLRByDVgzKkkgplDHgK6w3VMExqCztNGUyVfSLgmFZsa7TxjsHwTHZ6jDwHlU62mlEniWoAL1hyVApbBDdcBfAVpZBqUkimVD0dfdlrIUxkiUx/aKick6Mja0Vtx+tyWJFEsW1jrcoDIrvZKCdi8IlIQhNValRGSWONEXpiSKRQXZeJkiblvumLCJdlyszyrY3Il7qOu9hSaa+82A8UiXU+iE1v1fCnjJLHs3mC/sCexzAX/KSl/Bv//Zv/Mmf/Alf+MIXCCHwxCc+kW984xscf/zx+2KMjxhW+qGbLMHVmg9KSaaTiHr9SDzeWtEFt9ZT2QrnAmWQwFGW4JB6QSuNGJQO7T1p7bcYqz5ZpMBrtvaHrJ3oEEURtigpUAyqUsxrgSh4AobKe/q11kgtgoiOZcKojMH1YEtXgrUFtnnJuktk0rIJ3ncj2fEm4AErNegpIO7JNqNImCsgmfZaJPsOLGbfFsnGh3WWb4e1pkollMayEuqfq6RpyAbAyf6rPlSmnhyOZJ9WwXRdHzd1oT41MHBSdsk7MmHbnxWbNhVga68rajW1XrevG0/WTrQptvToFoFIVxgDnVZGYT2b+33WtSfBWwbK0DKGwlUUVUE7a4n2SFFQKUUrSXHeEQWI84yJNMI6iJTBeyicw3YHxElMnopRtAoilaDxZLEhjTTD0hFFGqU1cQzWyc2/abRxXrRX2pkEZtEkieuSR5NkiO6280FKLxr6dRNaEil8fR5HWqESmYtpujBNLaa2Ura8EpY2xXgPaie+lXuCPVl/Tzs1xzzw3cCJJ57IFVdcsbfH8qhEUwv3Wmhzjc5DI6AvjBBHv641Ns7gWmuCswys1BTLgaUqHVudZWFhiA0e5WHgKoqiEJEl54nrEgw6YraYZ+gDa1s5sTEc3GnRD4put4e3QSbvSgmWLgB1rXtYdzc2wbtRDiyRH7yWIyGpv2OMBHeQicohwhhpIRlxVm/HAZsRYSuHiFiZ+vWg/sywXr6xnjydryRjT0xtBgFUAxlQUT8G2HqGc80kTGei32IDJEo4+PNdz0SuybRmYWBZ6Eqr97AS84nplnQeJtpQWstct0JpWNOKCU7TyjXDOU/pJNufmVtgeqKNDQl2doapiQ6JVmzp9UTGt50QvCWNInyAltaUWqOD0OuyWNMvHK12SvDiJakxODzVoCCbjMmzBFNZclVPaDsHWkmWrBWqsrRjjYmF8ldW4nNpYo0KUFS1ZrzWNAJrizXpuisSOR/LSkp47Uwc3itrRbPH+3qeQcp4aRKtOCG5M2yf/TaGEY3u9iNF0dtdZsmByAP/sRp5DhTIo6smTWprKeRCdk5srYRyZQjBUrhAYgyD0mKtZa5XUFhL8AoULMwMQGs0in5Vce/WWQrlWZ9nYtFmIvlXGaIopmUrMBFKaeaqikQnrJ3u0H9wVgZn6iabnmiFVGVd/3bQnLIZUu5IkBLKXL08qpc1LBODBOGoXn+h/qyq31NIoBZVbbkRTNfbKoAtyI0gRgL2oJB1YmC2du1Jgd5QtucRjXGNlG9MJEYQw0I6SS2Bqgx0WlAF0KVl2ywMulLicV4s2oTy6emWHhOpWrEQIl3hgpRmNqxNmO+WFE6Et2YWeky2PVGWs6XbY03eohVHzJUWPRiSTkziXEUrSWnnCUVZ0S0KeqVHYcVYmASiiE4a43HkUYzSGcOyRGtNK40J3mN9oFQiV6C1OMEHLTepVmTqkobChoD1dYCt9bWl87EpCyiMkUadhrLXdFqi1EjP29a631makNb+l0lsVuyifChsn/0qWGY+vCcUvR8niO4us+TRbr6wL7DbAVwMfHc982sb88OfECy9qzfiVtZ6ysrJSeWC8H6VtNcTYK5foLWiV/tgRloR5ymSPAV85SiUCOxHWUwoK/ouYFDM9XtoExEPCoqyYmJ6iuHCHDNaE1uFjSq6s0OGpQhRVVYy3VBK9cAimfN8IeWNGAmuHjgognlbd0HW7/VZ5Hhb6olLJFBvQC7YgYdJDffXTJZG3EosKhZ54ZuRbXeALbUwVWCRjtiMJao/W8uuCFXRw9w2sJPynea81OAnpuSmFCUelJSIknpSs6zr87GO2DpfUlXgdcBaoTAOCynDZAb6w5JIKlYUBbgY8rIi7bQpbSDC41VCHgW0NlTWorSmlSgx89UaHxRrsoS0lWAri9GKiSymW1VkUUQUGZIoIs4TFvoD4lgTvMZVDluII3RsjKgeViKtMNVKiKOIbV15LGlnCYPSomujPq1VLX7lybOYlVzXtVZEQWGRCVStoJUnI3nXpXM4exrMlma/WitivVwHZXeun71Vk96dz4154DvBQ+mA33jjjVx88cU/kTO/S+/qQlWTIB5CoKxEV2JQOsmgrKOyVZ0RaRKlGGpwOiKm7rTzgUoFsI5hED1rpTW2rJgZ9lHWorWlCIpuVVJtm8FpiEsHaUykNJVSJLHUI3vzkrXOB/kx12WwbbCo4d1HsuASmLNSq1ZIFj6JZMxRvV5Rv+4g6/WATbk09MxZCfoVkrXn9TYSJKgXLLJTCha53kvPCF//zbAYxG29fu5lv7PzkK4Ttx+lxKdTaxjOQZSJ0NVwANSZYFnBfK+knkIQv0+oqZbCYKlKuSmEOts3WgZdBIsrC4yO8VGCcgWRiVBohsGzLkpYO5UxN18wKKXNfWgrygWZTBSfU4XyYmw91Vb44KlcIE9isarLYlo+UFpLVYkCYKQMqdG1/ok8i2SRtLWXVurlpXU47whBfCldzW4RZUxfM6Oa8oqCWpY2Ngqloh2ogUstzvb0/P9xeNWPdE16zAPfCc4444wdlt1666284x3v4Etf+hJnnnkmF1544V4d3KMBzQXS1BrjWvS+tJIVpZEmGBiWFh+aduJ6lj42RGWEJ1BYiy0rtIbMRAxcSRos1hiqqmKmv0CeZAQTMSyGZHmLllLM9vq0I4NNYqr5PkVL6q5VKQEpz2GurAMTsG0owbOLlDfWRvCgraVgkcw6sDiBeRCy/gISoJvJySbD7vehHxb5202gn2QxCBsWs3FXv58gATliUVdlaXBvtFWKej3q19MpzM5KMM5TUUdMknq7XWG3oKV1vyzFxHhQykSm0nXZKEjnabtV27u1oZ1pts15qgCbpiPmB5beELZGBY9fl5MZxVylKIoCnTg2hDZD55hfKDFpzASK+UHJTFGRaU8WR2I5pwzrJhK2Lgzol57pRKOcFWqfMiI5qwN5FFHZEuscncyQGKGc9ssKHRQueOLIkEcKH0Q+2Hk5r0rnUUHkg8u+qzW+vdyU6uC4SP2L8HUn2lKT7h83E304wXA1a9IHQvCGh1kDv++++7jgggv4xCc+wemnn853vvMdnvSkJ+3tse1zPNSJtJIspTRKiDyntb52MNHi2q01qVZkkWFhWNQ9xIFOK0Y5TxnARgaDo5VGbFFiURW6A6zRtJIU7z2Fd7TynJmFeSrn6eQZW+eHJAPHwIGdK0gT0fSemZfdrGnBbF+CcokEO4UESlWXTBQSVDezWIv2wH1IYO0gGXUjHasRNsqsPLGzPoWZQtb19boaeAzwIxYnSCsWSyN+yb5yFmvt00gjka+Xd1iccJ0tFrXHiwBVC4wVSdlgJBvvzor07NQUaC/B3hgIVqiFw4HwySMRHmQiz4m1ohM7tgxlTmJtO2OuGJLEMUMPcfC04pjCO3KlidMUqiEzw4KOl+AZa00njkWzPDaY2JAaw6BytLIUrTVlaTFG0TGGQKAvNu/EsWFNlNWG15DEwt3GB/JWgreablHhg8IoT2xkzqQ3FFXBNDGUlSfgiYyqVQUteSL0Qq+FDtjYmCmlSOOmI3J1gtmBWJN+pLFHAXxubo73ve99XHzxxTztaU/jq1/9Ks95znP21dj2GXanLrf9o59HeLWS1UjdUSohnsL6ke6y8544jgl1k4XzCpNElIMC5xylU2yd71JYRyuJqPKENAQCioGtKPqerb0uwXmsg7nBkEhDr5CsU8e1OUIpfGhthMWRKxjWdMKmTt1FAm0LCZTbkCAKkhU3fHDH4sRk8/8mU06RbPv+QrazHgm+GYsToA3zRLHYMq/r/YNQD5vg3jBf0vr9ZnJ1vv7/LIs3F+9g8xaYasHBHZicEDEm66TF3mj57rYSKmIUybFp55CmsKZl6FnP/GDAY6cmqXSgXYpVHKqkFSliBXO9AUkcU1mHCYo4TYmCo6cULW/weEqnKJ0l0ZpIa0ogs4GFYUEnTYhiTRoblBJnd2HuibdlYR15GpEnsZgjqEAeGVzd0ZtEBqsULRQajwu65rtrSiVCV81Ep1LSfWlDwDpQZUVkjHRv+oDRejlPe5VrwAdaTfqRxm4H8D/4gz/gAx/4AAcddBBXXnnliiWV/QW7qss1TvWNl2Cz3lIhniyRx9hh6YkaEXwFKE2kPQ6IjRFHnRKGpaffL4nSmGEVGFalqBkiTIMt8wMG1hFUIKqc1KtTQ3/oWOjVE4KxZJpOw2QOQwMTbbjrXtHenjK1tGtYZJVEyP+bLsimJt2UPVIk8x2wyAxpMF//O8ty4atpFlvtYTHoL4VFgrxhUTOlMURW9XgaTZUt9fYbPrmrt22AXoB4KG4/Cslmy6J2AOpCLxLGTaclnacgJs2xhzLA2ixlGDxBafAwkackKfxoW4HLICmGlEET9WNakWEizymLir5WRNRaNpWmKCsWhkPWtRJKIqKgSCcTYmChKGk5cW0SwnQgizVpEpMl0hWZxhEKRZIYIqXJEqltD0sncyd1K30axQwrR2UDWkm/QVl3PxJCzXWXiXSlFcMqYJwliw3eiybP0nN2tWvBB1pN+pHGbjvyaK3J85xTTz1VdId3gs9//vN7bXC7wsNx5Nkd9xDhc0soa1p/G+5ts41mXdFKEbH8QelxzlFUFus8W3qiLIiSx9pBKXXOhe6QfiXSsPODPoNiiPWezfNdnHOsmeywecscZZ15/egBmazzWjLMSAkLQ2vwShpmevPS1FMOZZKwyazbSJAs6r8ZFnnhTbDUyISlZ1FsailaSDDuIQF/Q72duN7OViTYZkiwBwn0TS18DYs1+qV6LN16bJ16H9TbSJHGnVlXl1+MZNQTLfm3dKJIGHxtGFFLByS56KkMavehyMi+Dt80IbzxomJ6osNgOGTOWnq9Icoo1rXa6ChiIoqYaAud0KMItqIE0ijFOUseR6RpQiuOaLdT+fYqEJwnTwx9G2o9b1AYOq2ULNb1+SDWbypAkhhaaYxzntKKCJWv2+ON0QwLS+UDsTEEfK0JrogjmYupnHDPq1r+VgF5IhK0zjUaJ3IvadQBx9h/sE8ceV71qlf9RNxBd1WXa7LzONJUNV2wURdsTB2AUa0RavVBHQGWYenoFtCvPM46siwhQjHfHxC8NN/EiSH1hhAcBqHQdfuFtEnHEZtn5ti2IJN4Ayv1bmVEx7vXFw2UWINJYM0awIv2SHdeSip9J8F2PYtljGbCcQNSs27ofc2tuOF9bx+8YXEC8xAWyyutevlM/ZmGldKgyd4bdkrDiGkC9VbkBjBRj2Vb/V5zQ5l3i08Isw7Svmi1tFvyF+taNkDLRKsLkpUbLfZuSSQ7KIcwPxyyrtWm6wbY+QXa7Q7TKiJqKTFUiA2ZiZgrK1rxkLy9jqGtqII88s+XBetbohpmFJhEFAKjJMLaQCfRDCpf+1V6yirglSNPNNbIba6VRkL303X9uw6wWRKNzkGAygayNMLY2lTBGGJT69RHhjgKUFQEr4lTI2WfWgecEB42T3uM/RO7HcAvv/zyfTiMRxY7q8ttP2uexKbm1aodhHQWSzC1FoeCYDQhaDHF1ZqpdsagqCiCaCzjC2wh1ME0NngrV9q6iQlaScS9MzP0KsnIqkrqvFQiTuWd6IFksQQqr8APINRdi51M3HCsW2R+3IME7AdZ1DFZekk3mfgQOBQJqNtWOF5NmaPhmDea3nWMpGAxYFNvM6+3P6zXbzpCu0iW3iwbLPlchAT75mbTjKepiZceokKYJTqqJz69TNQOnARvh2ibEwuNMM5gYViRRgMyHbFlYch8t6DVTghlyYKHTisnbRmiYClVi6KqiI2milNyreikCldT+UrvicoS6wOx9Uy2EqpQl61qV+ZOK8U5z6ByaB2RJoY8jUY3/Ob8k6beUJuDSPs/CD0VwHoPBNI4XuZDmacxSllCUMSpWtzukhb5n4Rka4xd44DsxNwd8SqtFa5umw80Sm8QnK/tq5oLSpx6tIKirCidk3prsJRlSX9QUnlPGhnyPCUxEcE7PIFt3UAaRXQHA4bW4tEkoWLoxDpsMBS6YLemBhqkKcVVkmnP9WHbD2AylSCbKgmOs/WYFRJYm/b5/nbHoeFvgwTTUK+7s1asWSQwN+WZOXasfYME3JLFzD0ggbpgsea+EhaQjLyot9ur1+2z2DVaVDBdLeqRT6TSeu+9BPY4Ft/PXk/0xGMHkxOweb5gXTtmohWzbb4i9IR7aa0EcOccE50Ok1mG0gofNJ1Ui1Sr0cyXJRN5ymSWErC4IqAjTbdfEqcRBE9RWPI8o6osE3lcN/+IqNlSA+DFCfTFpz5o5HUVRV2+M1oTaOZolh+rRtBKKTNKIHa3RX6Mnxwc0L/4zsSrRLinbh9WotWslHByKxdGzicgwTuEQAC6hWNYOfIkAg1z3SFBKdqtDG00WkV4rfBKU1pITEQaJziktJJpg0XYA95Lbdt5SGPoSJMnc7VW93y/fg38dyFt630nAXsp17vueVkRxZL/34d8dqWA3EAj2XxRb7cRx1q6/YTFrJt6DLNIcB7Wn8t2sv2ExRtQhNwsqMc0QLLx2fo7N08AxtSBL5J9aS1GyDoSup7R8mTS70O3V+EUTE9GhAjWdDIe/5h1JCGg4oS2iSmrQmQMtCJWUn92eDppQmoUSkNpNcPKoQL4SNPrl2I8nKUMixKjAoX1+HrKeFBaesOKsrK1n6qquyTrY+QD1vp6AlKRxlEtzyClEeeauRaRLhZbsoYsGvZI32SMnywckBn4Q2Fpdg7gtcYHMXIIQTJfGg3p2tfPh0BZiBphFkUEH0iMIm9npErRrZXiKuPRlaOqLFVQTLdiZhaGKBMTBzA40iihMAVG1Z6TtUOOzqGYX+yi7CCBVCEZqmWR550iQbUpTwzZPTxU8IbFTsr57ZYtRcmOaCYudzWWEnnSaCZXs3pZQ1FsSjdNHT6mdvCZh3XrIW2LL6eNJYj3S9FMibVk4j4GN6xI85SJPKZ0jtnuPDpKcHaI8o7D10zV3YyQJglxYtCIvohTclN2wGQrR2mF9o2UgqYVa6yVSdZWrESWN46onExyKzRLfRvF9qzOtk0teqWgLKQpzDWqikbWq2DJ52VeRKF+4hX3xtg5xrftnaBpgGgmOrVSwiJQCqV1PXEkF5N1ARNJi3MVPGlsCCjaSUyaxTgPs/0B1bCilUY4D8FaHti2QN85rC2pqgqSlIlWi6nUkOeio62MlFFm5yVYNqJS25DAvQUJcl0kO25og4OdfK/VQDMxme9qRRbLLSmLwb7hm3fq5XPId11ANMOdF3OIYkF48tZL+ckjnZwmgg3rFKGSm4ApLf3BgIVuSbew9AtpxV+Tp/RdoCxKYmOofMAQmMgTptoJkdZEUUSqldA9jcG6kkQpPNAbOiZbOWkErVgTVFTrxgulFKVG5ba6z4s40qQ1h7wRjEpimYm0zpNEGudrA4U6y7ZOFC6bycqmZX6MAw/jDHwX0EouDpnElAkn5wJoT2QijJb2l0EhzuO9QUWfksRoWi3FQuFJU8OUj+m0EnpDEeXol0N+1O0zLCvyWGODpyot23pdrJfH/ziCNR34YV+yXo0E7xQJXgureWD2EBUrM1xWQqPPUrFYDgK5SaUssmCam5ky9ZPBANoBWpk0NeFkvqBqQ2kD7dzQHziG2hEHaE0khAAbJ6fJkoShq/ChYt36CcrKoXSgXyi6ZZ9WlqBDENclk+K9o7QVE1mORzjZIHKxsVF4FIZAYR1ZFKG1Fm/KuvYd6R3nYCKjCDoQoyUbR4Kz0c3kZLN+oKrcsiA+nrQ8MDEO4A8B7z2l9ZIxB9GgqConbdXGEHBiAIsiiRUExVRH463Feih9IDaBydQwkbbJk5j+cA4fAsoktFNPUQ6pKuhWFdvmewQPvUrUBac6oqaXGFjjJIApavEnJLj9ZGk/SrbdRoL4UuXCBs13bzTKe8CUE6GrrQNYqGCjF2pmnEBnSuYSBilMJilZGoiVlrTcezp5jvPQtxWR8+QTkcimRgZbWYY4skgzt9Aji6WkUlWWPInII2hnMdYHXBD/SbwnjSJxVNIQp7E4Gjkn0gtL4uxKQbdZZsxicG4E0yOjRxl8k62P6YIHNsYB/CFQWhHET2KZdJQ2+lA/SteZOE1TkEIbcE5ROIhjBU6zpTugcoGpVkq/LPHOCn3POfplQb+wdIcLDOvWRuuFaeIN/PABeKAmVzcMEsciHXAK4VP/JKHRD1/KjtkeisWmoXkAD1O1J6cG5gbS7DQxCe1MOOEDK36audK4WLEmTRnYim6/h45TWmjSNGVtnlMMBqR5Cx1FdPJIfCgLg4o1k7k482ilWT+ZU/mAH1ZorZjIm0lHR57GtJJolAQ0fQSNk47RKwfwJitvqIYhMKpvNyWXhnEy7m4c44AN4Ls6+b33wj6pVeEio6mq2k1cG1wpeuAERRJJcLfWM9MdMKhErS5qBPm1BPoklqaNB2dm6TpHdzhkoRgQo3HBiztNqPWqkSaUjhHe95ZKslPPYk25FubbYSJxf0dvF+83DUFrWKz9h0KYOoUXM4jJKaEUxpFYqKXeo3xgITjW6ogqeDpxzBZbsTaJ2TQ9DcEyXxZUXlP2ukIZVDHD0pFnBhUk67UOtPL0i0r0X4Jo4SRaE8eaJBUVwhBEjiHTetT4FZA6eDBqmcHCSvo82zvDr0R7HePAxgEXwHdXYF4c6C3WSgt0WTlqJYqRG8qwcqSRJoljfLAMBpbSg7WBOVeivGdQedppxFy/oCgqtiz0mStLesMhAUUexXhX4a2UTgZdkYj1DtqT4k05qGQCbxuLHZNLaXbwkxnIHwqNyFajaT5P3dQDpFaCbJqIJ2ekC5IkJqhAW2mq4EgrS89o1uYt0jQmNobSBuIoZl0roXKeqG7IUpnBWUcni8iSmGFlydKErPa+bGeGLIkgBIwxtY6OZNGhboF3Xpq3GlgXiMxiQN6ZPs84YI/xUDjgAvjuCsyHEESDQtUc3Zq/q4105XkvuhdR7dTjvXDBW0lCGjnu39ZjWFYoH/CuYnZ+yMBXKB3RydoMipIqBCbbLf77/jmqANMTtaiTlXbxflcEmcpKJuw2sigX29D1MiQjPVCCdyM9C4uCWnn9p5GyyqSFTkcCOJX8loW1lC6At0ymBp+3yWs54MoFNs/NEbTmoMkpsjiinUcMqorp3JCnCf3S4UPAOsuaTkqkhZ8dG4VG+gJsgEyJ3GscGYzRlJWjsn4kgmaWaO40OBC9HMfYOzigAvieXChKNc0WAac8IRh8kAsxMboWzRc+mPO1lKfSeB0IXpHEmmERyPKEYVExXwzBK5JEMTfoMlsUtCLDPQ/0URFMxuCc1G77JfgCCiddhYHF8kkXmbxciW99IKCNfP8F5Li0EXXEGOHoH6KFSkhdSnFIFh5nYIyh9BanRKjKxzkGTeEsSkdEITAzHLJ2qkWvKFAhMNlpY50jTzWRFoProgqYSKh+RW3yIQYPi001Taduo6mjgq+7YyV4L82ux7rZYzxcHFABfE8vlMaJR8xkFSZIU89iwBd+uKnNZY1x+CowcE4aebJY1AxJmW612Dw/R78vUrORAlsVrF+TMtsv6pb8mrccRFkwiSDuShDyiLZJseJIDxz8qP5XIW5CSxUVY8RHUxuRmlXI04wHDu1EKGOYyFIMmizSYkxsNAkRU60Mow2x1ty3dZ7JLGZ6IqWsKpQyZLH4YioUWnlRGKz7A0IIVNaR1iYN3nushSgySyYeRT62Ofe2Z46MdbPHeDg4oAI47PmFIg07i0He1wwCkAaSpcJXAIlxknUlmiSu6A0dVVnUXoya2cEAE2DDRIv+oGTgAuvbLYKHe4s+ZQFr10nWuPlHwnYbWGl1P9CDd4NGr6VhnVgkI29H0F9ipTYsoJWLvOyP5krWT6dgLVOdFlneorSOVEEryzAqGolQRXg6nZw8i4mMIdI1/S8ElNEkxozc4KNI0xtWWB9IEUOPxnWnMb42tSG4BoJeuSwy1s0e4+HggAvge3KhNBl7w8dtgn7TEeeDX5bNS7OPiPW3shjnAlvn+iIhG0V0kpRB6chiTRUUpeuRFAVrJyapfODeB/t0JiR4z8yKG7zyiy3kYwgakawtyE1tAimjaCPiVmW/9uBsyfxBltdNP5UlRJrEKCaSmJAkVN7TSuqGLC+5fCvPKa0jMqlMXAeH81Irjz1ksRY1wiW8buckC4+MQis9Uhjc3tJsd865McbYXRywcWF3L5SHytiXvue8xzlPQNfBXigRUWQoBhVxFtFxGaV3DL1ibRLjypLpJGJoKx7cNoP1on1ivfg6NkbBjZvOGILGdKJE6uCNLko0gErVXZ8eNj8oMrtpJoqE03lCnOZUSurXSRKRhZg4iUgIJFlCO0tG5guzvZI1bcAotA7kSUTlREhKKSW/uZdySJYIddDVWbnMoYwnI8fYtzhgA/ju4qEy9uY951zd5CPyn8HDwqBg6GDdZBtPn+ACPk+YRvwMYxOhpiYoncXOd/FaMdEBncDcjDShmHkRp2rsx8YQNC35a5FJzOYkVrVio/aQKHHt6Q6gKOtSSvAYIE9SZouCCSCKYloeKqNIfCCttUn6Nc8/NhCUxmgpkRmt6RUlE2lEGhuKSvRKlBI3eeccwSgwejwZOcY+x1jMahdo6F4P2fQTFg0etFJUzlJaSCOZ3Nww2SIo6MSadidjupWQp5q0NtJVUcR0uyNGuIi3ox1KK/gEBy7j5KHQQere2xBXoHsRqd2BgyrUjU61AXSey0TmwkBEw4K19CvHll4PEwJWaXTQpGk0cl3KIsV0OwUV4ayjco7COvplhal9TLXWZIkhBFXLvyrheis1nowc4xHBOAPfCXan4WeRyyu0QTF9UETakMUWpTSVD1gfmMpjptqJ1MW7hTBcyoo0zSmdYlD1SCPNsPIYD3EOwcKgXBRzGkOQsFheWiqQdT/iLDSZw8JAXI3WdCT71hoGZWC22yeOI/IkobSO0jtaKFAy6Wi0hrIiT4RRksTSGm+tE3lZHVAEfKiVBfE4H1DKoLWYEIPQDcca3WPsa4wD+E7wUA0/y4M7NHTCOBK38DQxGJ3QLz2JUoQIsiwnrpkqAUXpLPMmppMo5roLaKBbeDIDtMW894EHxrXvlbCzJxIhdgp3XiEnt/YiCNbKEHVCA7GKUDqwod1mWDkWBn2mW20K60T+IIvpV57JCKx1xLEhiyOstTgjdRrrHRpF0JA2MsNKdMPjaGywMMYjg/FZtgJWavhZqrm8NLgvMzZWkoknkSaOIlpphNEwkWeg6olOH7DO0R9YPJ6FQR9MxESeM53BdCtm7dqY/jzMWGFXmJWHOcZ2yFn02WwlMNWCvCV6KJWD6emEx05N43UgI2LgKlzwVFXBsBhQFJ7ZXiGZtVYUlcNoiGtrM5GEFRmFSOu6p0DVde7FcYyrJmM8UhgH8BWw1DUFWDYZ1QT35oJtlAhFfGixNhqQ2ngSGXEqdzDfL9kyP5CSiIK5Xo+etcQKKluRxQk9W/HAAxWb56Vx5152bkE2xnIsIE8smREbuiwBnYqdWighjWMmWxkRnhlbsCZvM5lluCDZc5pGaB1R+Fp/TMGw8vjg0YiIWRobtKrlXtGIGXxt/qHqpp1x9j3GI4RxCWUneCj6oPMiM2uMqNPpJfVx76Xdnto30/rAsBITh/l+ydBaglMY41FBkxnDll4PFWDbsKTXFQpcGkNaCQNljN1HBvQc+FrSMO9BFEM/hpm5Hu1I0y8tWRwTRwZlPYPKkpQVaRyhIkNROEqjiDBkdUCOauXAKBis85SVNGwlkXRYuqZ0Ms6+x3gEMQ7gO8HO6IOubp9WRi5aXT9iN7rP3gN4KivUwqKyovk9KKmcpz+0VJUliSN6tsK7QIJm1jsGfej2hLc8PQX5lnEA3xMUSMeqZ9HFvlXBxpqDGUUw6C8wNQWJ1tyzbRvtLGNYDInw5HGKsQ6VegKiUJjE0uRTWk8Wa+F5G01kAkbX2bYPqFpZ0PlGXnZllcsxxtibGAfwXWDpRdiUTxqhIqPDqAZeWtEPR8HCsKIqJUMbVI5BUeHrzysUkdbMD8TxcWbQI6BZ326TAXerHtu2iJP6+PLfczQTnBZRK5wHHgywsQ/TfSl9TecwPd1jam2Plo5ITKB0HaI4xijNRtPCekc7zUXDxIsVWlU358RGiSb8kic0UMsmva3zy/S+xxhjX2AcwPcA24thLZrKBnEJ10oerXVEqSUj72QxeBhUFh8ZIuPoDQvWxjndAXSLkmFZ4L0mT1Im4x5bS1Ei3JWxwRi7B4dQDEugE8D2YVjJX2wsB20yBOeY6fdY154g1NPGg1KelFwQTn+amNqUYfkTGkBlRSo2BHGSF7cmsVEbZ+Jj7CuMA/geYqXauAR2R1H5Wl/aEikFkWZYOrLUkMSK0opJgLUReSoGAI9Rhi3dLpUrme31mS/AtGDCwrpqHMT3JrYiJak1gK3APQjrN8JC4WilnvlhRSdxDKxl2kugdtaSJDFpEi2b3F5aWnM1zdR5V78v8yOgdqo3P8YYewOrPl1+ySWXcMQRR5BlGSeeeCI33HDDag/pISGZlyYyall2lcaGyCgqJ1ziqJ7gnMgjsjgiT2I2TOY8dm2HQ9a2MBomJ1tMT2Q8ZnKCdpIx9J71a1KmpoSvnDFmoOxtFEiNfDqC1jQkCUymEe0sQytDHBvWTLTQtepglsaksR6VyrZvj28opXEk9mdl5UduPNvTT8cYY29jVTPwz372s7z5zW/mkksu4eSTT+ajH/0oP/uzP8stt9zC4x73uNUc2i6x/WOx1pp2FhNXVmRmlUJriIyRCx65yJWqhY+iiEHpRq4+vbLk4HUbKCuL9duobEX1Q5jwcpcdN/TsHUzXfwc/RtgpWQSPXbOGOI5Z39IcPDlBJ0vIk4g0ViSxSMeuxEjavl8gTSIobe0WPzZmGGPfQ4VVTA+e+cxncsIJJ/DhD394tOzYY4/lRS96Ee9///t3+fn5+XmmpqaYm5tjcnJyXw51jxCCTGKBqmvkUitvTGqtk6ae/qBgaAPz/YLZ7oAHti3QrSrm+j3+e8s2tIXZLmyZgd5A7MLuX+Xvtj8iRYL24xJYMw3rNsBjpqaYyGLWdybIs1Rc5NOI6U5LDIoTw2SekNWlE1jZCLsxK24mLyHU/QIsK7GNMcbuYk/i2qpl4GVZctNNN/Hbv/3by5afdtpp3HjjjSt+pigKimLR1mB+fn6fjvHhoimzLG23b7K2ZiJUK0W7lWEKSxprNk5mTOYR928dMJUlHNJpEcURC8OS+2a2UFaOBxccD9wLPxyIE/s4K18Z64ENSPmpQp5gNqyF446IWTM5wYaJCdZPTTLVTujkOXEErTShDr9opUhjTRJHy4LvSoF4xzkRPWr4GgfuMfY1Vi2Ab9myBeccmzZtWrZ806ZNPPDAAyt+5v3vfz/vec97Honh/dh4KBnaxUdwyFMDGKwLHLJhDZumOzjviOOYsrJUpWVheDALRUUxKCifNOTeuVluv3eOmTmwBfTmYCaI9OyDj/xXXRW0gUOAxySSUXdy2LA2Zn2nxfrptbTbKbZwoKGyjlaW0+mkbJzqkBiI4hSQslYzlyFlD7+DCcNDYWe/8zh4j/FIYNVZKCsp/O3s5H/HO97BW97yltHr+fl5Dj300H06vh8Xu7bPkp8gjppKVrJs3eZ4WFt3oyhNUZRU1mKriixLcU4c07fNzKFNwsz8Ap12hgmOshgytAGHotsd0q+kRptpz/RETq9wFKWl1++TxKL/EUJgamISo+VJqZWlTHXaaBXqMcFCt4t1gak1a+kuzBFpRZKIBZkxhkFRsm1uAevlCWTYW2DjpoMZDodMdtoUwz55a4ItcwvMz81x8Ia1TLRSJienWFiYJ0sTCbytNlu3bWPjxg2IJbCUKyKjabVao+MZQiCOYzEMjiKcc0SRCFA1re3Ne83/V/p9Hm4b/Dhgj7EaWLUAvn79eowxO2Tbmzdv3iErb5CmKWmaPhLDe0SwOxlbszyO49GyyGQ7PKaHEFg7PYX3nsPZCLAscHnvazEmtyzYATjnlgUu7z3GmB2C3Pa14LDE4Hml8TTbWprRbr/tZmxLA6tSjx2NJYTA4w597LJ97k6wbL7P0uO20nEdY4z9GatGI0yShBNPPJFrr7122fJrr72WZz/72as0qv0D2wfUpf/XdXv30oAs9l4ieRpF0SioNYE1iqJln4siqf02r3fm69iss7PxNPtdug1jzLL3m/1tv+2dfddx4B1jjEWsagnlLW95C6985St5+tOfzkknncTHPvYx7r77bs4+++zVHNYYY4wxxn6BVQ3gL3/5y9m6dSu/93u/x/3338+TnvQkvvzlL3PYYYet5rDGGGOMMfYLrCoP/MfFo5UHPsYYY4zxcLFf8MD3Bpp7z6OVDz7GGGOMsado4tnu5Nb7dQBfWFgAeNRTCccYY4wx9hQLCwtMTU095Dr7dQnFe899993HxMTEPmMnNFzze+65Z1ymqTE+JssxPh47YnxMdsTuHpMQAgsLCzzmMY/ZZV/Cfp2Ba6055JBDHpF9TU5Ojk/E7TA+JssxPh47YnxMdsTuHJNdZd4NVl1OdowxxhhjjIeHcQAfY4wxxthPMQ7gu0CaplxwwQU/US38Py7Gx2Q5xsdjR4yPyY7YF8dkv57EHGOMMcY4kDHOwMcYY4wx9lOMA/gYY4wxxn6KcQAfY4wxxthPMQ7gY4wxxhj7KcYBfDdx11138drXvpYjjjiCPM95/OMfzwUXXEBZlqs9tEcUl1xyCUcccQRZlnHiiSdyww03rPaQVg3vf//7+amf+ikmJibYuHEjL3rRi7jttttWe1iPGrz//e9HKcWb3/zm1R7KquLee+/lf//v/826detotVo87WlP46abbtor2x4H8N3Erbfeiveej370o/znf/4nf/Inf8JHPvIR3vnOd6720B4xfPazn+XNb34z/9//9//x7W9/m+c85zn87M/+LHffffdqD21VcP3113POOefw9a9/nWuvvRZrLaeddhq9Xm+1h7bq+OY3v8nHPvYxnvKUp6z2UFYVMzMznHzyycRxzN/93d9xyy238MEPfpDp6em9s4MwxsPGH/zBH4QjjjhitYfxiOEZz3hGOPvss5ctO+aYY8Jv//Zvr9KIHl3YvHlzAML111+/2kNZVSwsLISjjjoqXHvtteGUU04J559//moPadXw9re/Pfz0T//0Ptv+OAP/MTA3N8fatWtXexiPCMqy5KabbuK0005btvy0007jxhtvXKVRPbowNzcHcMCcEzvDOeecw8///M9z6qmnrvZQVh1f/OIXefrTn87LXvYyNm7cyPHHH89f/uVf7rXtjwP4w8T3v/99Lr744gPG/m3Lli0453YwnN60adMOxtQHIkIIvOUtb+Gnf/qnedKTnrTaw1k1XHXVVdx88828//3vX+2hPCrwgx/8gA9/+MMcddRRfOUrX+Hss8/mvPPO45Of/ORe2f4BH8Df/e53jwx2d/b3rW99a9ln7rvvPn7mZ36Gl73sZbzuda9bpZGvDraX7Q276RL/k443velNfPe73+XKK69c7aGsGu655x7OP/98rrjiCrIsW+3hPCrgveeEE07gfe97H8cffzxveMMb+LVf+zU+/OEP75Xt79dysnsDb3rTm/iVX/mVh1zn8MMPH/3/vvvu4/nPf/7IhPlAwfr16zHG7JBtb968eYes/EDDueeeyxe/+EW+9rWvPWLyxo9G3HTTTWzevJkTTzxxtMw5x9e+9jU+9KEPURQFxphVHOEjj4MPPpgnPvGJy5Yde+yxXH311Xtl+wd8AF+/fj3r16/frXXvvfdenv/853PiiSdy2WWX7VJs/ScJSZJw4okncu211/JLv/RLo+XXXnstZ5xxxiqObPUQQuDcc8/lmmuu4brrruOII45Y7SGtKv7n//yf/Md//MeyZb/6q7/KMcccw9vf/vYDLngDnHzyyTtQS2+//fa9Z9y+z6ZHf8Jw7733hiOPPDK84AUvCD/84Q/D/fffP/o7UHDVVVeFOI7DpZdeGm655Zbw5je/ObTb7XDXXXet9tBWBb/+678epqamwnXXXbfsfOj3+6s9tEcNDnQWyje+8Y0QRVH4/d///XDHHXeET3/606HVaoUrrrhir2x/HMB3E5dddlkAVvw7kPAXf/EX4bDDDgtJkoQTTjjhgKbM7ex8uOyyy1Z7aI8aHOgBPIQQvvSlL4UnPelJIU3TcMwxx4SPfexje23bYznZMcYYY4z9FAdOEXeMMcYY4ycM4wA+xhhjjLGfYhzAxxhjjDH2U4wD+BhjjDHGfopxAB9jjDHG2E8xDuBjjDHGGPspxgF8jDHGGGM/xTiAjzHGGGPspxgH8L2I6667DqUUs7OzAFx++eV7z3ljJzjrrLN40YtetNP3H4kx7K94JH+v7fe1r/DKV76S973vfft0H7vCu9/9bp72tKet6hhWA4/U9/7bv/1bjj/+eLz3j84AftZZZ6GU4qKLLlq2/Atf+MJ+JV368pe/nNtvv/2AHMNdd92FUorvfOc7j/i+Hy62P1b7WyD67ne/y//9v/+Xc889d7WH8hMPpRRf+MIXli1729vexle/+tV9vq//9b/+F0opPvOZzzw6AzhAlmV84AMfYGZmZq9u95E0Ic7znI0bNz5i+3u0jmF/wf5+rD70oQ/xspe9jImJidUeygGJTqfDunXrHpF9/eqv/ioXX3zxozeAn3rqqRx00EG7dPa4+uqrOe6440jTlMMPP5wPfvCDy94//PDDee9738tZZ53F1NQUv/ZrvzZ6VP7bv/1bjj76aFqtFi996Uvp9Xp84hOf4PDDD2fNmjWce+65OOdG27riiit4+tOfzsTEBAcddBCveMUr2Lx5807Htv0j+eGHH76iYUSDe++9l5e//OWsWbOGdevWccYZZ3DXXXeN3nfO8Za3vIXp6WnWrVvHb/3Wb7ErKZvtx9BklZ/61Kc4/PDDmZqa4ld+5VdYWFgYrfO85z2PN73pTbzpTW8a7et3fud3lu1rpQxkenqayy+/HGAkrXr88cejlOJ5z3veiuNzzvHa176WI444gjzPOfroo/mzP/uzZes0ZaL3ve99bNq0ienpad7znvdgreU3f/M3Wbt2LYcccggf//jHR59pngCuuuoqnv3sZ5NlGccddxzXXXfdbh2ryy+/nPe85z38+7//++h3uvzyy1d8spidnUUptWzbX/7yl3nCE55Anuc8//nPX/Y7Nrjxxht57nOfS57nHHrooZx33nnLDJEvueQSjjrqKLIsY9OmTbz0pS/d6di99/z1X/81v/iLv7hseVEU/NZv/RaHHnooaZpy1FFHcemll+7xsf+jP/ojDj74YNatW8c555xDVVU7HUuDj370oxx66KG0Wi1e9rKX7VA+uuyyyzj22GPJsoxjjjmGSy655CG397znPY/zzjuP3/qt32Lt2rUcdNBBvPvd7162ztzcHK9//evZuHEjk5OTvOAFL+Df//3fl63z3ve+l40bNzIxMcHrXvc6fvu3f3vZk9Y3v/lNXvjCF7J+/XqmpqY45ZRTuPnmm0fvN/4Av/RLv4RSavR66RPbV77yFbIs2+E7n3feeZxyyimj17s6B3aGX/zFX+Qb3/jGo1NK79WvfnU444wzwuc///mQZVm45557QgghXHPNNcvU/771rW8FrXX4vd/7vXDbbbeFyy67LOR5vkwN7rDDDguTk5PhD//wD8Mdd9wR7rjjjnDZZZeFOI7DC1/4wnDzzTeH66+/Pqxbty6cdtpp4Zd/+ZfDf/7nf4YvfelLIUmScNVVV422demll4Yvf/nL4fvf/37413/91/CsZz0r/OzP/uzo/X/6p38KQJiZmQkhiILh1NTU6P3NmzePJEd/+MMfhmc961nhOc95TgghhF6vF4466qjwmte8Jnz3u98Nt9xyS3jFK14Rjj766FAURQghhA984ANhamoq/J//83/CLbfcEl772teGiYmJcMYZZ+z0WG4/hgsuuCB0Op3w4he/OPzHf/xH+NrXvhYOOuig8M53vnO0zimnnBI6nU44//zzw6233hquuOKK0Gq1lqmoAeGaa65Ztq+pqanRsf/GN74RgPAP//AP4f777w9bt25dcXxlWYbf/d3fDd/4xjfCD37wg9G+PvvZz47WefWrXx0mJibCOeecE2699dZw6aWXBiCcfvrp4fd///fD7bffHi688MIQx3G4++67Qwgh3HnnnQEIhxxyyOh4ve51rwsTExNhy5Ytu/y9+v1+eOtb3xqOO+64ZTKxzXa//e1vj8Y3MzMTgPBP//RPIYQQ7r777pCm6bLjt2nTpmX7+u53vxs6nU74kz/5k3D77beHf/mXfwnHH398OOuss0IIIXzzm98Mxpjwmc98Jtx1113h5ptvDn/2Z3+209/529/+dgDCAw88sGz5L//yL4dDDz00fP7znw/f//73wz/8wz+MzundPfaTk5Ph7LPPDt/73vfCl770pR3Ohe1xwQUXhHa7HV7wgheEb3/72+H6668PRx55ZHjFK14xWudjH/tYOPjgg8PVV18dfvCDH4Srr746rF27Nlx++eU73e4pp5wSJicnw7vf/e5w++23h0984hNBKRX+/u//PoQQgvc+nHzyyeEXfuEXwje/+c1w++23h7e+9a1h3bp1o/PviiuuCFmWhY9//OPhtttuC+95z3vC5ORkeOpTnzraz1e/+tXwqU99Ktxyyy2j62zTpk1hfn4+hLBoXn3ZZZeF+++/P2zevHn0vZvtWGvDpk2bwl/91V+Nttss++hHPxpC2PU50GClay2EEDZu3PjolJNtAngIITzrWc8Kr3nNa0IIOwbwV7ziFeGFL3zhss/+5m/+ZnjiE584en3YYYeFF73oRcvWaaRh/+u//mu07A1veENotVphYWFhtOz0008Pb3jDG3Y6ziZINZ/ZVQBfivPOOy8cdthhox//0ksvDUcffXTw3o/WKYoi5HkevvKVr4QQQjj44IPDRRddNHq/qqpwyCGH7HEAb7Vao5MxBDlmz3zmM0evTznllHDssccuG8vb3/72cOyxx45e7yqArxTodhdvfOMbw0te8pLR61e/+tXhsMMOC8650bKjjz56dPMLQS6OdrsdrrzyymX7X+l4feADHwgh7Pr3WnpBNtidAP6Od7xjxeO3dF+vfOUrw+tf//pl277hhhuC1joMBoNw9dVXh8nJyWW/00PhmmuuCcaYZfu87bbbAhCuvfba3dpGCDs/9tba0bKXvexl4eUvf/lOt3HBBRcEY8wo8QohhL/7u78LWuuRfv6hhx4aPvOZzyz73IUXXhhOOumknW73lFNO2cHh/ad+6qfC29/+9hCCBN7JyckwHA6XrfP4xz9+FDSf+cxnhnPOOWfZ+yeffPIOv/NSWGvDxMRE+NKXvjRattL5v/35ct5554UXvOAFo9df+cpXQpIkYdu2bSGEXZ8DDZRS4W/+5m92GNfxxx//6Hel/8AHPsAnPvEJbrnllh3e+973vsfJJ5+8bNnJJ5/MHXfcsaz08fSnP32Hz7ZaLR7/+MePXm/atInDDz+cTqezbNnSEsm3v/1tzjjjDA477DAmJiZGZYG77757j77Txz72MS699FL+5m/+hg0bNgBiR/Vf//VfTExM0Ol06HQ6rF27luFwyPe//33m5ua4//77Oemkk0bbiaJoxe+2Kxx++OHL6qQHH3zwDqWgZz3rWcvKOyeddNIOx3Vv4SMf+QhPf/rT2bBhA51Oh7/8y7/c4Zged9xxyxyQNm3axJOf/OTRa2MM69at2+F7rHS8vve97+3177AU3/ve91Y8fktx0003cfnll49+606nw+mnn473njvvvJMXvvCFHHbYYfyP//E/eOUrX8mnP/1p+v3+Tvc5GAxI03TZPr/zne9gjFn2yL49dvfYL3XTWel82R6Pe9zjltnLnXTSSXjvue2223jwwQe55557eO1rX7vs+7/3ve/l+9///kNu9ylPecqy10vHctNNN9Htdlm3bt2y7d55552j7d5222084xnPWLaN7V9v3ryZs88+myc84QlMTU0xNTVFt9vd4+v8zDPP5LrrruO+++4D4NOf/jQ/93M/x5o1a0bjfahzoEHz3vbI8/zRb6n23Oc+l9NPP513vvOdnHXWWcveCysY6oYVasLtdnuHZXEcL3utlFpxmfcegF6vx2mnncZpp53GFVdcwYYNG7j77rs5/fTT92hi9LrrruPcc8/lyiuv5KlPfepoufeeE088kU9/+tM7fKYJ8nsLD/U9dxdKqR2O9e7URbfH5z73OX7jN36DD37wg5x00klMTEzwh3/4h/zbv/3bLsf8cL/Hj8Nkam4iS7/79t97pXNwe3jvecMb3sB55523w3uPe9zjSJKEm2++meuuu46///u/53d/93d597vfzTe/+c0VqY7r16+n3+9TliVJkgBygT8Ufpxj/3DOl+0/+5d/+Zc885nPXLbermzXHmos3nsOPvjgFec5lh6zXcWMs846iwcffJA//dM/5bDDDiNNU0466aQ9JkA84xnP4PGPfzxXXXUVv/7rv84111zDZZddNnp/V+dAg6mpqRUD+LZt2x79ARzgoosu4mlPexpPeMITli1/4hOfyD//8z8vW3bjjTfyhCc8Ya/77916661s2bKFiy66iEMPPRRgB7f6XeG//uu/eMlLXsI73/lOXvziFy9774QTTuCzn/3saPJlJRx88MF8/etf57nPfS4A1lpuuukmTjjhhIfxjR4aX//613d4fdRRR42O64YNG7j//vtH799xxx3LMsQmiOwqY7/hhht49rOfzRvf+MbRsl1lYXuClY7Xm970pt36bJIkO4y/uZnef//9HH/88QA7UCWf+MQn7jDBu/3xPOGEE/jP//xPjjzyyJ3uP4oiTj31VE499VQuuOACpqen+cd//Mcdzh1gNHl2yy23jP7/5Cc/Ge89119/PaeeeuoOn9mXx/7uu+/mvvvu4zGPeQwA//qv/4rWmic84Qls2rSJxz72sfzgBz/gzDPP3Cv7AzmmDzzwAFEULTMiX4qjjz6ab3zjG7zyla8cLdv+Or7hhhu45JJL+Lmf+zkA7rnnHrZs2bJsnTiOd+tp9BWveAWf/vSnOeSQQ9Ba8/M///PLxrurc6DZ//Zonswf9SUUkBPxzDPP5OKLL162/K1vfStf/epXufDCC7n99tv5xCc+wYc+9CHe9ra37fUxNFnRxRdfzA9+8AO++MUvcuGFF+725weDAb/wC7/A0572NF7/+tfzwAMPjP5AHrfWr1/PGWecwQ033MCdd97J9ddfz/nnn88Pf/hDAM4//3wuuugirrnmGm699Vbe+MY37rPGkHvuuYe3vOUt3HbbbVx55ZVcfPHFnH/++aP3X/CCF/ChD32Im2++mW9961ucffbZy7KjjRs3kuc5/+///T9+9KMfMTc3t+J+jjzySL71rW/xla98hdtvv513vetdfPOb39xr3+Mv/uIvRsfrnHPOYWZmhte85jW79dnDDz+cO++8k+985zts2bKFoijI85xnPetZXHTRRdxyyy187Wtf43d+53eWfe7ss8/m+9///uj4feYznxmxcxq8/e1v51//9V8555xz+M53vsMdd9zBF7/4xRGH+2//9m/58z//c77zne/w3//933zyk5/Ee8/RRx+94lg3bNjACSecsCyhOfzww3n1q1/Na17zGr7whS9w5513ct111/G5z30O2LfHPssyXv3qV/Pv//7v3HDDDZx33nn88i//MgcddBAgjI33v//9/Nmf/Rm33347//Ef/8Fll13GH//xHz/sfZ566qmcdNJJvOhFL+IrX/kKd911FzfeeCO/8zu/MwrS5557Lpdeeimf+MQnuOOOO3jve9/Ld7/73WVZ+ZFHHsmnPvUpvve97/Fv//ZvnHnmmTs8zRx++OF89atf5YEHHnhIqvOZZ57JzTffzO///u/z0pe+lCzLRu/t6hxocMwxx+zAL//6179Omqb7RwAHuPDCC3d41DnhhBP43Oc+x1VXXcWTnvQkfvd3f5ff+73f26HUsjewYcMGLr/8cv76r/+aJz7xiVx00UX80R/90W5//kc/+hG33nor//iP/8hjHvMYDj744NEfSE3+a1/7Go973ON48YtfzLHHHstrXvMaBoPBKCN/61vfyqte9SrOOuus0SPvUof4vYlXvepVDAYDnvGMZ3DOOedw7rnn8vrXv370/gc/+EEOPfRQnvvc5/KKV7yCt73tbbRardH7URTx53/+53z0ox/lMY95zE6d688++2xe/OIX8/KXv5xnPvOZbN26dVlG+OPioosu4gMf+ABPfepTueGGG/ibv/kb1q9fv1uffclLXsLP/MzP8PznP58NGzZw5ZVXAvDxj3+cqqp4+tOfzvnnn8973/veZZ973OMex9VXX82XvvQlnvrUp/KRj3xkh+7IpzzlKVx//fXccccdPOc5z+H444/nXe961+h8mJ6e5vOf/zwveMELOPbYY/nIRz7ClVdeyXHHHbfT8b7+9a/foQT34Q9/mJe+9KW88Y1v5JhjjuHXfu3XRjS1fXnsjzzySF784hfzcz/3c5x22mk86UlPWkYTfN3rXsdf/dVfcfnll/PkJz+ZU045hcsvv3xEP304UErx5S9/mec+97m85jWv4QlPeAK/8iu/wl133cWmTZsACajveMc7eNvb3sYJJ5zAnXfeyVlnnbUssH784x9nZmaG448/nle+8pWcd955O/QHfPCDH+Taa6/l0EMPHT2JrYSjjjqKn/qpn+K73/3uDk8buzoHGtx2223LaL4AV155JWeeeSZjT8wxdsDznvc8nva0p/Gnf/qnqz2Uh4277rqLI444gm9/+9v7VTflj4PhcMjRRx/NVVddtcOk6Rg7xwtf+EIOOuggPvWpT632UHYLDz74IMcccwzf+ta39o8a+BhjjLFrZFnGJz/5yR3qtWMsot/v85GPfITTTz8dYwxXXnkl//AP/8C111672kPbbdx5551ccsklHHHEEeMAPsYYP0l4KMrgGItllve+970URcHRRx/N1VdfveIk76MVz3jGM0bUx3EJZYwxxhhjP8V+M4k5xhhjjDHGcowD+BhjjDHGfopxAB9jjDHG2E8xDuBjjDHGGPspxgF8jDHGGGM/xTiAjzHGGGPspxgH8DHGGGOM/RTjAD7GGGOMsZ/i/wfCOCiR9X9rewAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "plt.plot(vae_output[10,:],vae_sigF[10,:],'.',alpha=0.01)\n",
     "plt.xlabel(\"Normalized input amplitudes (can be negative!)\")\n",
@@ -1333,12 +2214,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 83,
    "id": "00fd945d-04b7-4c46-b320-a236bad7b606",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size of training set = 1293\n",
+      "Size of test set = 324\n",
+      "CPU times: user 1.86 s, sys: 460 ms, total: 2.32 s\n",
+      "Wall time: 2.42 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Specify VAE Parameters; takes ~1 sec\n",
@@ -1383,12 +2275,534 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 84,
    "id": "f8754446-c53c-4085-b5ea-5683f3843ad2",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Ep 1: 100%|█| 13/13 [00:03<00:00,  3.93it/s, Test=4.66e+6, Train=4.97e+6, mem=0.\n",
+      "Ep 2: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=4.49e+6, Train=4.79e+6, mem=0.\n",
+      "Ep 3: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=4.41e+6, Train=4.24e+6, mem=0.\n",
+      "Ep 4: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=4.24e+6, Train=4.3e+6, mem=0.6\n",
+      "Ep 5: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=4.14e+6, Train=4.35e+6, mem=0.\n",
+      "Ep 6: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=3.71e+6, Train=3.69e+6, mem=0.\n",
+      "Ep 7: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=3.51e+6, Train=3.47e+6, mem=0.\n",
+      "Ep 8: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=3.43e+6, Train=3.82e+6, mem=0.\n",
+      "Ep 9: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=3.34e+6, Train=3.16e+6, mem=0.\n",
+      "Ep 10: 100%|█| 13/13 [00:00<00:00, 14.13it/s, Test=3.2e+6, Train=3.35e+6, mem=0.\n",
+      "Ep 11: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=3.29e+6, Train=3.28e+6, mem=0\n",
+      "Ep 12: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=3.15e+6, Train=3.09e+6, mem=0\n",
+      "Ep 13: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=3.07e+6, Train=3.12e+6, mem=0\n",
+      "Ep 14: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=3.18e+6, Train=2.84e+6, mem=0\n",
+      "Ep 15: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=3.16e+6, Train=2.99e+6, mem=0\n",
+      "Ep 16: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=3.16e+6, Train=3.08e+6, mem=0\n",
+      "Ep 17: 100%|█| 13/13 [00:00<00:00, 13.36it/s, Test=3.15e+6, Train=3.04e+6, mem=0\n",
+      "Ep 18: 100%|█| 13/13 [00:00<00:00, 13.35it/s, Test=3.1e+6, Train=3.08e+6, mem=0.\n",
+      "Ep 19: 100%|█| 13/13 [00:00<00:00, 13.43it/s, Test=3.12e+6, Train=3.21e+6, mem=0\n",
+      "Ep 20: 100%|█| 13/13 [00:00<00:00, 13.50it/s, Test=3.07e+6, Train=2.92e+6, mem=0\n",
+      "Ep 21: 100%|█| 13/13 [00:00<00:00, 13.53it/s, Test=3.05e+6, Train=3.15e+6, mem=0\n",
+      "Ep 22: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=3.05e+6, Train=3.02e+6, mem=0\n",
+      "Ep 23: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=3.07e+6, Train=3.11e+6, mem=0\n",
+      "Ep 24: 100%|█| 13/13 [00:00<00:00, 13.68it/s, Test=3.02e+6, Train=3.01e+6, mem=0\n",
+      "Ep 25: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=3.03e+6, Train=3.2e+6, mem=0.\n",
+      "Ep 26: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.98e+6, Train=3.26e+6, mem=0\n",
+      "Ep 27: 100%|█| 13/13 [00:00<00:00, 13.66it/s, Test=2.96e+6, Train=2.7e+6, mem=0.\n",
+      "Ep 28: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.94e+6, Train=2.94e+6, mem=0\n",
+      "Ep 29: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=3.02e+6, Train=2.93e+6, mem=0\n",
+      "Ep 30: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.96e+6, Train=2.97e+6, mem=0\n",
+      "Ep 31: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.91e+6, Train=2.86e+6, mem=0\n",
+      "Ep 32: 100%|█| 13/13 [00:00<00:00, 13.66it/s, Test=2.98e+6, Train=2.75e+6, mem=0\n",
+      "Ep 33: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.95e+6, Train=2.82e+6, mem=0\n",
+      "Ep 34: 100%|█| 13/13 [00:00<00:00, 13.74it/s, Test=2.86e+6, Train=2.66e+6, mem=0\n",
+      "Ep 35: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=2.87e+6, Train=2.81e+6, mem=0\n",
+      "Ep 36: 100%|█| 13/13 [00:00<00:00, 13.67it/s, Test=2.87e+6, Train=3.1e+6, mem=0.\n",
+      "Ep 37: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.86e+6, Train=2.95e+6, mem=0\n",
+      "Ep 38: 100%|█| 13/13 [00:00<00:00, 13.94it/s, Test=2.84e+6, Train=2.73e+6, mem=0\n",
+      "Ep 39: 100%|█| 13/13 [00:00<00:00, 13.74it/s, Test=2.84e+6, Train=2.62e+6, mem=0\n",
+      "Ep 40: 100%|█| 13/13 [00:00<00:00, 13.65it/s, Test=2.81e+6, Train=2.81e+6, mem=0\n",
+      "Ep 41: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.83e+6, Train=2.85e+6, mem=0\n",
+      "Ep 42: 100%|█| 13/13 [00:00<00:00, 13.93it/s, Test=2.72e+6, Train=2.59e+6, mem=0\n",
+      "Ep 43: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.72e+6, Train=2.57e+6, mem=0\n",
+      "Ep 44: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.69e+6, Train=2.86e+6, mem=0\n",
+      "Ep 45: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.68e+6, Train=2.82e+6, mem=0\n",
+      "Ep 46: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.7e+6, Train=2.59e+6, mem=0.\n",
+      "Ep 47: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.68e+6, Train=2.59e+6, mem=0\n",
+      "Ep 48: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.65e+6, Train=2.65e+6, mem=0\n",
+      "Ep 49: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.64e+6, Train=2.63e+6, mem=0\n",
+      "Ep 50: 100%|█| 13/13 [00:00<00:00, 13.69it/s, Test=2.64e+6, Train=2.7e+6, mem=0.\n",
+      "Ep 51: 100%|█| 13/13 [00:00<00:00, 13.89it/s, Test=2.62e+6, Train=2.45e+6, mem=0\n",
+      "Ep 52: 100%|█| 13/13 [00:00<00:00, 13.91it/s, Test=2.62e+6, Train=2.47e+6, mem=0\n",
+      "Ep 53: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.6e+6, Train=2.76e+6, mem=0.\n",
+      "Ep 54: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.59e+6, Train=2.61e+6, mem=0\n",
+      "Ep 55: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.56e+6, Train=2.52e+6, mem=0\n",
+      "Ep 56: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.56e+6, Train=2.7e+6, mem=0.\n",
+      "Ep 57: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.51e+6, Train=2.63e+6, mem=0\n",
+      "Ep 58: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.57e+6, Train=2.57e+6, mem=0\n",
+      "Ep 59: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.52e+6, Train=2.43e+6, mem=0\n",
+      "Ep 60: 100%|█| 13/13 [00:00<00:00, 13.56it/s, Test=2.55e+6, Train=2.39e+6, mem=0\n",
+      "Ep 61: 100%|█| 13/13 [00:00<00:00, 13.60it/s, Test=2.53e+6, Train=2.51e+6, mem=0\n",
+      "Ep 62: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.51e+6, Train=2.65e+6, mem=0\n",
+      "Ep 63: 100%|█| 13/13 [00:00<00:00, 13.60it/s, Test=2.43e+6, Train=2.73e+6, mem=0\n",
+      "Ep 64: 100%|█| 13/13 [00:00<00:00, 13.74it/s, Test=2.5e+6, Train=2.58e+6, mem=0.\n",
+      "Ep 65: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.49e+6, Train=2.63e+6, mem=0\n",
+      "Ep 66: 100%|█| 13/13 [00:00<00:00, 13.65it/s, Test=2.44e+6, Train=2.39e+6, mem=0\n",
+      "Ep 67: 100%|█| 13/13 [00:00<00:00, 13.53it/s, Test=2.46e+6, Train=2.48e+6, mem=0\n",
+      "Ep 68: 100%|█| 13/13 [00:00<00:00, 13.40it/s, Test=2.5e+6, Train=2.7e+6, mem=0.6\n",
+      "Ep 69: 100%|█| 13/13 [00:00<00:00, 13.59it/s, Test=2.48e+6, Train=2.4e+6, mem=0.\n",
+      "Ep 70: 100%|█| 13/13 [00:00<00:00, 13.59it/s, Test=2.43e+6, Train=2.49e+6, mem=0\n",
+      "Ep 71: 100%|█| 13/13 [00:00<00:00, 13.51it/s, Test=2.45e+6, Train=2.5e+6, mem=0.\n",
+      "Ep 72: 100%|█| 13/13 [00:00<00:00, 13.63it/s, Test=2.48e+6, Train=2.59e+6, mem=0\n",
+      "Ep 73: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=2.4e+6, Train=2.51e+6, mem=0.\n",
+      "Ep 74: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.45e+6, Train=2.45e+6, mem=0\n",
+      "Ep 75: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.51e+6, Train=2.24e+6, mem=0\n",
+      "Ep 76: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.45e+6, Train=2.49e+6, mem=0\n",
+      "Ep 77: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.41e+6, Train=2.53e+6, mem=0\n",
+      "Ep 78: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.46e+6, Train=2.42e+6, mem=0\n",
+      "Ep 79: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.43e+6, Train=2.46e+6, mem=0\n",
+      "Ep 80: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.47e+6, Train=2.48e+6, mem=0\n",
+      "Ep 81: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.45e+6, Train=2.31e+6, mem=0\n",
+      "Ep 82: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.43e+6, Train=2.68e+6, mem=0\n",
+      "Ep 83: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.37e+6, Train=2.32e+6, mem=0\n",
+      "Ep 84: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.39e+6, Train=2.32e+6, mem=0\n",
+      "Ep 85: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.4e+6, Train=2.23e+6, mem=0.\n",
+      "Ep 86: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.47e+6, Train=2.35e+6, mem=0\n",
+      "Ep 87: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.42e+6, Train=2.34e+6, mem=0\n",
+      "Ep 88: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.48e+6, Train=2.26e+6, mem=0\n",
+      "Ep 89: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.45e+6, Train=2.37e+6, mem=0\n",
+      "Ep 90: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.38e+6, Train=2.27e+6, mem=0\n",
+      "Ep 91: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.44e+6, Train=2.4e+6, mem=0.\n",
+      "Ep 92: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.45e+6, Train=2.32e+6, mem=0\n",
+      "Ep 93: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.37e+6, Train=2.45e+6, mem=0\n",
+      "Ep 94: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.37e+6, Train=2.5e+6, mem=0.\n",
+      "Ep 95: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.44e+6, Train=2.33e+6, mem=0\n",
+      "Ep 96: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.36e+6, Train=2.19e+6, mem=0\n",
+      "Ep 97: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.36e+6, Train=2.39e+6, mem=0\n",
+      "Ep 98: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.28e+6, Train=2.34e+6, mem=0\n",
+      "Ep 99: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.35e+6, Train=2.24e+6, mem=0\n",
+      "Ep 100: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.33e+6, Train=2.27e+6, mem=\n",
+      "Ep 101: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.32e+6, Train=2.17e+6, mem=\n",
+      "Ep 102: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.36e+6, Train=2.25e+6, mem=\n",
+      "Ep 103: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.37e+6, Train=2.25e+6, mem=\n",
+      "Ep 104: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.29e+6, Train=2.13e+6, mem=\n",
+      "Ep 105: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.32e+6, Train=2.31e+6, mem=\n",
+      "Ep 106: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.33e+6, Train=2.31e+6, mem=\n",
+      "Ep 107: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.34e+6, Train=2.22e+6, mem=\n",
+      "Ep 108: 100%|█| 13/13 [00:00<00:00, 13.57it/s, Test=2.36e+6, Train=2.17e+6, mem=\n",
+      "Ep 109: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.28e+6, Train=2.35e+6, mem=\n",
+      "Ep 110: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.36e+6, Train=2.35e+6, mem=\n",
+      "Ep 111: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.31e+6, Train=2.22e+6, mem=\n",
+      "Ep 112: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.33e+6, Train=2.15e+6, mem=\n",
+      "Ep 113: 100%|█| 13/13 [00:00<00:00, 13.39it/s, Test=2.38e+6, Train=2.14e+6, mem=\n",
+      "Ep 114: 100%|█| 13/13 [00:00<00:00, 13.46it/s, Test=2.35e+6, Train=2.21e+6, mem=\n",
+      "Ep 115: 100%|█| 13/13 [00:00<00:00, 13.70it/s, Test=2.34e+6, Train=2.05e+6, mem=\n",
+      "Ep 116: 100%|█| 13/13 [00:00<00:00, 13.61it/s, Test=2.33e+6, Train=2.14e+6, mem=\n",
+      "Ep 117: 100%|█| 13/13 [00:00<00:00, 13.42it/s, Test=2.36e+6, Train=2.32e+6, mem=\n",
+      "Ep 118: 100%|█| 13/13 [00:00<00:00, 13.68it/s, Test=2.32e+6, Train=2.3e+6, mem=0\n",
+      "Ep 119: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.35e+6, Train=2.22e+6, mem=\n",
+      "Ep 120: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.32e+6, Train=2.18e+6, mem=\n",
+      "Ep 121: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.34e+6, Train=2.09e+6, mem=\n",
+      "Ep 122: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.33e+6, Train=2.35e+6, mem=\n",
+      "Ep 123: 100%|█| 13/13 [00:00<00:00, 13.68it/s, Test=2.3e+6, Train=2.26e+6, mem=0\n",
+      "Ep 124: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.3e+6, Train=2.23e+6, mem=0\n",
+      "Ep 125: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.31e+6, Train=2.32e+6, mem=\n",
+      "Ep 126: 100%|█| 13/13 [00:00<00:00, 13.91it/s, Test=2.37e+6, Train=2.24e+6, mem=\n",
+      "Ep 127: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.38e+6, Train=2.23e+6, mem=\n",
+      "Ep 128: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.33e+6, Train=2.4e+6, mem=0\n",
+      "Ep 129: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.33e+6, Train=2.24e+6, mem=\n",
+      "Ep 130: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.31e+6, Train=2.07e+6, mem=\n",
+      "Ep 131: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.29e+6, Train=2.21e+6, mem=\n",
+      "Ep 132: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.22e+6, Train=2.19e+6, mem=\n",
+      "Ep 133: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.34e+6, Train=2.33e+6, mem=\n",
+      "Ep 134: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.32e+6, Train=2.16e+6, mem=\n",
+      "Ep 135: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.34e+6, Train=2.17e+6, mem=\n",
+      "Ep 136: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.31e+6, Train=2.28e+6, mem=\n",
+      "Ep 137: 100%|█| 13/13 [00:00<00:00, 13.62it/s, Test=2.35e+6, Train=2.22e+6, mem=\n",
+      "Ep 138: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.3e+6, Train=2.19e+6, mem=0\n",
+      "Ep 139: 100%|█| 13/13 [00:00<00:00, 13.75it/s, Test=2.28e+6, Train=2.18e+6, mem=\n",
+      "Ep 140: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.27e+6, Train=2.2e+6, mem=0\n",
+      "Ep 141: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.24e+6, Train=2.18e+6, mem=\n",
+      "Ep 142: 100%|█| 13/13 [00:00<00:00, 13.93it/s, Test=2.31e+6, Train=2.13e+6, mem=\n",
+      "Ep 143: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.33e+6, Train=2.26e+6, mem=\n",
+      "Ep 144: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.3e+6, Train=2.26e+6, mem=0\n",
+      "Ep 145: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.29e+6, Train=2.11e+6, mem=\n",
+      "Ep 146: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.26e+6, Train=2.27e+6, mem=\n",
+      "Ep 147: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.33e+6, Train=2.27e+6, mem=\n",
+      "Ep 148: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.32e+6, Train=2.06e+6, mem=\n",
+      "Ep 149: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.31e+6, Train=2.24e+6, mem=\n",
+      "Ep 150: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.31e+6, Train=2.28e+6, mem=\n",
+      "Ep 151: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.31e+6, Train=2.08e+6, mem=\n",
+      "Ep 152: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.31e+6, Train=2.17e+6, mem=\n",
+      "Ep 153: 100%|█| 13/13 [00:00<00:00, 13.58it/s, Test=2.32e+6, Train=2.19e+6, mem=\n",
+      "Ep 154: 100%|█| 13/13 [00:00<00:00, 13.92it/s, Test=2.26e+6, Train=2.29e+6, mem=\n",
+      "Ep 155: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.28e+6, Train=2.09e+6, mem=\n",
+      "Ep 156: 100%|█| 13/13 [00:00<00:00, 13.69it/s, Test=2.24e+6, Train=2.25e+6, mem=\n",
+      "Ep 157: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.19e+6, Train=2.09e+6, mem=\n",
+      "Ep 158: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.27e+6, Train=2.26e+6, mem=\n",
+      "Ep 159: 100%|█| 13/13 [00:00<00:00, 13.43it/s, Test=2.29e+6, Train=2.17e+6, mem=\n",
+      "Ep 160: 100%|█| 13/13 [00:00<00:00, 13.44it/s, Test=2.29e+6, Train=2.06e+6, mem=\n",
+      "Ep 161: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.21e+6, Train=2.42e+6, mem=\n",
+      "Ep 162: 100%|█| 13/13 [00:00<00:00, 13.65it/s, Test=2.31e+6, Train=2.15e+6, mem=\n",
+      "Ep 163: 100%|█| 13/13 [00:00<00:00, 13.61it/s, Test=2.27e+6, Train=2.24e+6, mem=\n",
+      "Ep 164: 100%|█| 13/13 [00:00<00:00, 13.40it/s, Test=2.29e+6, Train=2.26e+6, mem=\n",
+      "Ep 165: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.22e+6, Train=2.17e+6, mem=\n",
+      "Ep 166: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.28e+6, Train=2.23e+6, mem=\n",
+      "Ep 167: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.27e+6, Train=1.99e+6, mem=\n",
+      "Ep 168: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.27e+6, Train=2.19e+6, mem=\n",
+      "Ep 169: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.2e+6, Train=2.07e+6, mem=0\n",
+      "Ep 170: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.25e+6, Train=2.23e+6, mem=\n",
+      "Ep 171: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.27e+6, Train=2.01e+6, mem=\n",
+      "Ep 172: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.27e+6, Train=2.2e+6, mem=0\n",
+      "Ep 173: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.27e+6, Train=2.07e+6, mem=\n",
+      "Ep 174: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.23e+6, Train=2.11e+6, mem=\n",
+      "Ep 175: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.21e+6, Train=2.04e+6, mem=\n",
+      "Ep 176: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.2e+6, Train=2.2e+6, mem=0.\n",
+      "Ep 177: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.25e+6, Train=2.03e+6, mem=\n",
+      "Ep 178: 100%|█| 13/13 [00:00<00:00, 13.87it/s, Test=2.24e+6, Train=2.14e+6, mem=\n",
+      "Ep 179: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=2.09e+6, mem=0\n",
+      "Ep 180: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.24e+6, Train=2.03e+6, mem=\n",
+      "Ep 181: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.23e+6, Train=2.15e+6, mem=\n",
+      "Ep 182: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.23e+6, Train=2.27e+6, mem=\n",
+      "Ep 183: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.2e+6, Train=2.18e+6, mem=0\n",
+      "Ep 184: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.19e+6, Train=2.17e+6, mem=\n",
+      "Ep 185: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.28e+6, Train=2.23e+6, mem=\n",
+      "Ep 186: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.22e+6, Train=2.2e+6, mem=0\n",
+      "Ep 187: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.25e+6, Train=2.07e+6, mem=\n",
+      "Ep 188: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.25e+6, Train=2.17e+6, mem=\n",
+      "Ep 189: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.2e+6, Train=2.02e+6, mem=0\n",
+      "Ep 190: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.24e+6, Train=2.12e+6, mem=\n",
+      "Ep 191: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.24e+6, Train=2.08e+6, mem=\n",
+      "Ep 192: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.27e+6, Train=2.06e+6, mem=\n",
+      "Ep 193: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=2.05e+6, mem=\n",
+      "Ep 194: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.18e+6, Train=1.92e+6, mem=\n",
+      "Ep 195: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.26e+6, Train=2.06e+6, mem=\n",
+      "Ep 196: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.29e+6, Train=1.98e+6, mem=\n",
+      "Ep 197: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.23e+6, Train=2.06e+6, mem=\n",
+      "Ep 198: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.18e+6, Train=2.11e+6, mem=\n",
+      "Ep 199: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.27e+6, Train=2.09e+6, mem=\n",
+      "Ep 200: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.23e+6, Train=2.13e+6, mem=\n",
+      "Ep 201: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=2.23e+6, Train=2.08e+6, mem=\n",
+      "Ep 202: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.21e+6, Train=2.08e+6, mem=\n",
+      "Ep 203: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.25e+6, Train=2.07e+6, mem=\n",
+      "Ep 204: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.22e+6, Train=1.93e+6, mem=\n",
+      "Ep 205: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.23e+6, Train=1.98e+6, mem=\n",
+      "Ep 206: 100%|█| 13/13 [00:00<00:00, 13.40it/s, Test=2.22e+6, Train=2.08e+6, mem=\n",
+      "Ep 207: 100%|█| 13/13 [00:00<00:00, 13.44it/s, Test=2.2e+6, Train=1.93e+6, mem=0\n",
+      "Ep 208: 100%|█| 13/13 [00:00<00:00, 13.66it/s, Test=2.24e+6, Train=2.07e+6, mem=\n",
+      "Ep 209: 100%|█| 13/13 [00:00<00:00, 13.51it/s, Test=2.27e+6, Train=2.04e+6, mem=\n",
+      "Ep 210: 100%|█| 13/13 [00:00<00:00, 13.47it/s, Test=2.24e+6, Train=2.09e+6, mem=\n",
+      "Ep 211: 100%|█| 13/13 [00:00<00:00, 13.50it/s, Test=2.28e+6, Train=2.2e+6, mem=0\n",
+      "Ep 212: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=2.09e+6, mem=\n",
+      "Ep 213: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.21e+6, Train=2.12e+6, mem=\n",
+      "Ep 214: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.23e+6, Train=2.12e+6, mem=\n",
+      "Ep 215: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.19e+6, Train=2.05e+6, mem=\n",
+      "Ep 216: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.2e+6, Train=1.97e+6, mem=0\n",
+      "Ep 217: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.21e+6, Train=1.96e+6, mem=\n",
+      "Ep 218: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.18e+6, Train=1.87e+6, mem=\n",
+      "Ep 219: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.25e+6, Train=1.93e+6, mem=\n",
+      "Ep 220: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.22e+6, Train=2.04e+6, mem=\n",
+      "Ep 221: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.23e+6, Train=1.89e+6, mem=\n",
+      "Ep 222: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.19e+6, Train=2.13e+6, mem=\n",
+      "Ep 223: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=1.95e+6, mem=\n",
+      "Ep 224: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.16e+6, Train=2.01e+6, mem=\n",
+      "Ep 225: 100%|█| 13/13 [00:00<00:00, 13.87it/s, Test=2.17e+6, Train=1.94e+6, mem=\n",
+      "Ep 226: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.19e+6, Train=2.12e+6, mem=\n",
+      "Ep 227: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.19e+6, Train=2.03e+6, mem=\n",
+      "Ep 228: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.17e+6, Train=2.03e+6, mem=\n",
+      "Ep 229: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.19e+6, Train=2.04e+6, mem=\n",
+      "Ep 230: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.21e+6, Train=2.09e+6, mem=\n",
+      "Ep 231: 100%|█| 13/13 [00:00<00:00, 13.87it/s, Test=2.19e+6, Train=1.96e+6, mem=\n",
+      "Ep 232: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.24e+6, Train=1.92e+6, mem=\n",
+      "Ep 233: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.21e+6, Train=2e+6, mem=0.6\n",
+      "Ep 234: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.19e+6, Train=2.02e+6, mem=\n",
+      "Ep 235: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.21e+6, Train=2.07e+6, mem=\n",
+      "Ep 236: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.21e+6, Train=1.99e+6, mem=\n",
+      "Ep 237: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.21e+6, Train=1.86e+6, mem=\n",
+      "Ep 238: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.21e+6, Train=1.91e+6, mem=\n",
+      "Ep 239: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.2e+6, Train=1.96e+6, mem=0\n",
+      "Ep 240: 100%|█| 13/13 [00:00<00:00, 13.87it/s, Test=2.22e+6, Train=2.05e+6, mem=\n",
+      "Ep 241: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.22e+6, Train=1.98e+6, mem=\n",
+      "Ep 242: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.24e+6, Train=1.94e+6, mem=\n",
+      "Ep 243: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.93e+6, mem=\n",
+      "Ep 244: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.22e+6, Train=2.04e+6, mem=\n",
+      "Ep 245: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.21e+6, Train=2.02e+6, mem=\n",
+      "Ep 246: 100%|█| 13/13 [00:00<00:00, 13.58it/s, Test=2.2e+6, Train=1.97e+6, mem=0\n",
+      "Ep 247: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.18e+6, Train=2.06e+6, mem=\n",
+      "Ep 248: 100%|█| 13/13 [00:00<00:00, 13.56it/s, Test=2.21e+6, Train=2e+6, mem=0.6\n",
+      "Ep 249: 100%|█| 13/13 [00:00<00:00, 13.62it/s, Test=2.18e+6, Train=2.06e+6, mem=\n",
+      "Ep 250: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.16e+6, Train=1.92e+6, mem=\n",
+      "Ep 251: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.18e+6, Train=1.88e+6, mem=\n",
+      "Ep 252: 100%|█| 13/13 [00:00<00:00, 13.62it/s, Test=2.24e+6, Train=2.05e+6, mem=\n",
+      "Ep 253: 100%|█| 13/13 [00:00<00:00, 13.48it/s, Test=2.19e+6, Train=1.93e+6, mem=\n",
+      "Ep 254: 100%|█| 13/13 [00:00<00:00, 13.41it/s, Test=2.23e+6, Train=1.96e+6, mem=\n",
+      "Ep 255: 100%|█| 13/13 [00:00<00:00, 13.67it/s, Test=2.17e+6, Train=1.88e+6, mem=\n",
+      "Ep 256: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.19e+6, Train=2.06e+6, mem=\n",
+      "Ep 257: 100%|█| 13/13 [00:00<00:00, 13.34it/s, Test=2.26e+6, Train=2.06e+6, mem=\n",
+      "Ep 258: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.24e+6, Train=2.06e+6, mem=\n",
+      "Ep 259: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.23e+6, Train=1.99e+6, mem=\n",
+      "Ep 260: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.19e+6, Train=1.96e+6, mem=\n",
+      "Ep 261: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.18e+6, Train=1.9e+6, mem=0\n",
+      "Ep 262: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.17e+6, Train=2.2e+6, mem=0\n",
+      "Ep 263: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=2.02e+6, mem=0\n",
+      "Ep 264: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=1.81e+6, mem=0\n",
+      "Ep 265: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.13e+6, Train=2.03e+6, mem=\n",
+      "Ep 266: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.22e+6, Train=2.08e+6, mem=\n",
+      "Ep 267: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.23e+6, Train=1.9e+6, mem=0\n",
+      "Ep 268: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.19e+6, Train=1.91e+6, mem=\n",
+      "Ep 269: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.26e+6, Train=2.02e+6, mem=\n",
+      "Ep 270: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.18e+6, Train=2.02e+6, mem=\n",
+      "Ep 271: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=2.02e+6, mem=0\n",
+      "Ep 272: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.21e+6, Train=1.98e+6, mem=\n",
+      "Ep 273: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.21e+6, Train=1.94e+6, mem=\n",
+      "Ep 274: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.17e+6, Train=2.04e+6, mem=\n",
+      "Ep 275: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.19e+6, Train=1.96e+6, mem=\n",
+      "Ep 276: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=1.92e+6, mem=0\n",
+      "Ep 277: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.23e+6, Train=1.83e+6, mem=\n",
+      "Ep 278: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.2e+6, Train=1.9e+6, mem=0.\n",
+      "Ep 279: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=2.04e+6, mem=0\n",
+      "Ep 280: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.2e+6, Train=1.88e+6, mem=0\n",
+      "Ep 281: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.17e+6, Train=1.99e+6, mem=\n",
+      "Ep 282: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=2.05e+6, mem=\n",
+      "Ep 283: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.18e+6, Train=2.1e+6, mem=0\n",
+      "Ep 284: 100%|█| 13/13 [00:00<00:00, 13.88it/s, Test=2.18e+6, Train=1.94e+6, mem=\n",
+      "Ep 285: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.24e+6, Train=1.93e+6, mem=\n",
+      "Ep 286: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.83e+6, mem=\n",
+      "Ep 287: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.16e+6, Train=1.91e+6, mem=\n",
+      "Ep 288: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.17e+6, Train=1.97e+6, mem=\n",
+      "Ep 289: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=1.9e+6, mem=0\n",
+      "Ep 290: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.14e+6, Train=1.92e+6, mem=\n",
+      "Ep 291: 100%|█| 13/13 [00:00<00:00, 13.54it/s, Test=2.14e+6, Train=2.03e+6, mem=\n",
+      "Ep 292: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=2.16e+6, Train=1.81e+6, mem=\n",
+      "Ep 293: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=2.14e+6, Train=1.91e+6, mem=\n",
+      "Ep 294: 100%|█| 13/13 [00:00<00:00, 13.70it/s, Test=2.19e+6, Train=1.87e+6, mem=\n",
+      "Ep 295: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.17e+6, Train=1.96e+6, mem=\n",
+      "Ep 296: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.21e+6, Train=2.03e+6, mem=\n",
+      "Ep 297: 100%|█| 13/13 [00:00<00:00, 13.61it/s, Test=2.17e+6, Train=2.04e+6, mem=\n",
+      "Ep 298: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.21e+6, Train=1.9e+6, mem=0\n",
+      "Ep 299: 100%|█| 13/13 [00:00<00:00, 13.36it/s, Test=2.17e+6, Train=1.89e+6, mem=\n",
+      "Ep 300: 100%|█| 13/13 [00:00<00:00, 13.67it/s, Test=2.21e+6, Train=2.06e+6, mem=\n",
+      "Ep 301: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.22e+6, Train=2.05e+6, mem=\n",
+      "Ep 302: 100%|█| 13/13 [00:00<00:00, 13.30it/s, Test=2.22e+6, Train=1.91e+6, mem=\n",
+      "Ep 303: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.95e+6, mem=\n",
+      "Ep 304: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.2e+6, Train=1.88e+6, mem=0\n",
+      "Ep 305: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.16e+6, Train=1.9e+6, mem=0\n",
+      "Ep 306: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.18e+6, Train=1.88e+6, mem=\n",
+      "Ep 307: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.2e+6, Train=1.94e+6, mem=0\n",
+      "Ep 308: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.2e+6, Train=1.75e+6, mem=0\n",
+      "Ep 309: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.18e+6, Train=1.91e+6, mem=\n",
+      "Ep 310: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.15e+6, Train=1.89e+6, mem=\n",
+      "Ep 311: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.89e+6, mem=\n",
+      "Ep 312: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.18e+6, Train=2.06e+6, mem=\n",
+      "Ep 313: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=2.01e+6, mem=0\n",
+      "Ep 314: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.18e+6, Train=1.91e+6, mem=\n",
+      "Ep 315: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.15e+6, Train=1.89e+6, mem=\n",
+      "Ep 316: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.15e+6, Train=1.96e+6, mem=\n",
+      "Ep 317: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.82e+6, mem=\n",
+      "Ep 318: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.14e+6, Train=1.82e+6, mem=\n",
+      "Ep 319: 100%|█| 13/13 [00:00<00:00, 13.69it/s, Test=2.19e+6, Train=1.87e+6, mem=\n",
+      "Ep 320: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.14e+6, Train=2e+6, mem=0.6\n",
+      "Ep 321: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.19e+6, Train=1.94e+6, mem=\n",
+      "Ep 322: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.14e+6, Train=1.94e+6, mem=\n",
+      "Ep 323: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=1.94e+6, mem=0\n",
+      "Ep 324: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.13e+6, Train=1.94e+6, mem=\n",
+      "Ep 325: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.19e+6, Train=1.89e+6, mem=\n",
+      "Ep 326: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.15e+6, Train=1.89e+6, mem=\n",
+      "Ep 327: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.93e+6, mem=\n",
+      "Ep 328: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.19e+6, Train=1.88e+6, mem=\n",
+      "Ep 329: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.21e+6, Train=1.81e+6, mem=\n",
+      "Ep 330: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.89e+6, mem=\n",
+      "Ep 331: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.2e+6, Train=1.82e+6, mem=0\n",
+      "Ep 332: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=1.98e+6, mem=0\n",
+      "Ep 333: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.2e+6, Train=1.94e+6, mem=0\n",
+      "Ep 334: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.16e+6, Train=1.93e+6, mem=\n",
+      "Ep 335: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.1e+6, Train=1.93e+6, mem=0\n",
+      "Ep 336: 100%|█| 13/13 [00:00<00:00, 13.57it/s, Test=2.19e+6, Train=1.91e+6, mem=\n",
+      "Ep 337: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.19e+6, Train=1.85e+6, mem=\n",
+      "Ep 338: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=2.12e+6, Train=1.97e+6, mem=\n",
+      "Ep 339: 100%|█| 13/13 [00:00<00:00, 13.68it/s, Test=2.17e+6, Train=1.91e+6, mem=\n",
+      "Ep 340: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.18e+6, Train=1.83e+6, mem=\n",
+      "Ep 341: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.82e+6, mem=\n",
+      "Ep 342: 100%|█| 13/13 [00:00<00:00, 13.66it/s, Test=2.17e+6, Train=1.88e+6, mem=\n",
+      "Ep 343: 100%|█| 13/13 [00:00<00:00, 13.53it/s, Test=2.14e+6, Train=1.92e+6, mem=\n",
+      "Ep 344: 100%|█| 13/13 [00:00<00:00, 13.28it/s, Test=2.21e+6, Train=1.83e+6, mem=\n",
+      "Ep 345: 100%|█| 13/13 [00:00<00:00, 13.69it/s, Test=2.21e+6, Train=2.19e+6, mem=\n",
+      "Ep 346: 100%|█| 13/13 [00:00<00:00, 13.66it/s, Test=2.25e+6, Train=1.91e+6, mem=\n",
+      "Ep 347: 100%|█| 13/13 [00:00<00:00, 13.33it/s, Test=2.28e+6, Train=1.86e+6, mem=\n",
+      "Ep 348: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.22e+6, Train=2e+6, mem=0.6\n",
+      "Ep 349: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.19e+6, Train=1.78e+6, mem=\n",
+      "Ep 350: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.19e+6, Train=1.94e+6, mem=\n",
+      "Ep 351: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.17e+6, Train=2e+6, mem=0.6\n",
+      "Ep 352: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.99e+6, mem=\n",
+      "Ep 353: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=2.13e+6, Train=1.98e+6, mem=\n",
+      "Ep 354: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.12e+6, Train=1.92e+6, mem=\n",
+      "Ep 355: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.14e+6, Train=1.79e+6, mem=\n",
+      "Ep 356: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.2e+6, Train=1.88e+6, mem=0\n",
+      "Ep 357: 100%|█| 13/13 [00:00<00:00, 13.86it/s, Test=2.19e+6, Train=1.81e+6, mem=\n",
+      "Ep 358: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.13e+6, Train=1.81e+6, mem=\n",
+      "Ep 359: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.79e+6, mem=\n",
+      "Ep 360: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.15e+6, Train=1.83e+6, mem=\n",
+      "Ep 361: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.16e+6, Train=1.87e+6, mem=\n",
+      "Ep 362: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.85e+6, mem=\n",
+      "Ep 363: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.19e+6, Train=1.8e+6, mem=0\n",
+      "Ep 364: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.21e+6, Train=1.96e+6, mem=\n",
+      "Ep 365: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.08e+6, Train=1.98e+6, mem=\n",
+      "Ep 366: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 367: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.9e+6, mem=0\n",
+      "Ep 368: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=1.78e+6, mem=0\n",
+      "Ep 369: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.12e+6, Train=1.84e+6, mem=\n",
+      "Ep 370: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.14e+6, Train=1.91e+6, mem=\n",
+      "Ep 371: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.17e+6, Train=1.83e+6, mem=\n",
+      "Ep 372: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.17e+6, Train=1.86e+6, mem=\n",
+      "Ep 373: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.13e+6, Train=1.88e+6, mem=\n",
+      "Ep 374: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.22e+6, Train=2.03e+6, mem=\n",
+      "Ep 375: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.17e+6, Train=1.84e+6, mem=\n",
+      "Ep 376: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.12e+6, Train=1.77e+6, mem=\n",
+      "Ep 377: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.14e+6, Train=1.87e+6, mem=\n",
+      "Ep 378: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.16e+6, Train=1.86e+6, mem=\n",
+      "Ep 379: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.17e+6, Train=1.84e+6, mem=\n",
+      "Ep 380: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.19e+6, Train=1.84e+6, mem=\n",
+      "Ep 381: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.18e+6, Train=1.91e+6, mem=\n",
+      "Ep 382: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.1e+6, Train=1.84e+6, mem=0\n",
+      "Ep 383: 100%|█| 13/13 [00:00<00:00, 13.56it/s, Test=2.17e+6, Train=1.85e+6, mem=\n",
+      "Ep 384: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 385: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.79e+6, mem=\n",
+      "Ep 386: 100%|█| 13/13 [00:00<00:00, 13.75it/s, Test=2.2e+6, Train=1.82e+6, mem=0\n",
+      "Ep 387: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.11e+6, Train=1.72e+6, mem=\n",
+      "Ep 388: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.15e+6, Train=1.92e+6, mem=\n",
+      "Ep 389: 100%|█| 13/13 [00:00<00:00, 13.46it/s, Test=2.15e+6, Train=1.96e+6, mem=\n",
+      "Ep 390: 100%|█| 13/13 [00:00<00:00, 13.43it/s, Test=2.1e+6, Train=1.84e+6, mem=0\n",
+      "Ep 391: 100%|█| 13/13 [00:00<00:00, 13.62it/s, Test=2.16e+6, Train=1.96e+6, mem=\n",
+      "Ep 392: 100%|█| 13/13 [00:00<00:00, 13.52it/s, Test=2.15e+6, Train=1.85e+6, mem=\n",
+      "Ep 393: 100%|█| 13/13 [00:00<00:00, 13.54it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 394: 100%|█| 13/13 [00:00<00:00, 13.49it/s, Test=2.13e+6, Train=1.86e+6, mem=\n",
+      "Ep 395: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.13e+6, Train=1.8e+6, mem=0\n",
+      "Ep 396: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.14e+6, Train=1.85e+6, mem=\n",
+      "Ep 397: 100%|█| 13/13 [00:00<00:00, 13.64it/s, Test=2.2e+6, Train=1.87e+6, mem=0\n",
+      "Ep 398: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.19e+6, Train=1.71e+6, mem=\n",
+      "Ep 399: 100%|█| 13/13 [00:00<00:00, 13.71it/s, Test=2.13e+6, Train=1.79e+6, mem=\n",
+      "Ep 400: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.1e+6, Train=1.81e+6, mem=0\n",
+      "Ep 401: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=1.87e+6, mem=\n",
+      "Ep 402: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.16e+6, Train=1.97e+6, mem=\n",
+      "Ep 403: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 404: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.14e+6, Train=1.74e+6, mem=\n",
+      "Ep 405: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.17e+6, Train=1.84e+6, mem=\n",
+      "Ep 406: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.18e+6, Train=1.78e+6, mem=\n",
+      "Ep 407: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.11e+6, Train=1.79e+6, mem=\n",
+      "Ep 408: 100%|█| 13/13 [00:00<00:00, 13.75it/s, Test=2.13e+6, Train=1.87e+6, mem=\n",
+      "Ep 409: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.14e+6, Train=1.9e+6, mem=0\n",
+      "Ep 410: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.14e+6, Train=1.76e+6, mem=\n",
+      "Ep 411: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.11e+6, Train=1.8e+6, mem=0\n",
+      "Ep 412: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.13e+6, Train=1.86e+6, mem=\n",
+      "Ep 413: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.18e+6, Train=1.84e+6, mem=\n",
+      "Ep 414: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.14e+6, Train=1.77e+6, mem=\n",
+      "Ep 415: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.19e+6, Train=1.79e+6, mem=\n",
+      "Ep 416: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.17e+6, Train=1.84e+6, mem=\n",
+      "Ep 417: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.18e+6, Train=1.98e+6, mem=\n",
+      "Ep 418: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.16e+6, Train=1.91e+6, mem=\n",
+      "Ep 419: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.14e+6, Train=1.86e+6, mem=\n",
+      "Ep 420: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.2e+6, Train=1.85e+6, mem=0\n",
+      "Ep 421: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.15e+6, Train=1.91e+6, mem=\n",
+      "Ep 422: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.18e+6, Train=1.87e+6, mem=\n",
+      "Ep 423: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.16e+6, Train=1.87e+6, mem=\n",
+      "Ep 424: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=1.77e+6, mem=\n",
+      "Ep 425: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.15e+6, Train=1.82e+6, mem=\n",
+      "Ep 426: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.17e+6, Train=1.83e+6, mem=\n",
+      "Ep 427: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.11e+6, Train=1.8e+6, mem=0\n",
+      "Ep 428: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=1.87e+6, mem=0\n",
+      "Ep 429: 100%|█| 13/13 [00:00<00:00, 13.58it/s, Test=2.18e+6, Train=1.76e+6, mem=\n",
+      "Ep 430: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.18e+6, Train=1.87e+6, mem=\n",
+      "Ep 431: 100%|█| 13/13 [00:00<00:00, 13.56it/s, Test=2.19e+6, Train=1.8e+6, mem=0\n",
+      "Ep 432: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.1e+6, Train=1.98e+6, mem=0\n",
+      "Ep 433: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.09e+6, Train=1.79e+6, mem=\n",
+      "Ep 434: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.14e+6, Train=1.93e+6, mem=\n",
+      "Ep 435: 100%|█| 13/13 [00:00<00:00, 13.62it/s, Test=2.15e+6, Train=1.78e+6, mem=\n",
+      "Ep 436: 100%|█| 13/13 [00:00<00:00, 13.42it/s, Test=2.2e+6, Train=1.76e+6, mem=0\n",
+      "Ep 437: 100%|█| 13/13 [00:00<00:00, 13.41it/s, Test=2.21e+6, Train=1.77e+6, mem=\n",
+      "Ep 438: 100%|█| 13/13 [00:00<00:00, 13.63it/s, Test=2.18e+6, Train=1.81e+6, mem=\n",
+      "Ep 439: 100%|█| 13/13 [00:00<00:00, 13.33it/s, Test=2.17e+6, Train=1.76e+6, mem=\n",
+      "Ep 440: 100%|█| 13/13 [00:00<00:00, 13.31it/s, Test=2.17e+6, Train=1.82e+6, mem=\n",
+      "Ep 441: 100%|█| 13/13 [00:00<00:00, 13.63it/s, Test=2.14e+6, Train=1.68e+6, mem=\n",
+      "Ep 442: 100%|█| 13/13 [00:00<00:00, 13.94it/s, Test=2.15e+6, Train=1.8e+6, mem=0\n",
+      "Ep 443: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.12e+6, Train=1.81e+6, mem=\n",
+      "Ep 444: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.08e+6, Train=1.73e+6, mem=\n",
+      "Ep 445: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.15e+6, Train=1.8e+6, mem=0\n",
+      "Ep 446: 100%|█| 13/13 [00:00<00:00, 13.72it/s, Test=2.17e+6, Train=1.82e+6, mem=\n",
+      "Ep 447: 100%|█| 13/13 [00:00<00:00, 13.90it/s, Test=2.07e+6, Train=1.7e+6, mem=0\n",
+      "Ep 448: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.16e+6, Train=1.78e+6, mem=\n",
+      "Ep 449: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.22e+6, Train=1.82e+6, mem=\n",
+      "Ep 450: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.2e+6, Train=1.69e+6, mem=0\n",
+      "Ep 451: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.19e+6, Train=1.8e+6, mem=0\n",
+      "Ep 452: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.11e+6, Train=1.86e+6, mem=\n",
+      "Ep 453: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.13e+6, Train=1.74e+6, mem=\n",
+      "Ep 454: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.18e+6, Train=1.77e+6, mem=\n",
+      "Ep 455: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.14e+6, Train=1.83e+6, mem=\n",
+      "Ep 456: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.11e+6, Train=1.91e+6, mem=\n",
+      "Ep 457: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.12e+6, Train=1.84e+6, mem=\n",
+      "Ep 458: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.14e+6, Train=1.77e+6, mem=\n",
+      "Ep 459: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.15e+6, Train=1.81e+6, mem=\n",
+      "Ep 460: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.15e+6, Train=1.8e+6, mem=0\n",
+      "Ep 461: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.15e+6, Train=1.71e+6, mem=\n",
+      "Ep 462: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.19e+6, Train=1.86e+6, mem=\n",
+      "Ep 463: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.15e+6, Train=1.79e+6, mem=\n",
+      "Ep 464: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.14e+6, Train=1.82e+6, mem=\n",
+      "Ep 465: 100%|█| 13/13 [00:00<00:00, 13.77it/s, Test=2.18e+6, Train=1.88e+6, mem=\n",
+      "Ep 466: 100%|█| 13/13 [00:00<00:00, 13.87it/s, Test=2.2e+6, Train=1.82e+6, mem=0\n",
+      "Ep 467: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 468: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.19e+6, Train=1.86e+6, mem=\n",
+      "Ep 469: 100%|█| 13/13 [00:00<00:00, 13.79it/s, Test=2.19e+6, Train=1.8e+6, mem=0\n",
+      "Ep 470: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.74e+6, mem=\n",
+      "Ep 471: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.13e+6, Train=1.8e+6, mem=0\n",
+      "Ep 472: 100%|█| 13/13 [00:00<00:00, 13.82it/s, Test=2.16e+6, Train=1.77e+6, mem=\n",
+      "Ep 473: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.15e+6, Train=1.76e+6, mem=\n",
+      "Ep 474: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.18e+6, Train=1.83e+6, mem=\n",
+      "Ep 475: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.16e+6, Train=1.75e+6, mem=\n",
+      "Ep 476: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.17e+6, Train=1.77e+6, mem=\n",
+      "Ep 477: 100%|█| 13/13 [00:00<00:00, 13.58it/s, Test=2.13e+6, Train=1.66e+6, mem=\n",
+      "Ep 478: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.14e+6, Train=1.83e+6, mem=\n",
+      "Ep 479: 100%|█| 13/13 [00:00<00:00, 13.73it/s, Test=2.16e+6, Train=1.84e+6, mem=\n",
+      "Ep 480: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.16e+6, Train=1.74e+6, mem=\n",
+      "Ep 481: 100%|█| 13/13 [00:00<00:00, 13.85it/s, Test=2.21e+6, Train=1.85e+6, mem=\n",
+      "Ep 482: 100%|█| 13/13 [00:00<00:00, 13.39it/s, Test=2.14e+6, Train=1.68e+6, mem=\n",
+      "Ep 483: 100%|█| 13/13 [00:00<00:00, 13.44it/s, Test=2.15e+6, Train=1.94e+6, mem=\n",
+      "Ep 484: 100%|█| 13/13 [00:00<00:00, 13.60it/s, Test=2.14e+6, Train=1.81e+6, mem=\n",
+      "Ep 485: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.12e+6, Train=1.73e+6, mem=\n",
+      "Ep 486: 100%|█| 13/13 [00:00<00:00, 13.55it/s, Test=2.19e+6, Train=1.93e+6, mem=\n",
+      "Ep 487: 100%|█| 13/13 [00:00<00:00, 13.58it/s, Test=2.12e+6, Train=1.8e+6, mem=0\n",
+      "Ep 488: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.14e+6, Train=1.74e+6, mem=\n",
+      "Ep 489: 100%|█| 13/13 [00:00<00:00, 13.80it/s, Test=2.21e+6, Train=1.73e+6, mem=\n",
+      "Ep 490: 100%|█| 13/13 [00:00<00:00, 13.90it/s, Test=2.16e+6, Train=1.82e+6, mem=\n",
+      "Ep 491: 100%|█| 13/13 [00:00<00:00, 13.78it/s, Test=2.16e+6, Train=1.94e+6, mem=\n",
+      "Ep 492: 100%|█| 13/13 [00:00<00:00, 13.68it/s, Test=2.15e+6, Train=1.69e+6, mem=\n",
+      "Ep 493: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.2e+6, Train=1.81e+6, mem=0\n",
+      "Ep 494: 100%|█| 13/13 [00:00<00:00, 13.76it/s, Test=2.15e+6, Train=1.8e+6, mem=0\n",
+      "Ep 495: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.13e+6, Train=1.81e+6, mem=\n",
+      "Ep 496: 100%|█| 13/13 [00:00<00:00, 13.84it/s, Test=2.17e+6, Train=1.81e+6, mem=\n",
+      "Ep 497: 100%|█| 13/13 [00:00<00:00, 13.70it/s, Test=2.19e+6, Train=1.78e+6, mem=\n",
+      "Ep 498: 100%|█| 13/13 [00:00<00:00, 13.81it/s, Test=2.11e+6, Train=1.84e+6, mem=\n",
+      "Ep 499: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.13e+6, Train=1.65e+6, mem=\n",
+      "Ep 500: 100%|█| 13/13 [00:00<00:00, 13.83it/s, Test=2.17e+6, Train=1.79e+6, mem="
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 7min 49s, sys: 3.32 s, total: 7min 53s\n",
+      "Wall time: 7min 55s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Set up the optimizer and train the VAE\n",
@@ -1403,7 +2817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 85,
    "id": "2e8ce422-7576-4178-9192-be428994be20",
    "metadata": {
     "scrolled": true,
@@ -1433,10 +2847,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 86,
    "id": "8150f5d8-8b5a-403e-a7df-687028e93817",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb0AAAFbCAYAAABBM1DbAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAABQbUlEQVR4nO3deVhUZfvA8e9sDDuyiIgg4oqKG4KKe5aaS4u2mVa2v6aWZXuWS7/K9t5WLVust8zeXtOs3LByyQ3FDfcNFUFEZN+GYeb8/hgdHFkEBAaY+3NdXtecc55zzn2DcHPOec7zqBRFURBCCCEcgNreAQghhBB1RYqeEEIIhyFFTwghhMOQoieEEMJhSNETQgjhMKToCSGEcBhS9IQQQjgMKXpCCCEchhQ9IYQQDkOKnhBCCIfRaIrehg0buOmmmwgMDESlUrFs2bIqH0NRFN59913at2+PXq8nODiYN954o+aDFUIIYRdaewdQU/Ly8ujWrRsPPPAAt912W7WOMW3aNNasWcO7775Lly5dyMrKIi0trYYjFUIIYS+qxjjgtEqlYunSpdx6663WdUVFRbz88sv88MMPZGZmEh4ezltvvcXgwYMBOHjwIF27dmXfvn106NDBPoELIYSoVY3m9ubVPPDAA2zatInFixezd+9e7rjjDm688UaOHj0KwG+//Ubr1q35/fffCQ0NpVWrVjz88MOkp6fbOXIhhBA1xSGK3vHjx/nxxx/5+eefGTBgAG3atOGZZ56hf//+fPPNNwCcOHGCU6dO8fPPP/Pdd9+xcOFC4uLiuP322+0cvRBCiJrSaJ7pVWTnzp0oikL79u1t1hsMBnx9fQEwm80YDAa+++47a7uvvvqKnj17cvjwYbnlKYQQjYBDFD2z2YxGoyEuLg6NRmOzzd3dHYDmzZuj1WptCmPHjh0BOH36tBQ9IYRoBByi6PXo0QOTyURqaioDBgwos02/fv0oLi7m+PHjtGnTBoAjR44AEBISUmexCiGEqD2Npvdmbm4ux44dAyxF7v333+e6667Dx8eHli1bcs8997Bp0ybee+89evToQVpaGn/99RddunRh5MiRmM1moqKicHd359///jdms5kpU6bg6enJmjVr7JydEEKImtBoit66deu47rrrSq2fOHEiCxcuxGg08tprr/Hdd9+RlJSEr68v0dHRzJkzhy5dugCQnJzM448/zpo1a3Bzc2PEiBG89957+Pj41HU6QgghakGjKXpCCCHE1TjEKwtCCCEENPCOLGazmeTkZDw8PFCpVPYORwghhJ0oikJOTg6BgYGo1eVfzzXoopecnExwcLC9wxBCCFFPJCYmEhQUVO72Bl30PDw8AEuSnp6e1T6O0WhkzZo1DBs2DJ1OV1Ph2Z3k1bA01ryg8eYmedUf2dnZBAcHW+tCeRp00bt0S9PT0/Oai56rqyuenp4N5htcGZJXw9JY84LGm5vkVf9c7VGXdGQRQgjhMKToCSGEcBhS9IQQQjgMKXpCCCEchhQ9IYQQDkOKnhBCCIchRU8IIYTDkKInhBDCYUjRA3b+/jmFSXvtHYYQQoha1qBHZKkJSSf203vPDHoDRl6wdzhCCCFqkcNf6eWcT7J3CEIIIeqIwxc9IYQQjkOKnhBCCIchRU8mnxVCCIchRU9R7B2BEEKIOiJFTwghhMOQoie3N4UQwmFI0RNCCOEwpOgJIYRwGFL0hBBCOAwpekIIIRyGFD0hhBAOw+GLXsbeFdbPitlsx0iEEELUNocveqh19o5ACCFEHZGipymZXUmR0VmEEKJRs2vRmz17NiqVyuZfQEBAncag0pRc6UnRE0KIxs3uk8h27tyZtWvXWpc1Gk3dBqCSi10hhHAUdi96Wq22zq/ubFxW9M6ePEhoxwj7xSKEEKJW2b3oHT16lMDAQPR6Pb179+aNN96gdevWZbY1GAwYDAbrcnZ2NgBGoxGj0Vit85uLFPIL3QGFgiVTMT6/vlrHqY8ufU2q+7WprySvhqex5iZ51R+VjVWl2PFB1sqVK8nPz6d9+/acO3eO1157jUOHDrF//358fX1LtZ89ezZz5swptX7RokW4urpWKwbz2n9INo7AM/8U/Vu/zd4eb1brOEIIIewnPz+f8ePHk5WVhaenZ7nt7Fr0rpSXl0ebNm147rnnmD59eqntZV3pBQcHk5aWVmGSFVk/Zy6H0/rjkX+awW3eovlLe6sdf31jNBqJiYlh6NCh6HSN59UMyavhaay5SV71R3Z2Nn5+flctena/vXk5Nzc3unTpwtGjR8vcrtfr0ev1pdbrdLpqf2NUakvHmRzXloCqwXyDq+Javj71meTV8DTW3CQv+6tsnPWq66LBYODgwYM0b968zs6p0pR8CVyzzBQbi+rs3EIIIeqWXYveM888w/r160lISGDbtm3cfvvtZGdnM3HixDqMouRLcCEvmLj5D9fhuYUQQtQlu97ePHPmDHfffTdpaWk0bdqUPn36sHXrVkJCQuoshqKckqJnMLnimX2szs4thBCibtm16C1evNiepwfAo2kw5Fo+m811/GK8EEKIOlWvnunZg9655FWHTGPdPUsUQghR9xy+6JmLS6YT2u92G1Bv3uAQQghRwxy+6JmMtnPoqewUhxBCiNrn8EWv630DbZYVKXtCCNFoOXzRcwv0s1lWZNYFIYRotOQ3/BX8ixLtHYIQQohaIkXvCn5k2jsEIYQQtUSKnhBCCIchRU8IIYTDkKInhBDCYUjRAzwLSzqvmM3yyoIQQjRWUvQAH49z1s9ms0amFxJCiEZKih6g9zNZP5sULTuWfmjHaIQQQtQWKXqAazsn6+fCIldU5+LtGI0QQojaIkUP0J/+0/p5V8pI1MZ8O0YjhBCitkjRAwz+XayfixRXorJj7BiNEEKI2iJFD2g/6gnr56PuI8gvdLNjNEIIIWqLFD3Ay8ffZnlL0p12ikQIIURtkqJXhkNuN9s7BCGEELVAil458vNy7B2CEEKIGiZFrxwH1//X3iEIIYSoYVL0LuqY96vtCkWxTyBCCCFqjRS9i4a0WWiznH/uuH0CEUIIUWuk6JVjwOnP7B2CEEKIGiZF76K/tQPtHYIQQohaJkXvojydj71DEEIIUcuk6JVD5tUTQojGR4reRfnN++Gdd9S6bDJr7BiNEEKI2iBF7yKVkwu3Bc+yLidntLVjNEIIIWqDFL1LzGY0aqN18VxeOzsGI4QQojZI0btEMaNWl8ygXqzo7BiMEEKI2iBF7yK1kwtqdckoLCbFqYLWQgghGiIpehdpnVwovOzqzl17wY7RCCGEqA1S9C5zxLkrTsZsAPSafDtHI4QQoqbVm6I3d+5cVCoVTz75pN1iUFQq3IvOAmAya+0WhxBCiNpRL4re9u3b+eKLL+jatau9Q0GFGQAT8p6eEEI0NnYverm5uUyYMIEFCxbg7e1t52hUqBVLD05FkaInhBCNjd3v4U2ZMoVRo0Zxww038Nprr1XY1mAwYDAYrMvZ2Zbnb0ajEaPRWN5uV3X5vpeu9MyKmj2bV9Mpaki1j2tvl/K6lq9NfSR5NTyNNTfJq/6obKx2LXqLFy9m586dbN++vVLt586dy5w5c0qtX7NmDa6urtccj6GoiFR3yy3WY0UDaPr3p6w4X3jNx7W3mJgYe4dQKySvhqex5iZ52V9+fuU6H9qt6CUmJjJt2jTWrFmDs7NzpfZ58cUXmT59unU5Ozub4OBghg0bhqenZ7VjMRqNxMTE4OSkt65L8+hMR9USBowcWe3j2tulvIYOHYpO13hetpe8Gp7GmpvkVX9cuvN3NXYrenFxcaSmptKzZ0/rOpPJxIYNG/jkk08wGAxoNLbP1fR6PXq9/spDodPpaugbYzuzQkDRqQbzDa9IzX196hfJq+FprLlJXvZX2TjtVvSuv/564uPjbdY98MADhIWF8fzzz5cqeHWhoEl7m2UFmV5ICCEaE7sVPQ8PD8LDw23Wubm54evrW2p9Xel012xObF5KpmsbfPMOo9i/c6sQQogaJL/VL+Pq7kUIsZbPShoBnLdzREIIIWqS3V9ZuNy6devsHYJ1eiGzUq++NEIIIWqAXOldQYOl6JlUloeiu9b/as9whBBC1CApelcoVFuK3TnXLgC4bnzDnuEIIYSoQVL0rpCuWHpwKheLn/TgFEKIxkOK3hVMTk1tV0jNE0KIRkOK3hX0zsoVa6TqCSFEYyFF7woBUSUzPeQVeHBlCRRCCNFwSdG7gnuwj/XzyjNP077ooB2jEUIIUZOk6F2hXb9B1s/ZTi3QqORaTwghGgspelfQaEteSjerZCJZIYRoTKToVcDgZO+Z3IUQQtQkKXpCCCEchhS9Kjh5dB852Zn2DkMIIUQ1SdGrpKN7NtPqh34UvN/d3qEIIYSoJil6ZWiVu67UurQdvwDgT0YdRyOEEKKmSNErQ5aqhc1yTm5Ome0Us7kuwhFCCFFDpOiVwaRysn7ef6YvHu8GEZ24wKbN1p/fI+3VUI7t3VLX4QkhhKgmKXplcDenWj+v0z5bZps++1+lKZmolj1WV2EJIYS4RlL0ytDFfWWl26qRW5xCCNFQSNErQ5D3YZvlrFyfclqCSoqeEEI0GFL0yuCsz7dZTs7qUG7bVuZEio3G2g5JCCFEDdBevUlpSUlJbNq0idTUVMxX9GB84oknaiSw+sR8lb8NUpNOENiq/MIohBCifqhy0fvmm2+YNGkSTk5O+Pr6olKVTLKqUqkaRdHbr+9us3ygYBid2WRdzs/LxvXyBorMxCCEEA1BlYvezJkzmTlzJi+++CJqdeO8O2rUuNgsp7p3tVnOfzsc18smVFek6AkhRINQ5aqVn5/PuHHjGm3BA0BRcDaklbvZT5V1xZrSnVlMxcXs/Ot/pJ9PqeHghBBCVFeVK9dDDz3Ezz//XBux1BsqFMb4vmyzLu7k8HLbK+bSV3qxP79DxIaHyP90YI3HJ4QQonqqfHtz7ty5jB49mlWrVtGlSxd0Op3N9vfff7/GgrMfBR/3c5Bbsmar8yR6srrM1saiQjb/911cj6/AqPMicvoSvBL+ACCIc3URsBBCiEqoctF74403WL16NR06WHorXtmRpTEwd5sAW2Mr3f786nfom7XKsmCApJOHkKd8QghR/1S56L3//vt8/fXX3H///bUQTv3g5Olf5vqlR17AR32aAa0XcfkjzdCsbTbtzGZTbYYnhBCimqpc9PR6Pf369auNWOqPcnpjJnv2JpneND17ik4tSl5haHrFdEO672+hMxdqNUQhhBBVV+WOLNOmTePjjz+ujVjqjZadIivc/rfmGTYdv52cfK8ytwdcUfC2LH6brMz0GotPCCFE9VT5Si82Npa//vqL33//nc6dO5fqyPLLL7/UWHD24uHdjOzJ+7j+lYf5U/V8mW12u03geMoA7ms97arHiz70OnGJ/9Dz2eU1HaoQQogqqHLRa9KkCWPHjq2NWOoVT/9gPJtv5c8KXrPLcW3JgTPRdAq6+px6PfPW12B0QgghqqNKRa+4uJjBgwczfPhwAgICaiumesUrP4Es19Byt/+tfY59R/dxe5tXuNr7+vu3rqZzn/Lf9xNCCFG7qvRMT6vV8thjj2EwGGornnrnBu+PrtrmvEc4206OZWHCPD5NWUqBwbXMdp1X3UlK4vGaDlEIIUQlVbkjS+/evdm1a1eNnHzevHl07doVT09PPD09iY6OZuXKyk/gWhcCvE9Wqt1O13vJc7Fc/f59+iEKDS6kpIeUape4eDqxv32B2STz8AkhRF2r8jO9yZMn8/TTT3PmzBl69uyJm5ubzfauXbuWs2dpQUFBvPnmm7Rt2xaAb7/9lltuuYVdu3bRuXPnqoZWazrk/cFht1GVbp/gMYTvU7pj0PswMvUVQv33WbdF5a2DuHVsRyHqpn/VQrRCCCHKU+Wid9dddwG28+apVCoURUGlUmEyVf7F7Jtuuslm+fXXX2fevHls3bq1XhW961p9jc/ZMxSZnYlzmlipfQx6y2zre7JG2RS9S8wnNwNS9IQQoi5VueglJCTURhyYTCZ+/vln8vLyiI6OLrONwWCweZ6YnZ0NgNFoxHgNs5df2vfKY1x6GUOjMRMRZBlmLC6lckXvkiSPPmw/OZKoVits1ve+sIxty78gYsQD1Qu6EsrLq6GTvBqexpqb5FV/VDZWlWLnyeDi4+OJjo6msLAQd3d3Fi1axMiRI8tsO3v2bObMmVNq/aJFi3B1LbvzyLUoOhvPHSnv2Kw7khLF5sL7yXMOrNKx/HP2MMR/Pr5etu9A/Nrju2uOUwghHF1+fj7jx48nKysLT0/PcttVq+j95z//Yf78+SQkJLBlyxZCQkL497//TWhoKLfcckuVjlVUVMTp06fJzMxkyZIlfPnll6xfv55OnTqValvWlV5wcDBpaWkVJnk1RqORmJgYhg4dWupl++S53Qkxnym1j8msZn7qkiqfa4DxA7oGbyg594zy5+27VhXl1ZBJXg1PY81N8qo/srOz8fPzu2rRq/LtzXnz5jFz5kyefPJJXn/9deszvCZNmvDvf/+7ykXPycnJ2pElMjKS7du38+GHH/L555+XaqvX69Hr9aXW63S6GvnGlH2csmeO0KjNDFe9xmrl5TK3l2ej7im6UlL0dDodyaeO4u7th6end1VDrpSa+vrUN5JXw9NYc5O87K+ycVb5lYWPP/6YBQsWMGPGDDQajXV9ZGQk8fHxVT1cKYqi1Kv3AIvUzuVua9ssjn81vaPKx8zJb2L9nJRwmMBvItG816E64QkhhKiCKhe9hIQEevToUWq9Xq8nLy+vSsd66aWX2LhxIydPniQ+Pp4ZM2awbt06JkyYUNWwao3T7V9UuF2rKaZpXunemRX5LvsbzCbLFWSLb3sB4KYysOWndyjIy61oVyGEENegykUvNDSU3bt3l1q/cuXKMp/DVeTcuXPce++9dOjQgeuvv55t27axatUqhg4dWtWwak1IWMRV29wcNJdBpg942O8uWuZtump7gG9Pz2N/Ul+bddEHX2P3d89UK04hhBBXV+Vnes8++yxTpkyhsLAQRVGIjY3lxx9/ZO7cuXz55ZdVOtZXX31V1dPXS876fMJbWJ7T3dTmXf44buKk28AK98l3acY6nqUzY2zWB5zfXGtxCiGEo6ty0XvggQcoLi7mueees3YRbdGiBR9++CHjxo2rjRjrnV0e1+FcmEpH4/4yt49q8wHzk3ph0pT/PPCS1Mwg/JuU9A4NNZ+qsTiFEELYqvLtTYBHHnmEU6dOkZqaSkpKComJiTz00EM1HVu9kXD7SmLbPG5d1kXdT7ZXxR1PJrW4m4leD9Cl4L/ojOU/p7uQ36LUup1v3cimb14AwCRjdAohRI2pctEbMmQImZmZAPj5+eHv7w9Y3pEYMmRIjQZXX4SG96XXva8R2/5p4rxH0Ln/TVffCXB3yWRg6I/c7ft4uW3+Ur9Qal1EwRb6nZrHlv/9m5xXg9i3dXW1YxdCCFGiyrc3161bR1FRUan1hYWFbNy4sUaCqq96jZ9ZsuDuD5V8r9zDNROyy9++/0xf2jXbgZPO9usavW8WqKB41aPQ5+q3PeM3/YEh+wKRI+6rXGBCCOFgKl309u7da/184MABUlJKhtMymUysWrWKFi1K36prrLrdMQPemV8jx1qnfZZ1F2CQ8X3Cg8v+w6HYaGT78s8I7DqE1CPbKDqfQL/7X7dp0yVmPADJHXsT2Ere+xNCiCtVuuh1794dlUqFSqUq8zami4sLH3/8cY0GV585u3lyeNQSOvxxW6Xa3+k6lf/mf1Jhm/W66TTNOEUz79M26/3I5MzrnYnmHMTP5NIsfYfjbsBkNnPh0Caibn+GS91mctKSQIqeEEKUUulnegkJCRw/ftz6mkJCQoL1X1JSEtnZ2Tz44IO1GWu90yHqBvYN/Jwz49cT29z2hfqTd66xWW7qmUTvoopfdAf4n+FDElPbYyzW2KwP4lyptgXpZ+n0x1gGHH+P0+8OqPC4KWdOsGnBdFKTTl41BiGEaKwqfaUXEmK5vjCbpTfh5cKHWF7TyM24Fc7+AMD5h+NoFdS2VNvIlivpYV6NWmXm+5Mfku3SssxjLje/BefNTGle8VWk2Vxs/dzedKzCtnlfj6Gf+SRHv16P/ytxFbYVQojGqlqvLIjSFEomq2h6seCdvGMNZsV2wGqN2oxKBfeGTsMn/0j5B1Sp2Xj8rgrPaTzwRzmxlCjISGLfeyNpYz4JQLurFEchhGjMpOjVECcXt1LrWnXujfnlVGJDJ5e5z92tn6/wmHvdxrHu2D0UF1suyDeduJ1Fx962jtvZO2tVmfuF/T6GM8cPADAg4X16FMbabI/9fQGnjuypOCEhhGiEpOjVkNbhfdne9DZi206zWa/VORExfg4X8CZJ3bzUld/V7He/jRUnnuTPY/ez23UCGe7tWJzw5lX3O7/kaYzGIlqozpfa1mvHM4Qssh0mraioCEVuXQshGrkqv6cnyqZSq4ma8nWZ27Q6J5rMOIJKpSY3Mw3PT0p6VobkbuCUe8XjdCZ69rNZznBvf9V41IoJ17crnt09Py+bXb98gHPSFnoWbiHOOZqeL5R99SiEEI1BlYteYmIiKpWKoKAgAGJjY1m0aBGdOnXi0UcfrfEAGwuNzgkAT78Am/VuqgvVOt7uU0M4XDSETs5r2KB7igFFH9K15Trr9m4F2656DNd3grm8nPYs3AJAYUEeh2LXENZrOM4urtWKTwgh6qMq394cP348f//9NwApKSkMHTqU2NhYXnrpJV599dUaD7Cxc9dWr+ht0j9OmkdnNuieAmCj0zT2Jg5i0/HbyC8s/XzxStl5TSgyOpW5be+8B+j+9/3sme9Yr6AIIRq/Khe9ffv20auXZeLT//73v4SHh7N582YWLVrEwoULazq+Rim2tWUszhxc6RG0itDcvxlQ/CEPeN9Dm7y11T7uRt2T7Ha7h28yv+fTlKXMS/4vmTl+AFz+uC4zx4//5HzDf5I/s667tP3U0Xh6ZVvG+uydtbLasQghRH1U5dubRqMRvV4PwNq1a7n55psBCAsL4+zZszUbXSPV677XMBpmkJN8Eo9v+zCy7UfWbTe2+ZS9SfvZqJlWwREqx6zW8UPeArg4ob17/hlyXYPomPsruEOh3pevTn2FR1EymfoQbtC/Q+sf+lf6+Ed2/8O57cvoc/9cdDrdNccrhBC1rcpXep07d2b+/Pls3LiRmJgYbrzxRgCSk5Px9fWt8QAbK53ehcDQjmRPO1pqW9cW65jUtHLDm1VFrqvlOexB91us6wr1Ppz3CMfo5MFK5VVy8pvwx9FpnDofBsCWf4+nsMBSNU8cjOP8uTOkpZ6lsLCA9stGMSBpAbrX/Wo8ViGEqA1VvtJ76623GDNmDO+88w4TJ06kW7duACxfvtx621NUnqe3Pzt8RhOZ/rvNeo3GjIshjQK9H26FZ8lzbl4n8XyX/Q14wEnTYKYwBvf4HH7+1090HdOMbnvGl7tf/OaVdOk7ok5iFEKI6qpy0Rs8eDBpaWlkZ2fj7e1tXf/oo4/i6io9/aoj8okfYLZXqfVj/V7g8Pl+dG8Rg15XAFievc1LXVonce1P7GvpKKODA78coVsbyMn3YsuZu2jhso+OgVtQayzjv3RZM47CsERMBYVofNw4FLuWsF5DcXZxxWQyowLUmtI3Fg7HrSNj4wLa3P0mLm5euLt7VivWrT+/j/fB72kxfV21jyGEaPyqXPQKCgpQFMVa8E6dOsXSpUvp2LEjw4cPr/EAHVkTtwv0dltus06thtZ5f3LC7fpaP/863bPWz+lu7fnv0Vc579EFPOEoI1h3HoaY3kKjMmIodmPDSzus7Uer3iRu4xJ0XaLptesFYhNGkWjqik9YBhF3PY5roC9aV2c6/HbxVus8y5XuJv/xOOeepu3D3+LlU/nbpn32z7F8eDcYZmdde/JCiEapykXvlltuYezYsUyaNInMzEx69+6NTqcjLS2N999/n8cee6w24hSXGdHmEwzGL9HrCskr9ODEhQg2aJ6s9fOe9+hSat1fmotDqV3x9sPvyutwBqKOfs1hp0i2uzwMQMoZOPCeZczRkNw/ceEBDrnfzFinp1ChEJK2nSC/o2z58QWip3xpPZ7ZWEzm0UQyDiURNCLS5lyK2XIlWZHtv3+JudhA71unVC1pIUSjUuWit3PnTj744AMA/ve//9GsWTN27drFkiVLmDlzphS9ajquaU0b04lKt9frCgFwc86hS4v1qJJMrNc8zWDTu4Q138L81CW1FWqVbHcp/12/U+4lV6u/FH1g/Tzs7KvEJ97MuftfI8m5LwDOhgwK9Za7C1EJK6Gt5Vbp/lWraPrPJPwr+J9sMBQQteNpADL634b3FQMECCEcR5WLXn5+Ph4eHgCsWbOGsWPHolar6dOnD6dOnarxAB2FctVrlYqFt/iHcP6xLkcXzeNUUU9GtXqXBWn/vdbw6tQa1UzQQZKur3XdpYIHsP2oF+57kvhi5UYsl5hf06vgC9QqEz2CY0p1Sc65kIr+4ueC3KxSRa8wPZvU7YcJuiGC4rwCirXg6uqOoiioVLbfF0VRMJsVNGU8nxRC1H9VLnpt27Zl2bJljBkzhtWrV/PUU5YRQVJTU/H0lA4E1ZXu3RXSjtfY8SJariECy0S2j/rdyfrTE2npupsYZgCWmdzj04aSqI7ilqaz+CFnQY2duy7kurawWY51sQyBt/X8YzDpLzp4JRMSFULS7jOknLrAHa3UqFRmTv72Fs7XzyRh9S4yU/Np0tyDQ3tyydQFwNL1ANzu9DhJD32JftmDqBUTTV/YjdqkIm3nURK3zSYwdz++z8bh4uZe53mLipnNZvbOX4F/l2ACB3SzdziiHqpy0Zs5cybjx4/nqaeeYsiQIURHRwOWq74ePXrUeICOovN9HxC7xJ9m0ePw8m1Ok0/DauzYOq2RG1pbno+Zz75JQbEnTT2TGOK5EFgIQNuUNRxzG1Zj57S3w1mBHF5rBJqBWzPmn7fc7h145gN+3H8C8LL8ywB0tsXrf0Uf0+qtlTipRtKr+S+seewNTuuHXNw6Fa/c43g/Nx+jyY9W4T50n3ozxrwC1Hod62Yt4EKKCxfUzTBr9Hgbz9KihYYeDwzEPSQAtdr2CtFUWMQvk7/EWZvJsI+mV5iT2VhM7ulUPNsElnkVKuDAwhg27XWFvRe40/0ITXtcfXB24VhUiqIoV29mKyUlhbNnz9KtWzfrD3FsbCyenp6EhdXcL+uryc7OxsvLi6ysrGu6yjQajaxYsYKRI0fWm5FFzrzaiSBzks267R2eJerwO7V2zk9TLK9CNM/dwVl3S2eRMfpnQAVLC9+ttfM6kiDVaQqK1Oi1Cq26+FBkLGLHYcut26ZFx1Drioi4JRJzngG1Tk3oLf3JSzpP3OdrOZDig1lj6THkVpTGhI9vYt2sn2neKYDwB4ex7pXFXEg1MPDRaP674Awdvc8yZO4EzMZiAIy5+Wid9SRv2ANaLac3HyPi0RvY8ObvePi6YDIWs/dcM7oFptF/5p0A5KdcQK3T4uxb+pWay+UlpeLSzIfU7Ydp2qMdar3OWpTNJhMFGdms3bSh2j9jZpMJtUZz1XafTvrLZllflMmYaV3x7da2yuesjPr4u6Mm1EReR3/egGIy037c4JoNrhyVrQfVKnqXnDlzBpVKRYsWLa7euBY05qKXn5uJ67shNutML18g7usnCTm7kmZKWo2f87djT3POKZzx/lNJzQnF1/0MHi6ZgOX9wLUJ/wJUFKMjXd2GQo0nBidvm2OM0rzCH6b/q/HYHFVnn7PsT7/6wATuhlRy9f41dt6eLdMwFhazN9Xy/DOsyVl6PjAAz9aBrHx6EXpXDUPeuJv0vcf46+MtnNcFl3mcm8Z6sO2/B0jVtCAo4iwDhwzk1OrddLhzIC7+Jf93FEVBMRajdir5+Tv0499sjTlPm2ATB8+4oTUbCPIpJPqJofw85x9Uipnb5wzCo2Uz6z5XFr1Lpswfwrmt+0ClolnvzjXxJQLK/91hNputFwRFmTk4NfGosXNaz1HJPwSqo6y8FEVh+ztLOHm0gOHPX4dX26By9y/KLWDBM5ZZWx6Y051tH67Ew9eFiKduLXW3o6bUWtEzm8289tprvPfee+Tm5gLg4eHB008/zYwZM2otobI05qIHkHR0N2qNltRjO/Fu2ZmWYT2Bi130X/W+yt7VYzKr0agrP5lsVr4vhmIXcgr9KDS607nFP5zPbkGeoQlHs/tyxG0kPQ0LiQr+jaz8pmxOHU8WgWS61s5f3qLhcDFcILKXC0d3ppGiaQlYeun2H+bN0c1nOGUs/5fq5Xq1y6TdyAiyTqTw+2/5ZbbRFBdg0roA0DXgHKGDOxI0uDsA2QnJ/DJnI2qVGU8XI9dNvx59E1c2zl1OQb4ZtVZN2KDWKEC72wdgzM1H46JHrdFgNBr54/c/GNp/IC5NPEGjZuGDSyhw9mXY9VrW/Gm5yo7ulEN6Ui75eSZGf3RPqd+Tx5f+Q2JcIh1v6krst7H4NndFpVFz5mQBt7wzFicvyy34M2vjUDtp+fU/ZzFrnAhvmsKg/7OMlGQ2FlNcYCD237+TcsZAp37NMeQaMJvMHI/Pon0Pb3ZuL6R9q2Lys4toGupN0sELjPpkIiqVCmN+IWue/4k2fYJpdUtv1sxbRPugNvy5Hjp5n+XgBX8UtaXINjGm0L6zKwf2Gbjp6d74dG4FQN6Zc7gENiV5/V5+/Sm91PehjUsiw96ZgFqrZccHyyjKL6JFRAghI3pX6ntdkVorei+++CJfffUVc+bMoV+/fiiKwqZNm5g9ezaPPPIIr7/++jUHX1mNvehV6OIILju8htN9ynckvDOQdsbDdg6qNLPZ8kL95c5lBvO/wo9onffnxXcOXTic2gdXbSYBXsdJyW5Na7/dxCQ8xgnnwTQrjKe5dj879ffZJwkhLmpiSCZTb5mc2bcoCa2mmHOakKvsVQ7FDCo1TQqTyHS2z92yS1SKCUVVctXYUnOa06aWld5/8rzr2Pnhr2w95IlL4QUKnKs2DvPwYTrajh1QpX2uVGtFLzAwkPnz51tnV7jk119/ZfLkySQlJZWzZ81z5KK3Y+lHNNn/Hd4P/YJv85aYTSZysy9wdv5YijRudMnfWqnj7Pa6nu5Zf9ZytKUVm7RoNcVV2ifP4IGbPocfj79JulvJ7POXfmBb5a0jxDmO9ZqnazpcIUQte2BWN1ybV3/SgsrWgyr33kxPTy+zs0pYWBjp6aUvZ0XtiBzzBIx5wrqs1mjw9PbH80XLu3oHN/1Gzpn9ND/4NcGcK/c43Z/6hZ0rvyZi21O1HvPlqlrwANz0OQCMCHiXbSl30NZjK7lF3nRuvh6txmRt184Yy9LTc7jgVvVOVc5F6fRz+oI/eaHK+wohqs9kqvxjlWtR5aLXrVs3PvnkEz766COb9Z988ol1xgVhfx373YTReCMrVnQkzTkLF+8AwlbcUWbbHsPvh4tFL7bjC/Q6+KZ1W2yzO+l1rn693N7ELY3hbeaVu12vK2JcmxetyztOj6DY7EyfVkspLHLF2SkfsxlOXujKStMcVIqJe7wexVWfjQozGo2Zg8e2k+weZT3GEN6mlc9e4lOGsJcx+BYdJdR5O0cMgyhSu5HlEgqKmVv1z7Os6B28849hUHuQ79ysrBCFEFfQOFW5HFVLlc/y9ttvM2rUKNauXUt0dDQqlYrNmzeTmJjIihUraiNGcY3Ch9xtuW17xbdne/uniQJUajXbOzyLJmU3kbc9y66PYumRbekF5xo+GupZ0auqyJYlM8A7O1k6OqjV0LrpXiYrYzCZNTZXigC3tnmD89nBrE5/mu66pXQMsvRE69XyN3rxm7Vdd0rPdD+FMQAUF2v54vxiFJWG/sUf065pLK76XPINbvxx5nlcucBJt8HW/cLyl3PIteSxwc2653F3zsRNn4nB6MyOs7dSrOjpFbCEZamvkutieQ4UmLcdBTVn3Xpa971RPYdV5lnWZW1xHsVatzK/Ps7FWRRqbV9JaFa4g3POJWOcRncp4MzhTBKLyu9J6mlKJ+I6f9ZtqPpVfE0b/3pX1j63mFRdJ3uHIipJo62dnqhXqtYrC8nJyXz66accOnQIRVHo1KkTkydPJjAwsDZiLJcjP9OrjCvzOhr3Fx6//4ukJpF0fuQLnF3L70adevowrl5+FBbk4Te/9EDTonLMZhWZ+f74uJd9izkpoy0xWU8DCne3mM6x1EjSjUEMaLW4wuOmZLQiJvMpeup/olPg5jLbnM1ozdb0cUT7fk9Ak9MUFes4k9GRlj77WXT6fYrVLtzo9Samyf/ht3eTUdSWv4G7F/xAv9D/sTHvJvbmWMZO7dzqMFET72ThnD0A9OqUT64xjuty3qewyJWEm3+gY58hJSef7cWWk2PY6VzS+aip+gguThq8W3oQ0LYVB9YeJrGo7FcdKqOZ+hyKApG3tmfF0pKZNboU/JeBoT8CcCC5L3+rny3vEKIeeeS9vji5OVd7/zp5T+9yiYmJzJo1i6+//romDlcpUvQqVlN5JR3bg9lkIvjH62owOmFPZrMKBZX19ZRik5bvEz+iAzFEtyqZr/HSgAX3ej7I0SH/R+vW15ESd4Lg0V1xf8+21+LmoIcJHvIwSfs30yeuZHSZjDx/Mif8xPb9e7jz6JMAHL11Be2WjbScu1jL+dxgfil837rPkEFaspMz2XHU0lW/U7MLpJ4zkYblXcReHfOJmjb6snzMfP/tRgL/WciQFr/Y9BjemTiMs01G0yqiFZ0nDOL0n7v57WdL/4Pm6mT0LhpO5pV/G9pXOUfE0GBi1haV2hbeIp2kk1l0H9qWv9dZ7hb4cY40LMdrrkkhfHAwMX8arfu0ck1h+Bu3o3bSkrb3JD/PP1nmefWmXIwqPWZ1yc/uvz7ox+Elm1n3j+XXdiu3czaxB2rPcb7QHXdNAcVmNWP/bwjfzt5d5vE9i9PI1pY9fZerKQvvUWqUtbkkF9te3fuaz9G8hQ61TsPe05Y7BFpTIcUaS8HqF2niyM50WoW5s/2AC+7FF4gc0ox1G4pxM2WQpyl53ap7q2zc/VxRa9V0uf+GMmOprFrryFKe9PR0vv322yoVvblz5/LLL79w6NAhXFxc6Nu3L2+99RYdOnS4+s6izrRoa3lWe3Dof1A7uVBw/hTOexZS4ORHj5y/bdrm4UziyO8JW3G7PUIVlaRWK0DJ37taTTH3t5pcqt09no9gKHbB0zWDnlunsnNPX7o/8wdbfnyNfle07XvmS/juS668dvN2SyXfyw1zzlnruksFD0CrLaZ5kwSiOp6gyw2WkWBcfC2/tMLPZVCQmsmJUwlEd4ymRcv2aHQlv7aSE0/g6x+IXu9MsuE49wX/UiqHiOA1wBriAr6kID+Pltd3J3TljyTkNsO76TaCb7ubZhszyU0rYOArY1Cr1RQXFrF341KCNz3PqejXaT+8P817p7LnP//QdUI/PEMshebSH5btRvbFp/UJiguLCBo4pFQMZvMG/vy7GK2pgCEvjULrbBlZx797a1o6b+V0YQB3PBKEqaiYX75NAeDhBZZb3adidhHz02mieunRuujpfM91tOiTjGdogHVi5nM7juAe3BS3ZqXf371rciv+nreVVKVkoPVBfSH8vjs58XssK3+3vG/drWUW3i2b0GZEBBpPV1asWMHwN25h5YvLCW7vSdjYXhxcso3wCSNwbdoEgD65BaidndBoNcS8+BMA3R++i+4Xz9Prsjg6W14n5MTvsZyNP0P087X3onpFauxKb8+ePURERGAyma7e+KIbb7yRcePGERUVRXFxMTNmzCA+Pp4DBw7g5lb284fLyZVexeokr8tmfD+jboHmviU0b9XRZv3OiDdw9g7Eaf3rhBSfQEfl/4+IxiF+6GK6xIyrsM2m4H8RMX4O+XnZ+PqVXL1sW/YpvXe/BFiuENt2jUZR4MiejYQtv5lD6naEzdxh83+uPFu9RtLnqR9RFIWt74wnOt/yoNs4I41DO/6iXfcBOLu4kpV+Hq+PSgZQODV+AyHtS3fUq+rP2OUjtZTn0E8b8GzpR2B0yfPImhpr1ZCTT/rBRJr3KrmwOLvtEB4tfHEPampd1xB/J9b5lV51rFq1ymb5m2++wd/fn7i4OAYOHFiqvcFgwGAwWJezs7MByzfIaDSWal9Zl/a9lmPUR3WR16UfhyJFQ7MX91jPl4MnPli+P2HXT0TnpIc+o0FRSEk5hSE/h4LMVArSTtJjx/Oljrul1WQiJ7yK7nXL7ZcUVVN0k9bhO6/mhpASdedqBQ+gX+Ln8NbnuAA7nSLJ7zCG4PhP6M0VV4jL4IQ6hDCzZSqzMPNRNsybSunfGKX1yVoBs73Y0PxBQgr2WtcffWsAXYoPsn3jQIrbDsd7/7dcXkLPrv6AwNAFxC75AJVaQ9TF14Wq8zN25YVBeloK504eomPkYADajLUM4n8m4TBn4tfT7YZ70FZQeAwGA4aCPDyb+Fz13GpnHX49WtvE6xfRplQODfF3YmVjteuV3pWOHTtGu3btiI+PJzw8vNT22bNnM2fOnFLrFy1ahKura7XPK6rPf+/HRJu2s8p5NIaOd1rXF2Wfo2ni76S1GI6uScXDSRUb8hix/0n2azpxxr0LzfP2c7bTFNRaLbfssnSE+Nl3Kk4te2EsyOb2Q1NrNSchrmRSVCzxfog7My2zlSzp9DlavWVYs6Jjf2JW69AGR6PWaCg2GnA7/itexvOkdpmKWl1yhVZwegeoNOgCOlN0/ihO/h0Yuncqnqp8fgx4HpV7M8yGXNQaHeNOWl672ajuRXo32//zilmhIP0UTl7NiYx/hRBVCj+HfYqTS82P8dlQ5OfnM378+JrryDJ27NgKt2dmZrJ+/fpqFz1FUbjlllvIyMhg48aNZbYp60ovODiYtLS0a769GRMTw9ChQxvMpXxl1EVehsJ8TsdvJLTbYLRO+qvvUI7iokI0WidUV9z6STl5kPNHthF+w33WbZeu/i7JePwo3h+3K/O4WbjjRW614xKiLCcJJH3wG3itn0UbpfzJsw+MXELLztHonZzISj+P37yOAOx07k1E4Ta2eN9MdMZyALY0vZPo85bXg8yKCrWq5Fdz+tQjOOldSDwWT5tOkexc/S19dj7LUXUb2pkt83Buav88TcOvJ33te3jkn6H19LU2V4jbFr6Ayt2fXrfbTmGlKAoZ6efx8S0ZsNxoNPL7r0sI8dHRfdAY67PDyjh1ZA9FBbm062b71Le2p8PKzs7Gz8+v5m5venlVfL/cy8uL++6r/tiIU6dOZe/evfzzzz/lttHr9ej1pX+x6nS6GvmlXlPHqW9qMy+dzotOfUdfveFVj1N2fMHtuhLcrqvNuiJFi5Oq5F0wb19/mJ3FzuWfEbHT8tfxYV1HPO7+msDWnSr1rEeIqmhFMq3W3X/VdhkH19HujzvZ0vIR2t3woHV9ROE2AGvBA/DK2G/9fHnBAyg25GP+OIqOqiz4FfpcXH+p4AH0O/IWHHnLupz8djcSmo+gz8MfcHT3BvonWa5Sd65vhU9wGK06WJ5RbvzsMQakLmJH3/l0H3IHWq2WfVtXc+dhy9XltoJ0et86meTTx0n43TK1Wb/J8zmyZwvuPv4EBrexibXtz9cDsD3tY0zxy+g25T+knzsD347mVLv76Dvhlat+3aqjsr/jauz25rV4/PHHWbZsGRs2bCA0NLTS+0lHloo11rwyzqfg/ellPXxnZ1322VLgdvf9hO7D7gXAMMsPvar0/f5Duk6EGQ9Yl49p2+I09jOCw6I4GLuGTqvuqp0EhEPar+lIZ9NBe4dhtXPgVxTu/4O+F0p6vF55hXnJniH/odtf95Z9oMt+/sqaASYFP5LcOtEzb0Op9jWpsvWg7vuLXkZRFKZOncovv/zCX3/9VaWCJxyXe5OSQWkzsP3PfWb8enZFvkO3GyZY150bH0Nss9IFTDvqLXaEl/zVaVTpadmpt+U26mV/C27v8DS7vIZWKrb9131V6TyEY6lPBQ8gYsNDNgUPSl9hXlJuwQNOHNqF+eK4mQUFeaW2B5CGa1Hp+T+zMtM59mp3Nn31XFXCvmZ27b05ZcoUFi1axK+//oqHhwcpKZb3U7y8vHBxcbFnaKKBONb9eaIuWw5q352g9t1t2rTs0IOWHb5gT8xAXGM/ovi6mai1Ojp0HwjdB8I+y6S3l+YKA9A6lYwMEXX3TAB2/bGAHtufIbbFfbi3H0j+ye1EJnxeEsvo/9E5cij8/VDNJypEPdV68WByFBeK0OGryi6zTcfL7qgoZjMqtZoDS98h2pxA28TPSTv3JH7N6mZEL7sWvXnzLIMGDx482Gb9N998w/3331/3AYkGR62rfOeZbkPvgaH3lFof2/FFWh+cj/vYkkHU2/UYxK7112P0bGl9wbbHqEfI6XszvbwvvkM26A5STtzLuSM7aBV5I239yh6X8qyqGc2VkmHIku7+G88fR5GlbkKQObnS8dekBE0rQk0n7XJu0fh4qAqAgkq1Vb3qTYbigdarj3Wd62fdYU5q7QR3BbsWvXrwOFE0UL+73UYr00m6Di3/tktl9brrBVCeh8t6lqnUanpMLz26h4e37XBVAa27ENDadmzS7WHPEXXobbaHPUfnUZNpqndl58fjiMixDOLdokMEyiuJeGi0pJw6RM75RNr9bhnBJoEWhGKZk3Jbu6dxcvemx66XAUtPVPcZCWheb0plJauaEaiUHvcz28kfCk5W+jhC1CRvVQ5R2THWZVeVoYLWNcuuz/SEqC5T+1vo8PRqdE7VH6DWRg12pY4aN4PcJ48TNW4Grh7eaJ30hN73KTu9buDQcMtAyCqN5e/NgJAw2kWWPC/c3voJdvR8mzivYXS/7Rl63PK4dVuCW3c0Oid2dJllc75tzS1Xrxfwpuji37FxEW9y7oFt+D4XVyq+3dEfU9iib43lK0RDYtcrPSEaK/cmtu8SejcNxPupJeW2P/9wHBnnTqM/k0O3G0ei0/3Lum1v/89Q7/iSoAmfAhB523SUMU9ae8l1vvv/SM16Et/mrdBoLb10e1527INOXehYFG9ddvENIvy6u0h461cKtZ7kthmFT/to2iy7CYDY1lPpdeKTUjGmqby5MOxTOqweb12XOeUgyQe30OmvB0u1r6o8XHCr5C2yimzzuZne6cuv3lDUK1npaXj5lD0Adk2SoidEPdA0qC1NmoVw8EzpOSm73jABLuuNCpbbr8aXzmE05OPu4YO7Z/lDUAVN/pU9234jaMssPJUcQjpFWa4+X9lt27C7pSt5L+DA+h50uqxDTmzwQ/R66H38gO2nLLdv9/b7mK5NA2nS9DYyw/pwbOlr+Pa7D9/mrThzYAud/nygzHgOXL8Q/Ya5tDEeLlk5O4t9i9+g96G3ytzHGkebx9F6BxOxo/wef4rOjV1R79Jj+zMVHkvUL3mZqVL0hBDl0zk5V+r2rkcTX7oNvx/TkPEUFxfh7OJ+1X06Dhhr7YV64PpviepXMrlt1LgZFBU8SVeXkkHhm/i3IPJfJbPZdxowlh0H16KYjCjeofS6WMz2OfcgfMAYGDCGY7s3oP59GoWDZ9MJUDvZDiW4r/8nhP9jO/xWr3tfA6Bg0F0c27SELlttRxcB8O8/kdZdoknp3B//oHaoX/Mt1UbUP4Gt62bCXyl6QjgIjc4Jjc6pUm1VajWxLe5DXZBBZP9bSj3zdHK5+iwokY9+BkCxsYht310g40Iq0Q+/Z93etvtA6L7Lutxt5L84cnAx7Y0HiQ26n1433Msxn5ZkbZxHh4x1HGh2i7UnrYtHE7rc+BDbM84Sdfgdm/O27mIZsDmglWXIr+wnj3F07bcYs1Ppc/pzyjU7i5P/15VWpvKHFbua7W2noXLxJjJ+drWPIWqXFD0hRJl6PfJxjRxHq3Mi4r43WbFiBa4eped7u8TJ2YX2M7Zazn1xXduIQRAxCMVsplcZU/JE3f0y2Rce4fy8EWT49KD12JlceaPXs0lTet7+DKcO7YQrit5uj0F0z1lvXW75Yhy8Vv4ttq1BD9Ln4Q+sI/9s7fQyp3O0tMn+h+A73iYq6OKQXFcUvQL0HPQcQET22nKPLeqG9N4UQtR7Vw5EfjlP32a0eXknkZO/wicgpNx2IWERJI77i+yph9gT+SaxgfcQ/sT/OHbTEtIe3Q2AWqsjB9vbrCc1rayfFY3lStlwcVKt5t1uQO/Xmq5TF+MfVDIG5TmVbeF0mpFI2/vnscetL7ujP0KZmcH2preVijFx3F8UPptYav0ez+u48K94Dt34o8367R1fYE+v92zW7Qi4q9JDfW1vehu73QdUqu0lu71KT5JbnvMPbq/SseuCXOkJIRxGcJilX2u30Y9Z17XteYNNm7wH/ubw5v+CzgUl7wKR974BF3vKqp0st3WLnzpMxoWzBAZ3YPeh06XO4/n0Trav/IKo/ZZnkBqdHk8ff7o9u9LaJmrK1zDb0qM3zmso3ab8QPDFmUpi206j5fEfUT+0CndPb7pd7Kjk27wlu1LfoMfOl9jT612iRj4CwMG9/6F9wR5yph4gsmn5I5vsingD/10fcbb5DXSb+C5RF6dH2rbkA3pXcEv2jLoFfubzFE7eRfemLWBOk3LbAuz0HY3vdVMJadmefc4RhBfurLB9XZKiJ4QQlwkICSMgZKbNuu0dX8A1IYZuY54CwM3LFzcv33InLnVx98IlsCPsL3NzKcUt+9lMzdXrnleBV8ts2+PmKRQPf5Bu+pKhGsOe+4siQwFNyuiklKANxfuR33Br4kcPvQvcPIUWV7Tx7xAN8aV2tfKdvgVndy8udZs64tSR9kWlxxLNe+oEbl6+RFy2ruWjP8FHlqm/9jpHURx+R6net6fuWE351+g1S4qeEEJcRdRdLwIvVmkf36Cy53gsS7Owqg0WoNXbjk2sUmvQl9Mr13DDXJo0C67weKHhfTiS/xOe/iEkrP6M6LPfAXBizO8Ete+ByxXHDn36b5JOHqBFe0t5277gcVTeLYn0Kt1T1tPHn12eQ+iR/RdOg56ia/Qo9rp40XXjxXdRZ2fVWcEDKXpCCFErmod0YP/1C3HxbErrctqkPbKTzHOnadu5d42ff//1C8lPOkBUnxGVat++140AnLzs+Wlwpz5lTkum07vQokPJEAhRj5YezOBy3Z9cQnZGKmG+AQCED7qdXXt+wujf1dppqa5I0RNCiFrSecCYCrf7tWiDX4s2Fba5tnNXfP6ydBzzAsmfrmK3Sx8qN6HW1anUajwvFjwAtVZLj+lLa+joVSO9N4UQQlh5+TWn6Uv7MHYYa+9QaoUUPSGEEA5Dip4QQgiHIUVPCCGEw5CiJ4QQwmFI0RNCCOEwpOgJIYRwGFL0hBBCOAwpekIIIRyGFD0hhBAOQ4qeEEIIhyFFTwghhMOQoieEEMJhSNETQgjhMKToCSGEcBhS9IQQQjgMKXpCCCEchhQ9IYQQDkOKnhBCCIchRU8IIYTDkKInhBDCYUjRE0II4TDsWvQ2bNjATTfdRGBgICqVimXLltkzHCGEEI2cXYteXl4e3bp145NPPrFnGEIIIRyE1p4nHzFiBCNGjKh0e4PBgMFgsC5nZ2cDYDQaMRqN1Y7j0r7Xcoz6SPJqWBprXtB4c5O86o/KxqpSFEWp5VgqRaVSsXTpUm699dZy28yePZs5c+aUWr9o0SJcXV1rMTohhBD1WX5+PuPHjycrKwtPT89y2zWoolfWlV5wcDBpaWkVJnk1RqORmJgYhg4dik6nq/Zx6hvJq2FprHlB481N8qo/srOz8fPzu2rRs+vtzarS6/Xo9fpS63U6XY18Y2rqOPWN5NWwNNa8oPHmJnnZX2XjlFcWhBBCOAwpekIIIRyGXW9v5ubmcuzYMetyQkICu3fvxsfHh5YtW9oxMiGEEI2RXYvejh07uO6666zL06dPB2DixIksXLjQTlEJIYRorOxa9AYPHkw96TwqhBDCAcgzPSGEEA5Dip4QQgiHIUVPCCGEw5CiJ4QQwmFI0RNCCOEwpOgJIYRwGFL0hBBCOAwpekIIIRyGFD0hhBAOQ4qeEEIIhyFFTwghhMOQoieEEMJhSNETQgjhMKToCSGEcBhS9IQQQjgMKXpCCCEchhQ9IYQQDkOKnhBCCIchRU8IIYTDkKInhBDCYUjRE0II4TCk6AkhhHAYUvSEEEI4DCl6QgghHIYUPSGEEA5Dip4QQgiHIUVPCNEoGEwGJsVM4rv939k7FFGPSdETQjQKvx77lU3Jm3hnxzv2DkXUY1L0hBCNQkFxgb1DEA2AFD0hhBAOQ4qeEEIIhyFFTwghhMOQoieEaBQURbF3CKIBkKInhBDCYdi96H322WeEhobi7OxMz5492bhxo71DEkII0UjZtej99NNPPPnkk8yYMYNdu3YxYMAARowYwenTp+0ZlhBCiEZKpdjxRnjv3r2JiIhg3rx51nUdO3bk1ltvZe7cuaXaGwwGDAaDdTk7O5vg4GDS0tLw9PSsVgx7Dm9h7a8Lyc3Jxd3DHZVKVa3j1KbqfoMURbHNq9a+03X7X0hRFHJz83B3d6uX36/qsPwUKuTm5uLu7g5UPi9VHX39r+UsiqKQl5eHm1vtfc9S8lLIL84HoLVX61o5x5UURSEvNw+32vq/aKffzpbvVy5ubnX3O/GhyW/g7elX7f2zs7Px8/MjKyurwnqgrfYZrlFRURFxcXG88MILNuuHDRvG5s2by9xn7ty5zJkzp9T6NWvW4OrqWq04jiZuQ7c3FW8A8qt1jPrMB5C8Gg5LXo3zJWs9UJu5tUQDeFxcOl9r57lSbedlL5a8CuvsfKvXrMTT1bfa++fnV+73gd2KXlpaGiaTiWbNmtmsb9asGSkpKWXu8+KLLzJ9+nTr8qUrvWHDhlX7Su/A8WasNWaTmZFJE+8mdr9yUFXhL/yrMStma15qld0f31ZNqS9DyQpFUcjISMfb28cu368qn7GSOyhmhYyMDLy9vVGpK3uWus2//LNVHIeimEnPyMDH2xtVLf5fPJlzkib6JjRxalJxwxr6simKmfT0DHx8ajevuqYoCunp6fj41N3P2MgRo/F08672/tnZ2ZVqZ7eid8mVX1BFUcr9Iuv1evR6fan1Op0OnU5XrfN3C+tDpzY9WbFiBSNHjqz2ceojo9EoeTUgjTUvaLy5SV71R2XjtNufJn5+fmg0mlJXdampqaWu/oQQQoiaYLei5+TkRM+ePYmJibFZHxMTQ9++fe0UlRBCiMbMrrc3p0+fzr333ktkZCTR0dF88cUXnD59mkmTJtkzLCGEEI2UXYveXXfdxYULF3j11Vc5e/Ys4eHhrFixgpCQEHuGJYQQopGye0eWyZMnM3nyZHuHIYQQwgE0nj62QgghxFVI0RNCCOEwpOgJIYRwGFL0hBBCOAy7d2S5FpfGyq7s8DPlMRqN5Ofnk52d3WBGH6gMyathaax5QePNTfKqPy7VgavNodCgi15OTg4AwcHBdo5ECCFEfZCTk4OXl1e52+06tdC1MpvNJCcn4+HhcU2Dol4auDoxMbHaA1fXR5JXw9JY84LGm5vkVX8oikJOTg6BgYGo1eU/uWvQV3pqtZqgoKAaO56np2eD+QZXheTVsDTWvKDx5iZ51Q8VXeFdIh1ZhBBCOAwpekIIIRyGFD0s8/TNmjWrzLn6GjLJq2FprHlB481N8mp4GnRHFiGEEKIq5EpPCCGEw5CiJ4QQwmFI0RNCCOEwpOgJIYRwGA5f9D777DNCQ0NxdnamZ8+ebNy40d4h2diwYQM33XQTgYGBqFQqli1bZrNdURRmz55NYGAgLi4uDB48mP3799u0MRgMPP744/j5+eHm5sbNN9/MmTNnbNpkZGRw77334uXlhZeXF/feey+ZmZm1ktPcuXOJiorCw8MDf39/br31Vg4fPtzg8wKYN28eXbt2tb7UGx0dzcqVKxt8XleaO3cuKpWKJ5980rquIeY2e/ZsVCqVzb+AgIAGndMlSUlJ3HPPPfj6+uLq6kr37t2Ji4trFLldE8WBLV68WNHpdMqCBQuUAwcOKNOmTVPc3NyUU6dO2Ts0qxUrVigzZsxQlixZogDK0qVLbba/+eabioeHh7JkyRIlPj5eueuuu5TmzZsr2dnZ1jaTJk1SWrRoocTExCg7d+5UrrvuOqVbt25KcXGxtc2NN96ohIeHK5s3b1Y2b96shIeHK6NHj66VnIYPH6588803yr59+5Tdu3cro0aNUlq2bKnk5uY26LwURVGWL1+u/PHHH8rhw4eVw4cPKy+99JKi0+mUffv2Nei8LhcbG6u0atVK6dq1qzJt2jTr+oaY26xZs5TOnTsrZ8+etf5LTU1t0DkpiqKkp6crISEhyv33369s27ZNSUhIUNauXascO3aswed2rRy66PXq1UuZNGmSzbqwsDDlhRdesFNEFbuy6JnNZiUgIEB58803resKCwsVLy8vZf78+YqiKEpmZqai0+mUxYsXW9skJSUparVaWbVqlaIoinLgwAEFULZu3Wpts2XLFgVQDh06VMtZKUpqaqoCKOvXr29UeV3i7e2tfPnll40ir5ycHKVdu3ZKTEyMMmjQIGvRa6i5zZo1S+nWrVuZ2xpqToqiKM8//7zSv3//crc35NyulcPe3iwqKiIuLo5hw4bZrB82bBibN2+2U1RVk5CQQEpKik0Oer2eQYMGWXOIi4vDaDTatAkMDCQ8PNzaZsuWLXh5edG7d29rmz59+uDl5VUnX4usrCwAfHx8GlVeJpOJxYsXk5eXR3R0dKPIa8qUKYwaNYobbrjBZn1Dzu3o0aMEBgYSGhrKuHHjOHHiRIPPafny5URGRnLHHXfg7+9Pjx49WLBggXV7Q87tWjls0UtLS8NkMtGsWTOb9c2aNSMlJcVOUVXNpTgryiElJQUnJye8vb0rbOPv71/q+P7+/rX+tVAUhenTp9O/f3/Cw8Ot8VyKsaKY62te8fHxuLu7o9frmTRpEkuXLqVTp04NPq/Fixezc+dO5s6dW2pbQ82td+/efPfdd6xevZoFCxaQkpJC3759uXDhQoPNCeDEiRPMmzePdu3asXr1aiZNmsQTTzzBd999Z43pUpwVxV0fc7tWDXqWhZpw5ZREiqJc0zRF9lCdHK5sU1b7uvhaTJ06lb179/LPP/+U2tZQ8+rQoQO7d+8mMzOTJUuWMHHiRNavX19uTA0hr8TERKZNm8aaNWtwdnYut11Dy23EiBHWz126dCE6Opo2bdrw7bff0qdPnzLjqe85gWXatcjISN544w0AevTowf79+5k3bx733XdfuXE1hNyulcNe6fn5+aHRaEr9NZKamlrqr5/66lIvs4pyCAgIoKioiIyMjArbnDt3rtTxz58/X6tfi8cff5zly5fz999/20wR1dDzcnJyom3btkRGRjJ37ly6devGhx9+2KDziouLIzU1lZ49e6LVatFqtaxfv56PPvoIrVZrPW9DzO1ybm5udOnShaNHjzbo71fz5s3p1KmTzbqOHTty+vRpa0zQMHO7Vg5b9JycnOjZsycxMTE262NiYujbt6+doqqa0NBQAgICbHIoKipi/fr11hx69uyJTqezaXP27Fn27dtnbRMdHU1WVhaxsbHWNtu2bSMrK6tWvhaKojB16lR++eUX/vrrL0JDQxtFXuVRFAWDwdCg87r++uuJj49n9+7d1n+RkZFMmDCB3bt307p16wab2+UMBgMHDx6kefPmDfr71a9fv1KvAR05coSQkBCg8f2MVUld9pqpby69svDVV18pBw4cUJ588knFzc1NOXnypL1Ds8rJyVF27dql7Nq1SwGU999/X9m1a5f1tYo333xT8fLyUn755RclPj5eufvuu8vsdhwUFKSsXbtW2blzpzJkyJAyux137dpV2bJli7JlyxalS5cutdbt+LHHHlO8vLyUdevW2XQVz8/Pt7ZpiHkpiqK8+OKLyoYNG5SEhARl7969yksvvaSo1WplzZo1DTqvslzee1NRGmZuTz/9tLJu3TrlxIkTytatW5XRo0crHh4e1t8BDTEnRbG8VqLVapXXX39dOXr0qPLDDz8orq6uyvfff29t01Bzu1YOXfQURVE+/fRTJSQkRHFyclIiIiKs3ebri7///lsBSv2bOHGioiiWrsezZs1SAgICFL1erwwcOFCJj4+3OUZBQYEydepUxcfHR3FxcVFGjx6tnD592qbNhQsXlAkTJigeHh6Kh4eHMmHCBCUjI6NWciorH0D55ptvrG0aYl6KoigPPvig9f9T06ZNleuvv95a8BpyXmW5sug1xNwuvZum0+mUwMBAZezYscr+/fsbdE6X/Pbbb0p4eLii1+uVsLAw5YsvvrDZ3pBzuxYytZAQQgiH4bDP9IQQQjgeKXpCCCEchhQ9IYQQDkOKnhBCCIchRU8IIYTDkKInhBDCYUjRE0II4TCk6AkhhHAYUvSEEEI4DCl6QtQjqamp/Otf/6Jly5bo9XoCAgIYPnw4W7ZsASzTuCxbtsy+QQrRgDn8fHpC1Ce33XYbRqORb7/9ltatW3Pu3Dn+/PNP0tPT7R2aEI2CjL0pRD2RmZmJt7c369atY9CgQaW2t2rVilOnTlmXQ0JCOHnyJAC//fYbs2fPZv/+/QQGBjJx4kRmzJiBVmv5u1alUvHZZ5+xfPly1q1bR0BAAG+//TZ33HFHneQmRH0htzeFqCfc3d1xd3dn2bJlGAyGUtu3b98OwDfffMPZs2ety6tXr+aee+7hiSee4MCBA3z++ecsXLiQ119/3Wb/V155hdtuu409e/Zwzz33cPfdd3Pw4MHaT0yIekSu9ISoR5YsWcIjjzxCQUEBERERDBo0iHHjxtG1a1fAcsW2dOlSbr31Vus+AwcOZMSIEbz44ovWdd9//z3PPfccycnJ1v0mTZrEvHnzrG369OlDREQEn332Wd0kJ0Q9IFd6QtQjt912G8nJySxfvpzhw4ezbt06IiIiWLhwYbn7xMXF8eqrr1qvFN3d3XnkkUc4e/Ys+fn51nbR0dE2+0VHR8uVnnA40pFFiHrG2dmZoUOHMnToUGbOnMnDDz/MrFmzuP/++8tsbzabmTNnDmPHji3zWBVRqVQ1EbIQDYZc6QlRz3Xq1Im8vDwAdDodJpPJZntERASHDx+mbdu2pf6p1SU/4lu3brXZb+vWrYSFhdV+AkLUI3KlJ0Q9ceHCBe644w4efPBBunbtioeHBzt27ODtt9/mlltuASw9OP/880/69euHXq/H29ubmTNnMnr0aIKDg7njjjtQq9Xs3buX+Ph4XnvtNevxf/75ZyIjI+nfvz8//PADsbGxfPXVV/ZKVwj7UIQQ9UJhYaHywgsvKBEREYqXl5fi6uqqdOjQQXn55ZeV/Px8RVEUZfny5Urbtm0VrVarhISEWPddtWqV0rdvX8XFxUXx9PRUevXqpXzxxRfW7YDy6aefKkOHDlX0er0SEhKi/Pjjj3WdohB2J703hXAAZfX6FMIRyTM9IYQQDkOKnhBCCIchHVmEcADyFEMIC7nSE0II4TCk6AkhhHAYUvSEEEI4DCl6QgghHIYUPSGEEA5Dip4QQgiHIUVPCCGEw5CiJ4QQwmH8Pxsl3xobnzWBAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 500x350 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "vae = valdo.VAE.load(vae_path + run_prefix + 'trained_vae.pkl')\n",
     "loss_array = np.array(vae.loss_train)\n",
@@ -1450,10 +2875,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 87,
    "id": "cd5ec823-ee45-4261-9239-aced93af3d40",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAK2CAYAAACcgZxBAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3hT1RvA8W+SpnsAZZRRKKvMUvYoyJBRpoDsKYggMgQUByoKCgLKFBQUlSXI+CGIyh5llVHAskfZmzJbSlfS3N8fsaGhu6RNx/t5nj4k9557c+6bkrw959xzVIqiKAghhBBCWIna2hUQQgghRN4myYgQQgghrEqSESGEEEJYlSQjQgghhLAqSUaEEEIIYVWSjAghhBDCqiQZEUIIIYRVSTIihBBCCKuSZEQIIYQQViXJiBBCCCGsSpKRdNizZw8dOnSgWLFiqFQq1q9fn+5zKIrC9OnT8fb2xs7ODk9PT77++mvLV1YIIYTIIWysXYGc5NmzZ/j6+jJw4EC6dOmSoXOMGjWKrVu3Mn36dHx8fAgLC+PBgwcWrqkQQgiRc6hkobyMUalUrFu3jk6dOpm2xcbG8tlnn7F8+XKePHlC1apVmTZtGk2bNgXg7NmzVKtWjVOnTlGhQgXrVFwIIYTIZqSbxoIGDhzI/v37WblyJSdOnKBbt260bt2akJAQAP766y/KlCnD33//TenSpfHy8uKtt97i0aNHVq65EEIIYT2SjFjIpUuX+P3331mzZg2vvPIKZcuWZezYsTRq1IhFixYBcPnyZa5du8aaNWtYunQpixcv5ujRo3Tt2tXKtRdCCCGsR8aMWMixY8dQFAVvb2+z7TExMbi7uwNgMBiIiYlh6dKlpnK//PILtWrV4vz589J1I4QQIk+SZMRCDAYDGo2Go0ePotFozPY5OzsDULRoUWxsbMwSlkqVKgFw/fp1SUaEEELkSZKMWEiNGjWIi4sjNDSUV155JckyDRs2RK/Xc+nSJcqWLQvAhQsXAChVqlSW1VUIIYTITuRumnSIiIjg4sWLgDH5mDlzJs2aNaNAgQKULFmSvn37sn//fmbMmEGNGjV48OABO3fuxMfHh7Zt22IwGKhTpw7Ozs7Mnj0bg8HA8OHDcXV1ZevWrVa+OiGEEMI6JBlJh4CAAJo1a5Zo+xtvvMHixYvR6XRMmjSJpUuXcuvWLdzd3WnQoAETJ07Ex8cHgNu3bzNy5Ei2bt2Kk5MTbdq0YcaMGRQoUCCrL0cIIYTIFiQZEUIIIYRVya29QgghhLAqSUaEEEIIYVVyN00qDAYDt2/fxsXFBZVKZe3qCCGEEDmGoig8ffqUYsWKoVYn3/4hyUgqbt++jaenp7WrIYQQQuRYN27coESJEsnul2QkFS4uLoAxkK6urhY5p06nY+vWrbRq1QqtVmuRc+Y0EgOJAUgMQGIAEgPIvTEIDw/H09PT9F2aHElGUhHfNePq6mrRZMTR0RFXV9dc9UuXHhIDiQFIDEBiABIDyP0xSG2YgwxgFUIIIYRVSTIihBBCCKuSZEQIIYQQViVjRqwkzmDtGgghLEFRFPR6PXFxcRk6XqfTYWNjQ3R0dIbPkdNJDHJuDDQaDTY2Ni899YUkI1bwzZYL/HxIQ4U6T6lSQtakESKnio2N5c6dO0RGRmb4HIqi4OHhwY0bN/LsXEYSg5wdA0dHR4oWLYqtrW2GzyHJiBUs3HcVUDFr+0V+HlDX2tURQmSAwWDgypUraDQaihUrhq2tbYa+RAwGAxERETg7O6c4KVRuJjHImTFQFIXY2Fju37/PlStXKF++fIbrLsmIFckKhULkXLGxsRgMBjw9PXF0dMzweQwGA7Gxsdjb2+eYLyFLkxjk3Bg4ODig1Wq5du2aqf4ZkXOuOBeS9ZKFyPly0heHEJnBEv8H5H+RFSnSNiKEEEJIMmJN0jIihBBCSDJiVZKLCCHyAi8vL2bPnm3tamQbAwYMoFOnTuk6RqVSsX79+kypT3YgyYg1STYihMhCKpUqxZ8BAwakenxmfCFOnDiRV155xeLnfVleXl4pxqtp06YZOu+cOXNYvHhxuo65c+cObdq0ydDr5QRyN40VyZgRIURWunPnjunxqlWr+Pzzzzl//rxpm4ODgzWqlW0FBQWZJiALDAykS5cunD9/3rRo6ovzauh0ujQtcufm5pbuunh4eKT7mJxEWkasSMaMCJG7KIpCZKw+3T9RsXEZOi7+R0njh4mHh4fpx83NDZVKZbZtxYoVlC1bFltbWypUqMCyZctMx3p5eQHQuXNnVCqV6fmlS5fo2LEjRYoUwdnZmTp16rB9+3aLxvXkyZO8+uqrODg44O7uzpAhQ4iIiDDtDwgIoG7dujg5OZEvXz4aNmzItWvXADh+/DjNmjXDxcUFV1dXatWqxZEjR9L0uoUKFTLFpkAB4wSVhQsXNm1zd3dnwYIFdOzYEScnJyZNmkRcXByDBg2idOnSODg4UKFCBebMmWN23he7aZo2bcqoUaP4/PPPKViwIB4eHkyYMMHsmIStUlevXkWlUvHHH3/QrFkzHB0d8fX15cCBA2bHLFy40HTreefOnZk5cyb58uVL07VnNWkZsSLJRYTIXaJ0cVT+fEuWv+6ZL/1xtH25j/N169YxatQoZs+eTYsWLfj7778ZOHAgJUqUoFmzZgQFBVG4cGEWLVpE69at0Wg0AERERNC2bVsmTZqEvb09S5YsoUOHDpw/f56SJUu+9LVFRkbSunVr6tevT1BQEKGhobz11luMGDGCxYsXo9fr6dSpE4MHD+b3338nNjaWw4cPmyag69OnDzVq1GD+/PloNBqCg4PT1HqRVl988QVTpkxh1qxZaDQaDAYDJUqUYPXq1RQsWJDAwECGDBlC0aJF6d69e7LnWbp0KcOGDePAgQMcOnSIAQMG0LBhQ1q2bJnsMZ9++inTp0+nfPnyfPrpp/Tq1YuLFy9iY2PD/v37GTp0KNOmTeO1115j+/btjB8/3mLXbWmSjAghhGD69OkMGDCAYcOGAfDee+9x8OBBpk+fTrNmzShUqBAA+fLlM+sy8PX1xdfX1/R80qRJrFu3jg0bNjBixIiXrtfy5cuJiopi6dKlODk5ATBv3jw6dOjAtGnT0Gq1hIWF0b59e8qWLQtApUqVTMdfv36dDz74gIoVKwJQvnz5l65TQr179+bNN9802zZx4kTT49KlSxMYGMjq1atTTEaqVavGRx99hKurKxUqVGDevHns2LEjxWRk7NixtGvXzvSaVapU4eLFi1SsWJG5c+fSpk0bxo4dC4C3tzeBgYH8/fffL3O5mUaSESuK1uWcxZCEEKlz0Go486V/uo4xGAw8DX+Ki6tLhiePctBqMnRcQmfPnmXIkCFm2xo2bJioi+FFz549Y+LEifz999/cvn0bvV5PVFQU169ff+k6xdfL19fXlIjE18tgMHD+/HkaN27MgAED8Pf3p2XLlrRo0YLu3btTtGhRwJhUvfXWWyxbtowWLVrQrVs3U9JiCbVr1060bcGCBfz8889cu3aNqKgoYmNjqV69eorn8fHxMXtetGhRQkNDUzymWrVqZuUBQkNDqVixIufPn6dz585m5evWrZttkxEZM2JFd8OirV0FIYQFqVQqHG1t0v3jYKvJ0HHxP5ZaWO3F8yiKkuq5P/jgA9auXcvkyZPZu3cvwcHB+Pj4EBsba5E6pVSH+O2LFi3iwIED+Pn5sWrVKry9vTl48CAAEyZM4PTp07Rr146dO3dSuXJl1q1bZ5G6AWZJEsDq1asZM2YMb775Jlu3biU4OJiBAwemGo8Xu45UKhUGQ8rLuyc8Jj4W8cckFbe0ji2yBklGrChGn/IvmhBCZJVKlSqxb98+s22BgYFmXR5arTbR8vZ79+5lwIABdO7cGR8fHzw8PLh69arF6lW5cmWCg4N59uyZadv+/ftRq9V4e3ubttWoUYNx48YRGBhI1apVWbFihWmft7c3Y8aMYevWrbz++ussWrTIYvV70d69e/Hz82PYsGHUqFGDcuXKcenSpUx7veRUrFiRw4cPm21L68Bda8jVyciECRMS3ReenW6Pio2TZEQIkT188MEHLF68mAULFhASEsLMmTP5448/TGMOwHhHzY4dO7h79y6PHz8GoFy5cvzxxx8EBwdz/Phxevfunepf9EmJjo4mODjY7OfixYv06dMHe3t73njjDU6dOsWuXbsYOXIk/fr1o0iRIly5coVx48Zx4MABrl27xtatW7lw4QKVKlUiKiqKESNGEBAQwLVr19i/fz9BQUFmCZallStXjiNHjrBlyxYuXLjA+PHjCQoKyrTXS87IkSPZuHEjM2fOJCQkhB9//JFNmzZZrBXN0nJ1MgJQpUoV7ty5Y/o5efKktatkEistI0KIbKJTp07MmTOHb7/9lipVqvDjjz+yaNEis4m9ZsyYwbZt2/D09KRGjRoAzJo1i/z58+Pn50eHDh3w9/enZs2a6X79ixcvUqtWLWrUqGH6eeutt3B0dGTLli08evSIOnXq0LVrV5o3b868efMAcHR05Ny5c3Tp0gVvb2+GDBnCiBEjePvtt9FoNDx8+JD+/fvj7e1N9+7dadOmjdkAU5VKle4JyFIydOhQXn/9dXr06EG9evV4+PChaVBwVmrYsCELFixg5syZ+Pr6snnzZsaMGZPhVXUzm0rJzp1IL2nChAmsX7+e4ODgDJ8jPDwcNzc3wsLCTBPdvCyvj/8xPb46tZ1FzpnT6HQ6Nm7cSNu2bS16m11OIjHI2TGIjo7mypUrlC5d+qU+4A0GA+Hh4bi6uubZFYCtFYOrV69Svnx5zpw5Y/G7bNIrK2IwePBgzp07x969ey163pT+L6T1OzTX300TEhJCsWLFsLOzo169enz99deUKVMm2fIxMTHExMSYnoeHhwPGD02dTmfx+mXGOXOC+OvOq9cPEgPI2THQ6XQoioLBYMhQt0S8+L8H48+VF1krBhs3bmTw4MGULVvW6rHPjBjMmDGDFi1a4OTkxObNm1myZAnz5s2z+LUaDAYURUGn05nmn4mX1v/bubplZNOmTURGRuLt7c29e/eYNGkS586d4/Tp07i7uyd5zIQJE8ya8OKtWLECR0dHi9TrcdBvOBLDN/qejG/glPoBQohsx8bGBg8PDzw9PRNNCy5EdjBw4ED27dtHREQEXl5eDB48ONGcKJYQGxvLjRs3uHv3Lnq93mxfZGQkvXv3TrVlJFcnIy969uwZZcuW5cMPP+S9995LskxSLSOenp48ePDAYt00kZNK4qaKpFnMDLZ++YZFzpnT6HQ6tm3bRsuWLXNc87ylSAxydgyio6O5ceMGXl5eL9VNoygKT58+xcXFJdsOLsxsEoOcHYPo6GiuXr2Kp6dnkt00BQsWlG6ahJycnPDx8SEkJCTZMnZ2dtjZ2SXartVqLfZhafhv3LAaQ477ALY0S8Y1p5IY5MwYxMXFoVKpUKvVL9XHH99kHn+uvEhikLNjoFarUalUSf4/Tuv/65x1xS8pJiaGs2fPmmaqs5b8KuMCTz01u9h1LuUZ9oQQQojcLlcnI2PHjmX37t1cuXKFQ4cO0bVrV8LDw3njjezRNTLYZiMDF2f9/edCCCFEdpKru2lu3rxJr169ePDgAYUKFaJ+/focPHiQUqVKWbtqQgghhPhPrk5GVq5cae0qCCGEECIVubqbRgghhBDZnyQjVpdn7qwWQuRRXl5ezJ4929rVsJoBAwbQqVMn0/OmTZsyevToFI+xVMxySuwlGbGyYjy0dhWEEHnEiwuHvvgzYMCAVI9fv369xes1ceJEXnnlFYuf92WNHDky2Wnib926hUaj4Y8//kj3ef/44w+++uqrl62emcWLF5MvX75E24OCghgyZIhFXyszSDJiBXeV/NaughAiD0q4aOjs2bNxdXU12zZnzhxrVzFbGTRoEBcvXkxyLZfFixfj7u5Ohw4d0n3eAgUK4OLiYokqpqpQoUIWmz08M0kyYgUf6p5nqUVUj61YEyGERSkKxD5L/48uMmPHxf+kcSJtDw8P04+bmxsqlcps24oVKyhbtiy2trZUqFCBZcuWmY718vICoHPnzqhUKtPzS5cu0bFjR4oUKYKzszN16tRh+/btFg3ryZMnefXVV3FwcMDd3Z0hQ4YQERFh2h8QEEDdunVxcnIiX758NGzYkGvXrgFw/PhxmjVrhouLC66urtSqVYsjR46k6XWrV69OzZo1+fXXXxPtW7x4Mf3790etVjNo0CBKly6Ng4MDFSpUSDWpe7GbJjQ0lNdee42iRYtStmxZli9fnuiYmTNn4uPjg5OTE56engwbNswUg4CAAAYOHEhYWJiplWvChAlA4m6a69ev07FjR5ydnXF1daV79+7cu3fPtH/ChAlUr16dZcuW4eXlhZubGz179uTp06dpillG5eq7abKrhBP9jrH5H9ceDqaUu6xRI0SOp4uEr4ul6xA1kO9lX/eT22D7cp8h69atY9SoUcyePZsWLVrw999/M3DgQEqUKEGzZs0ICgqicOHCLFq0iNatW5sWRIuIiKBt27ZMmjQJe3t7lixZQocOHTh//jwlS5Z82SsjMjKS1q1bU79+fYKCgggNDeWtt95ixIgRLF68GL1eT6dOnRg8eDC///47sbGxHD582DSlep8+fahRowbz589Ho9EQHBycrtl+Bw0axIcffsjcuXNxdnYGYPfu3Vy8eJE333wTg8FAiRIlWL16NQULFiQwMJAhQ4ZQtGhRunfvnqbXGDBgADdu3ODPP/8kf/78jB49mtBQ8wkx1Wo13333HV5eXly5coVhw4bx4Ycf8sMPP+Dn58fs2bP5/PPPOX/+PICprgkpikKnTp1wcnJi9+7d6PV6hg0bRo8ePQgICDCVu3TpEuvXr+fvv//m8ePHdO/enalTpzJ58uQ0xy29JBmxgg9bloHdxsf2qlh6LzzE/o9ftW6lhBB52vTp0xkwYADDhg0D4L333uPgwYNMnz6dZs2aUahQIQDy5cuHh4eH6ThfX198fX1NzydNmsS6devYsGEDI0aMeOl6LV++nKioKJYuXYqTkzHhmjdvHh06dGDatGlotVrCwsJo3749ZcuWBaBSpUqm469fv84HH3xAxYoVAZIdA5Kc3r178/7777NmzRoGDhwIwK+//kqDBg2oXLkygNniqqVLlyYwMJDVq1enKRm5cOECmzZtIjAwkEqVKuHq6sovv/xidg2AWUtK6dKl+eqrr3jnnXf44YcfsLW1NWvpSs727ds5ceIEV65cwdPTE4Bly5ZRpUoVgoKCqFOnDmCcmn7x4sWmrqR+/fqxY8cOSUZymwqlS5uSETUKt55EWbdCQgjL0DoaWynSwWAwEP70Ka4uLhlfk0T78mMCzp49m2igY8OGDVPtcnj27BkTJ07k77//5vbt2+j1eqKiorh+/fpL1ym+Xr6+vqZEJL5eBoOB8+fP07hxYwYMGIC/vz8tW7akRYsWdO/e3bTsx3vvvcdbb73FsmXLaNGiBd26dTMlLWmRL18+Xn/9dX799VcGDhzI06dPWbt2rVnXx4IFC/j555+5du0aUVFRxMbGUr169TRfn42NDbVr1+bZs2cAVKxYMdFg1F27dvH1119z5swZwsPD0ev1REdH8+zZM7PYpPZanp6epkQEoHLlyuTLl4+zZ8+akhEvLy+zMS1FixZN1FJjaTJmxAqU4jVNj0up7qVQUgiRo6hUxu6S9P5oHTN2XPyPhVZ5fXG1WEVRUl1B9oMPPmDt2rVMnjyZvXv3EhwcjI+PD7GxsRapU0p1iN++aNEiDhw4gJ+fH6tWrcLb25uDBw8CxjEQp0+fpl27duzcuZPKlSuzbt26dNVh0KBB7Nu3j5CQEFatWgVAjx49AFi9ejVjxozhzTffZOvWrQQHBzNw4MA0X7/y33iflOJ87do12rZtS9WqVVm7di1Hjx7l+++/B4wrX6dVcrF8cfuL3Vgqlcq0kF9mkWTEygqpwqxdBSGEoFKlSuzbt89sW3zXQTytVktcXJxZmb179zJgwAA6d+6Mj48PHh4eXL161WL1qly5MsHBwaZWA4D9+/ejVqvx9vY2batRowbjxo0jMDCQqlWrsmLFCtM+b29vxowZw9atW3n99ddZtGhRuurQrFkzypQpw+LFi/n111/p3r27qeVg7969+Pn5MWzYMGrUqEG5cuW4dOlSms9dqVIl9Hq92aDa8+fP8+TJE9PzI0eOoNfrmTFjBvXr18fb25vbt81b4GxtbRO9Ny+qXLky169f58aNG6ZtZ86cISwsLFG3UFaTZEQIIQQffPABixcvZsGCBYSEhDBz5kz++OMPxo4dayrj5eXFjh07uHv3Lo8fG+8ELFeuHH/88QfBwcEcP36c3r17Z+iv6OjoaIKDg81+Ll68SJ8+fbC3t+eNN97g1KlT7Nq1i5EjR9KvXz+KFCnClStXGDduHAcOHODatWts3bqVCxcuUKlSJaKiohgxYgQBAQFcu3aN/fv3ExQUlO4vXpVKxcCBA5k/fz4HDhxg0KBBpn3lypXjyJEjbNmyhQsXLjB+/HiCgtK+AGqFChVo3bo1b7/9NkeOHOHo0aO89dZbODg4mMqULVsWvV7P3LlzuXz5MsuWLWPBggVm5/Hy8iIiIoIdO3bw4MEDIiMjE71WixYtqFatGn369OHYsWMcPnyY/v3706RJE2rXrp2umFiaJCPZRIw+5YxWCCEyU6dOnZgzZw7ffvstVapU4ccff2TRokU0bdrUVGbGjBls27YNT09PatSoAcCsWbPInz8/fn5+dOjQAX9/f2rWrJnMqyTv4sWL1KpVixo1aph+3nrrLRwdHdmyZQuPHj2iTp06dO3alebNmzNv3jwAHB0dOXfuHF26dMHb25shQ4YwYsQI3n77bTQaDQ8fPqR///54e3vTvXt32rRpYzbgVKVSsXjx4lTrN2DAAMLCwqhQoQINGzY0bR86dCivv/46PXr0oF69ejx8+NA0CDitFi1aRIkSJWjfvj1du3ZlyJAhFC5c2LS/evXqzJw5k2nTplG1alWWL1/OlClTzM7h5+fH0KFD6dGjB4UKFeKbb75J9Drxk9blz5+fxo0b06JFC8qUKWPqerImlaKk8Qb1PCo8PBw3NzfCwsJwdXW1yDl1Oh0XvqpFFfU1YhUN3jHLWPJmXZp4F7LI+XMCnU7Hxo0badu2bbpus8tNJAY5OwbR0dFcuXKF0qVLY29vn+HzGAwGwsPDcXV1zfgA1hzOWjG4evUq5cuX58yZM+m+y8bScvLvQUr/F9L6HZqzrjgXOW4wjua2VRlbRDQWGoAmhBAibTZv3syQIUOsnogIubXXauqrz5g97/vLIa5ObWel2gghRN4zdOhQa1dB/EdaRqxkj6Ga6fHnNkutWBMhhBDCuiQZsZJDtg1Mj9+02UxRWb1XCCFEHiXJiJWEawuaPf9Y+7uVaiKEeBlyD4DI6yzxf0CSESt5pMpv9ryjJpBYfebOcCeEsJz4u3+Sms9BiLwk/v/Ay9wRJwNYs5Etp+/SwTd9K34KIaxDo9GQL18+05odjo6OqU6dnhSDwUBsbCzR0dE57pZOS5EY5MwYKIpCZGQkoaGh5MuXz7SSc0ZIMmIlHg5AtPm2kHtPrVIXIUTGxK+Q+jKLiCmKQlRUFA4ODhlKZnIDiUHOjsGLKzlnhCQjVuJTwECfe+NYbvt8Fr3vdl7kvVYVrFgrIUR6qFQqihYtSuHChdO1YFlCOp2OPXv20Lhx4xw38ZulSAxybgy0Wu1LtYjEk2TESgraw2PFJfWCQohsT6PRZPgDWaPRoNfrsbe3z1FfQpYkMZAY5IyOqVzIzRZiyHu/cEIIIcSLJBmxostKUWtXQQghhLA6SUasSEkUfpmvQAghRN4jyYgVvVatKCv0zUzPbdFbsTZCCCGEdUgyYkWeBRz4St/P9NxfHWTF2gghhBDWIcmIFRkMCroENzTlV8k8I0IIIfIeSUasTM/z2wHrqc9asSZCCCGEdUgyYkVv+JUCns+0105z2HqVEUIIIaxEkhErcneypUR+B9PzYENZK9ZGCCGEsI48lYxMmTIFlUrF6NGjrV0Vk4RLEKyKa2q1egghhBDWkmeSkaCgIH766SeqVatm7aqYUaFiR1wNAOLyztshhBBCmOSJb7+IiAj69OnDwoULyZ8/v7Wrk0j8IFYtcVauiRBCCJH18sRCecOHD6ddu3a0aNGCSZMmpVg2JiaGmJgY0/Pw8HDAuKJiRlflfFH8eYz/Kuj+S0ZsiGPb6ds09S5kkdfJzsxjkDdJDCQGIDEAiQHk3hik9XpyfTKycuVKjh07RlBQ2iYUmzJlChMnTky0fevWrTg6Olq0btu2bSMyUkMtdQgArdRH6LPsX+Y0yDszsW7bts3aVbA6iYHEACQGIDGA3BeDyMjINJXL1cnIjRs3GDVqFFu3bsXe3j5Nx4wbN4733nvP9Dw8PBxPT09atWqFq6urReql0+nYtm0bLVu2ZOb5QxSNfARAQ81p0EHbtm0t8jrZWcIY5MXlskFiABIDkBiAxABybwziexdSk6uTkaNHjxIaGkqtWrVM2+Li4tizZw/z5s0jJiYGjUZjdoydnR12dnaJzqXVai3+C6LValGrVUluzysyI645jcRAYgASA5AYQO6LQVqvJVcnI82bN+fkyZNm2wYOHEjFihX56KOPEiUi1lDRwwUuWrsWQgghhPXk6mTExcWFqlWrmm1zcnLC3d090XZrmdSpKqunNqG7zW7uKAWsXR0hhBAiy+WJW3uzM3dnO/YZfAC4bCgKwONnsdaskhBCCJGlcnXLSFICAgKsXYVEorAFwF5lTEKmbT7H1C7Za3I2IYQQIrNIy0g2UNGzMAAOGJORlUE3rFkdIYQQIktJMpIN1ChbDIDK6muAYt3KCCGEEFlMkpFsoG7ZoqbH5VS3rFgTIYQQIutJMpINODs+n9fEjrwz+6oQQggBkoxkD/b5TA+lk0YIIUReI8lIdpC/lOnhfO1s69VDCCGEsAJJRrKZUupQAE7dCrNyTYQQQoisIclINvXbwWvWroIQQgiRJSQZEUIIIYRVSTIihBBCCKuSZCSbitbFmR4rikKcQe6zEUIIkTtJMpJNrQ++bXo88vd/aTBlBxExMgeJEEKI3EeSkWyiR8z4BM/MW0H+PnGH0KcxbD19N2srJYQQQmQBSUayiRi353ONdNPsBkAfZzAro1JlaZWEEEKILCHJSDYxol190+NvtT8BUHH8Zhbtv5Ko7JbTd2n8zS6CbzzJquoJIYQQmUaSkWxCo7VLtE1vUJj415lE299edpTrjyIZtDgoK6omhBBCZCpJRrIpL9WdRNtUmPfTRMbGJSojhBBC5DSSjGQTyguDVgPs3k/1mCidJCNCCCFyPklGspGWMd+kuD+pAazn7oZnUm2EEEKIrCHJSDZR0cOVe0q+dB/39/HE3TlCCCFETiLJSDZRLJ8DhhfeDlt0Zs+P3wjj0v0Is20vdu8IIYQQOY2NtSsgnlNjPq+IhjhAa3r+6/4rHLry0KyMIrmIEEKIHE5aRrKRCBzNnr9rsw47Ys22PXpm/jylXOTwlUe889tR7oRFWaqKQgghhMVJy0g2YkDNv4Zy1FBfBOAdm78AmKbvZSpzJyza7JiELSNXHzxDbzBQrrALAN1/PADA02g9v71VLzOrLoQQQmSYtIxkM3P0r5s9j09IkqMoCuv/vUXdydtpOj2AFjP3JFpQ78bjSIvXUwghhLAUSUayGT2aRNtUGCjMY5LqlFGA0auCCX0aY9r2IMFjkHElQgghsjfppslmgg1lE227Yt8XgKX6lnyuH2i276c9lxOV3xtyn6fR+kTbhRBCiOxIkpFs5sVBrAn1t9nGr3GtiVLsuEeBZMuN//O02XMFhftPYyjkknj9GyGEEMLapJsmG/l7ZKNUywTYvc8h+xF0VO9L83lvPIqizuTtzNke8jLVE0IIITKFJCPZSNXibgzw86J+9NxUy86x/YFKqmvpOv+s7RcyWjUhhBAi00gyks00q1iYu7inqewmu3Es0M7CnbA0n//y/QgUGdEqhBAiG5FkJJtpXL4gAGN1b6epfGtNEEft30GNgRnaH/jT9jPsiUm2/KszdjNLumuEEEJkI7k6GZk/fz7VqlXD1dUVV1dXGjRowKZNm6xdrRSp/lua939xTdJ13GX7vnTR7MNXfZnumgAACvEYB6ITlf1uRwgXQ59y9Nqjl62uEEII8dJydTJSokQJpk6dypEjRzhy5AivvvoqHTt25PTp06kfnA0cMlTM0HFfapdQnPsE2Q/nkN2IJMu0mLmHLvMPcOuJTBUvhBDCunL1rb0dOnQwez558mTmz5/PwYMHqVKlipVqlXa9Yz+lt2YHxVUPeKy4ME77e5qP3W8/CgBXVSRFeJTsrcCX70dQPJ+DReorhBBCZESuTkYSiouLY82aNTx79owGDRokWy4mJoaYmOdjLsLDwwHQ6XTodDqL1CX+PKmdLw4Ny+JamZ6nJxlJ6JD9CAbEfshuQzWUFxrD+v1ymJHNyvDuq+UydO6MSmsMcjOJgcQAJAYgMYDcG4O0Xo9KyeW3Vpw8eZIGDRoQHR2Ns7MzK1asoG3btsmWnzBhAhMnTky0fcWKFTg6Jj8hmSVtuali443E08IP16ynpjqEfKoIaqkzNgi1W8zn3FAKJbpjZ04DmbFVCCGEZUVGRtK7d2/CwsJwdXVNtlyuT0ZiY2O5fv06T548Ye3atfz888/s3r2bypUrJ1k+qZYRT09PHjx4kGIg00On07Ft2zZatmyJVqtNskz58VtTPMce21GUVN/PcB28oleYPQ/5qlUyJTNHWmKQ20kMJAYgMQCJAeTeGISHh1OwYMFUk5Fc301ja2tLuXLGLojatWsTFBTEnDlz+PHHH5Msb2dnh51d4mnTtVqtxX9BXuacTWJncdxuCK6qjK3I21B9kv0GH7O6RMXGse7fW7xasTAebvYZOm96ZUZccxqJgcQAJAYgMYDcF4O0XkuuvpsmKYqimLV8ZFdViqXcCqOgplrMz1SIXpyh8y+3nULBBJOl7ToXyjdbzvHJupO8Ni/tU80LIYQQLytXJyOffPIJe/fu5erVq5w8eZJPP/2UgIAA+vTpY+2qpeqn/rXTVC4GW9NKv21jvk7XaxyxfwcnolBjYODiIBbtvwpA6NMYev10kIuhT9N1PiGEECIjcnUycu/ePfr160eFChVo3rw5hw4dYvPmzbRs2dLaVUtVem63fT12IpWif+WM4kWd6B/S9Tqn7Qfxh+0XibYfuPyQIUuPputcQgghREbk6jEjv/zyi7WrkCnKFHTi8oNnpucG1ERhHONxn3xUjf6ZU/Zvpfl81dWXKMpD7rxwh831RxkbjyKEEEKkR65uGcnpetX1TLTtypS2fNQm5ZlZI3CkUvSv7I2ryhVDkTS91iibtYm26Q0KETF6dp0PJVZvSFulhRBCiHSSZCQb+7qzD6cm+vNOU+OYkB61PVGpVKj/W78mJVHY00/3Cc1iZ9Egei4No+ekWL6nTUCS26t+sYWBi4KYvvU8d8KimLntAqHhide7EUIIITIqV3fT5HQqlQpnOxvGtqpA26pFqVTUBTDeEZQe8d0vjxRnCqgiki23RDuVN3QfJ7nvpz2X+WnPZQD2htxn3bCG6apDWJQON4fcc7uaEEIIy5GWkRxAo1bhU8ING43x7apX2j2VI5KW2krATTQneEezgXna78hPeLLl/r3+BDAmRaFPja0kT6N1HLn6KMlE6cfdl/CduJXfD1/PUL2FEELkbpKM5EBujlpOTfRP93Hz9J04EJf0zLPxPtKupL3mIP/aDzWbh+RF/zt6k2mbz1N38g6WHbxGx+/303XBAdYH3wLg0bNYYvRxAEzZdA6AcX+cTHedhRBC5H6SjORQznY2zOrhS5eaJQgY2xQHrflaNmuGNqC6Zz6zbeE40Uv3WZpf44j9O4Dy34+5sWuOs2D3JQDGrz/F5fvGu3v+DL7NjUeR1PxqGxU+28yf/yUnqQmL0rHrfCj6OBkoK4QQeY0kIzlY5xolmNHdF6+CTvzQt6Zp+5ye1anjVYD1w5Me11Eveh4f6IbgG/0Tu+J8U3yNq/Z9uGrfhwqqtHWxKApsO3PP9HzUyuA0Hdfn54MMXBRkSnCEEELkHZKM5BYJGi86Vi9uejzldZ9ERZ0KebImrilhODNQ9xHf6Tulevotdh/jwcNUy90Ni+ZOWFSaqgyw6shNft57mVO3jGNU/vg3bS0pQgghcg9JRnIJW5uk38pedUty+eu2fOBfwbTtxVuDZ+q7M0PXNdXXOGg/klfVx9CiN20ba7OKMTZrTM/P33vKwr1Xkj1HwnEjigKf/XmGSf+cfV5AgYuhERy8nHriI4QQIneQZCSXqF/GnRaVijDsvzlJElKrVQxvVo5utUoA8GGCxCTe3LjOaXqdX22nM1X7EzVVF9hm+wEjbP5klM06XlPvT9Pxvx++bhoXEnAn8XwpBkWhxczd9PzpIJfvJ74NWSZfE0KI3EfmGcklNGoVP7+R8uJ633StxkdtKlLQ2Y7No1+h9ey9CfamPpFavC6afXTRmK/s+53t92yITvvcIyuDbrL+mibR9oRDZUNCI3B10PLbwWsYDArf7bwIwP6PX03X2j1CCCGyN0lG8hCVSkVBZzsAKnq4Wvz87dUHGGSziZtKQfYYqvGt9ic+1A1mdVwzs3K1J2/nSaQuyXMYEsxT8vaypBfqWxp4lXFtKxGti2PjyTs08S6E+3/XJYQQIueRbhphcshgXPPmrpKfr3W90n38PNu51FBfpIPmIN9qfwLgG+1CXlUfY6b2B97RbEBDHE8idahJurvlxiPj4FdHommkPolNgvEp8eITlsn/nOW91cfpvfBQuusqhBAi+5BkJA/7qV8tiudz4H9DGwAwInYkC/Tt6R77OT/Ftef1mAkWeZ1fbafzumYfH2lXcsm+H1fte3PZvi++KmO3S0HCcCUCFQbc/5tobaF2Br/ZTmGUzR84Y1w9uDj3sUHPwr1XuBcezaZTdwDjoFkhhBA5l3TT5GGtqnjQqooHAJM6VeWz9aeYqu9t2n9M8aZC9GIaqE/zoc1qKquvWfT1/7T7PMntY2LfoaHmNAAjbdYz0ma9ad/+uCr00X1K358PEaNL32DWv47f5v01x1k71A+fEm4ZrrcQQgjLkpYRAUDf+qVMLSQJxWBLgKEGbWO/zrK6zLKdn+y+hprT2KLD7+FatvE2rdRBAHh9/A9z/zkCkY8A+DP4FquP3GDTyTucuR1OwPlQRv7+L7F6Ax3m7SPOkL7FBoUQQmQeaRkRJrW9CjCmhTeztl9IYq+KufpOjLRZz7e67vxtqM9uu/cACFXyUVj1JMvqecH+DdPjn2xn4RW9AlAYGdQcguD7Bvv4dlfKM8aW/WQjV6e2e+m6xOoNaDUqVKq0342UmjiDQmSsHhd7WeVYCJE3SMuIMDOqRflk983Qd6NRzGy+j+vINcUDr+gVeEWvoG7MD1lYw8Su2vfmqn0f0/N/AvagIY4iPOK83Rtcte/Nebs3KMRjs+P27QuAyUVRNrzLlRs3GLL0CH+fuA0YZ5L98q8zHLj0kBidnvN3E49LCYvU4TtxK4OWHOHEzSf8fvg6iqJw41FkkqsXp1W77/biM2Ern66ThQWFEHmDtIyIdFBxUymc5J7y0Uv5RfstN5VCrItrRG+bHbRWB+Ggis3iOsJGu08SbbNT6QiyHw7AVUMRCqrCcN4eDYDq2BJKH1vCq/qmPL2gAp911J+yHVDRLagHdurrVAA2eH3Ca4Xug09XAh86sfmqnmr6U+w/V5ad50IBWPfvLQ5fecTbjcswrm2lDNX/3H+Jz/JD15ncOfF0/vFi9YZkZ94VQoicRJIRkUjveiVZcShtC+PF02FDf9040/MgXUXew8Bbmo18ql0BwPf619hvqMoK26wbf5IUL/W9JLf3tAkwPpiYj6v2ife/dvVruAoELcQPqKeo0NgZW0A6xXxJF80eXG9Gcpjh/L3nEIOLXsK1ahtsg36Aci3BuTDs+hpuHYXitaDVFLPzX38YyfazSdftRQcuPaTXwoN83KYiQ5sknnVXCCFyEklGRCJ2FvprW0HNwrj2nFVKcV0pzHWlCADXDYUoqb5Pz9jPqKkK4UPtKou8XlbTqJ53xaxPcGdQR02g8cGf//0AbP3M/ODbx9DERGCjNIY7xzFE3MZp1XDWxI4DSmGcizb5cShvLTEO3J266ZwkI0KIHE+SEZGIJsFgzKYVChFw/v5LnW+fwbyroXXsNIqpHnBRKcFRvGmlOUJ19SU+0w1kknaRqdwJQ2mqqY2L7g2I/ZDFtt+8VD2yG/WJ32nH7/Df0BB3FWyyG2deaNM7ULgiVOsJNnYQdgMuBxAb60b8f984g4JGrTKuPBgXCzePgGddOL8JAqaCT1fYMZFllX9CXao+feqV4q/jt4nSxdG9tqfZy524+YS/jt/m3eblZQBtXqKLBrUGNPKeC+uQZEQkMrRpWTafvsvrNUswqnl5Bi0JeumEJKFI7LmoGBft02FDp9iv0BBHHBoKqx4zVPMXDWO+4z75cSMCF1UUN5VC/B1Xj/aa57Otxig22KkSz9Caqxz67zbnv0ZBfi94fBWAEHvQKRqm6nvy+Z8l+cR2JU5B854f590aLmw2Pt5hnLOl35khBJz05ViBFSxYuZ7ziicnrz/gq5rP4MIWCPyOX2OHcchQCfuIG7zf9VUIvw35SsILdwspzx6iuncK7FwgZCv4dIOL28G3J9inPIeL/u4Zblz4F8+G6Z/lV2QCXRRMNs43xLCDUDhjY52EeBkq5WWG/ecB4eHhuLm5ERYWhqurZdZz0el0bNy4kbZt26LVZs+/RBRFMd2uGq2Lo+L4zVauEagxsEQ7lVc0pwBoEzPF1JIwW/86fTXb2WvwobMmbSsIi3TovwEO/wT3TsPjK8mXs88HbiWg7mBwLQFFKsOlXcbWHTdP47iZCc+TFd0H1wj643vqdBqK1ikfoAL1f92EigJProMSB2vfAt9exmSsUAWo2R+ePYDQs+DVyJgsXdoJYTeN+0K2wZk/oe23oE1hUcU4Pdz+F4pVB7UNnP4DilY3Jn6bxxn/bTDsJYPH8+tJ4hZwq38ebB0Pgd89fz4kAJ7ehQptsqwKVo9BNpApMXhyHZwKpfx/IJOl9TtUWkZEkhLOm2Gv1bBicL1Ea8DM6VmdhuUK0un7/dx8HJXpdTKgZo7+dV7RnOKZYsdZpRTf6HpwS3HnT0MjZuu7AjBZ15efbGdQU32RBfr2DLX5O8XzfqAbYlpLRyRj6WtpKxf9xPjz16gkd2906kzbBM+135bCD2BGgi44rSOMuwmzfSD81vPttxIsnLhh5PPHtd+EwpVh49jE+/5dZvxXpQGvhnBlT9quIyH3ssYkq5A3BEyDa/uh4zzjOT2qGstc2AoPLoDfCONzfQzcOgaLWpufy28k3DluTEy6LwVbJzQrulE+ujDER0YXDSo12NimvY67poBTQSjfyhiH6n2MXXYV28PTO7BnOpRqANX7Pk/24iVMRAB+amr8t/OPxpau+DppkxjVLbKGokDwCmPC7NsjbceEnoUf6hv/CBhzCh6EGH8qtEkyKbY2aRlJRV5tGUnK6qAbONhqUICgK4+Y8FoV41gFQB9noNLnm9HFZf6vUzXVJW4ohXhMSu+HggoFBTVqDBhQ404YNdUh1FJf4KShDK01h1kT14Q9Bl98VRdpqznE/+KasM3uQwD+iavLJF0/HFQx7LQbS4RiTziOFFM9yvRrFHmPwacH6pOrMQ5expgM3DsFTT+BGwdh/XB4apwHh7f3GFuebhyClSl0d9V+E478ar6t3lBoNRk0NsZuuJkpdMv0XQu/dTE+rvu2sTuuSBWwdXxe5uldOLTAmBA+ugx1h4BjAWP3z6Vdxq68W0ehzlvGL8jiNY3jUxJI9jPREGf8Qi3bHFp8AX+OgFP/g8YfQLNPYddkY32qdE66/pGPjN2VlV6DmKdwMwg8fIzJ4pFf4JX3wcXjefmYpxD1GJyLwKT/pjH48IrxehJSFGPsr+4zjsmKuG9ssTu/yTiuq/abxgSwziA49w+UawEx4fDoClRP8H7F6SDoFyjTFF3+smz5ex3+rduifXYXNn0ADUYYW/4mJZhSYdxNY6vg9i+g4SjjnXkJ6xWfaCzvZuxCBejwHfz17vNyn91/nuw+vQuXA6B0E3DIb/GkM63foZKMpEKSkbQb98dJfj9svCX4+OetuPkkki//OsOhKznry7uE6j5PFCcicEy07zV1IN/ZziMwrjJDdO8RgSNt1IdooTnKvjgfHuDGezb/4zt9Z0KUEvym/dp0K/Gg2Pf5xXZGVl+OEJandQQbe4hK5v+2rQvEprCAZY/lsKoPlGoIVbsQ9+gKR+6qqXdlTsbrVNLP2IoVnwjl94ItieccSpL/f7fcn1qb8ddPq0IVoVp32DvLLEa6j26hnVY89eMrtIOw63D3v5HvI45CwXLGLtT5flB7EMTFwL+/pb9uGjsYH5r+41IgyYiFSDKSdnfCougwdx8965RkrH8FwDje5Pzdp+w8F8qcHSEMa1qWHwIupfmcrat4cPF+BBdDIzKr2umkUF51i6uKB7oM9HKWVN1DjYEbSmGWaqeaFgSMF6eo0KgUbinuDI0dw192nyVzJiGEyAS2LvDJTYudTpIRC5FkJH0SDnxNzpojN1ApBuZuOcm1iJTLTuviQ486JQHjYni5iTthTNAu4fe4VymvusVxQ1mClXJmZdQYqKc+y/faORRQvVxCNij2fRqqT/OmjfUHIwshsrEJYRY7lQxgFVaRlgXjutX2RKfTob0dTN3GzfnzxD06VS9O/Sk7EpVNLlXeNbYpzaYHmJ4vf6sefX4+lHThbOohbozUGftxA6maZBkDag4YqlAz5vkA29fU+/nO9nuaxszgmlIEDx5zB3cAChDOIJuNDLfZwB2lAI1jZgPgxjMe4MYOQy2Kqx7grzliOt9qfRNOKqXZGlebWuoLvG+zhlAlPxsNdYlQHOiu2c1t3Omi2QvAiNiR3FXy8z+7L9kT58Mn+rfYZ/d8wOpv+ub0tTG+l1m9iKIQImeSlpFUSMtI5kgqBi+2fJTI78CW0Y1xsjPmzJfvR/D1xnOMeLUc1T3zMXPreb7beRGAM1/68/ayo+wNeZC1F5JNaYhDhYI+yb83FGyIY652LneVAkzUv5FEmeQkPTNsBdV1tth9bHwcvRhHonmCMwpqqqkuMdZmNUviWiUaM9Mp5kuz2WtHxQ5jn8EHLXpCyY8CdNPsprjqIRcMJfjHUJ/JNr/Q579kZ5Hen8eKCyXVodRQhVBWfQeAi4ZidI/9nGP2Q03nfqI4cU4pSX312eQvr+3053flJLC5+Eha35prem5wKYb6/bOw8FXzu3z+s8mhPW2iEtzF9fYeuHE4yXNnF2cHX6Ws5g43f+hMGfVda1dHWJMVWkYkGUmFJCOZI6kYXL4fwbTN5yjgZMfoFuUp7GKXaktLWJSOOINCASdbdp0PZeCioHTXxcXOhhIFHDl7JzxD1yKMHIhGgyHJgb/x3Amjq2YPXTR7mKrvxU5DTRqpT+KpCuX3uOZpep38hDNH+z1r4prwl8EvxbLVVJforglgrtKDe3HOgLH1KJ8qgstKMa62PsmNnT/TVzeOab0bobd35+q6CfSNNN4SvCmuDh/phhCOE4dGVqbIwuoA7FPXodHn2yEiFKb/t9J1j+XE5i9LhdkXUVDjQDRrhjejcvH8qNXPf4+9Pv4HX9VFPrZZSQPNGQDuO1cmf4vRXL33mDCdmlpNOkLEPUK3zyYyZF+y6ymlWY2+xjtTbOyMd2DcOw2r+pp2t4qZxgXFk+L5HLj1JIqO6n3MsbXuatwZUuV141wx4uVIMmJZU6ZM4Y8//uDcuXM4ODjg5+fHtGnTqFChQprPIclI5sisGNx6EkURFzvKfboJgJ51PFkZdCPFYxqWc6dsIWeWHrhmsXqInMHRVkNkbFyi7WNtVvFQcWVRnPnEXzO0P9BFs4+OMV9yXCnHrrFNKemkR/PoIhSryRuLgth9wXy24ooeLqwf3pDvd13kabSexYFXzfZ7O0cz3MeGtm3bUn688VZM/ypF+LFfbbPWQg1xTPcMpPP9/2blLV7LeOttyDYoUAZ+bg4uxaD7Erh7Av55H7ROxltf+/4vyZlxf12/hXWHLnBSKZNoXxP1ccb7l6ZcyRLPJ5a7ecT4OmCc5bfrIvi2HOieGbd5vQLu5cDRHfZOB8CgdUJd/x2o+jpE3INl/92G22EOHPgBoh6j67Wai39/R/km3bEpWAbWDIDQM9BpAQQvN94We+c4tJoE9d6B9e/AydXPK/veOePtuGo1GAwQGwFTEyx1UH8YHEyQXDX52Hhrbssv4cdXnm+P/xJe+xacXAOvfgb5ShlvyQ34b4HPBiOMr3X9gHGCvVNrjZPr2dg/n8n2RZ1/Mt5mq8TB6XVJFjGUa8Vfzn1o27YN2r9GPL++ci2MsxuD8Tbjs38Z39ODPzy/+6fLL7B2kPHxB5fh+O/G9+zhReM8MgW9wX+K8bWvH4Ci1WD7BGP50k3As55xjpyQbVDUFwqWT/o6MkCSEaB169b07NmTOnXqoNfr+fTTTzl58iRnzpzByckpTeeQZCRzZHYMHkTEcP9pDOUKO7P+31vE6A3EGRS+2HA6UdlpXXxoX60Y768+zubT0jwtkqfCgBvPeIKLaVt1z3ysH96QDcdv8+7v/6b7nAWdbRnvE4lHVT96LDxs2n5lSltKj9toVrZe6QKsGlzv+VwSCVsOY54SFmfH1M3naOtTlFfKF0r0WltO36WIqz3VPfNhMCiU+WRjojIvGtGsHH7l3PErW9C44dgylIM/8Jn9Z5C/JJM7VoFLO4wz7yaYSl5RFDp9v5/jN8N4vUZxpnfzNbYQPblunI+kTFNT2USfB7poY+KSv1TyFTu2DHZ8aZxjpG0S61bt/hZ2TYIxp411O74K1g0xTgTXc/nzcqfXGxOezj8+n09EUYwtSZoE3ZyGOGOSk9JyB0+uG+cNUalg3yzjtmo94fUfn593RgXjtfl0g07zjQlDoYro9PrnMVADAVOgTDMo/QrcO2OcRbVA6eRf++hi46RoNfomXyahR1eMCV+Ftpk6CZokI0m4f/8+hQsXZvfu3TRu3DhNx0gykjmsFYOEf2n2rlcS/yoevFKuIGq1ilO3wmg/d59p/6mJ/sTqDTyMiGH61vN0rF6c8etPUbW4W6K/fpPSzqco3kVcmLX9gmnbZ+0qMWPrBaJ0if8aF3lX33Jx/HbRfCKw5FptfnmjNs9i44iK1dPBtxiOts+/MD9Yc5w1R423Zb7dpAzDm5Xj1K0wfIq7cTcsmpazjDPQHv60OSdvhjFoyZFE50/O1antTI/P332K/2zjudYPb0g+By2/HbzG4MZlKOJqnDTr+10X+XbLedMxs3r40rlGiSTPnWWfBw8uGucf0WTRvRv6GGPXWEKKYpwHxda8OzO3fi/I3TRJCAszNsEVKFAg2TIxMTHExMSYnoeHG8cR6HQ6dDqdReoRfx5LnS8nslYMani68e8N4+/BxPYVAYiL0xMXB0Wcn38AfN/LFzu1gp2tCpcC9szr6QtAsw8ao1GriDMoRMbGERGjp8mMvabjPFztuBseQyffonzb1bhacXwy4le2AG/U96RX7eK8/7+TbD79kuMARK7xYiICJJmIAGYJxEdrT+Ll7sjVh5GJyv24+zI/7r4MgIu9DU+jny8qWXdy4jvXUpMwkf/m9ed3f3X6/vlaUPsuPmBAg5IsDrzGuXvmt6JvO32XdlUK8zhSR9cfD9Hex4P3Whq7A1L7PLj1JAoXOxtcHdL+Jb3/0kO2nL7Hx629nydsbqXAoLA/5C6/7r/K8KZlqVkyX6rnuvYwkoAL9+lZuwR22sTvVfLUkNQ1qbSJtufW74W0Xk+eaRlRFIWOHTvy+PFj9u7dm2y5CRMmMHHixETbV6xYgaNj8gPzRM7wOAZmn9LQyMNAy+KJf/XvRYFWDQXskjg4GU9iYP01NU2KGshvC6ceq6hTSMHuv8+sVZfUBIaq+chXT7H/foUMCow5aP63QItiBs6HqbjxLPutGyGEJbhoFSrmUwi6b1wfZ1Z9PWoVRMfBo2iYdsKGwvYKr5UyEKfAw2go7gTzzxr/M81pYL5Kt6LAgrNqHGxggLeBP6+pcdAotCqhMOqA8f9Xq+IGmhczsOqympoFFQwK/HrheUIxzlePRxIf7TciYO9dNe1KGvj8qPFcLYsbaF/SABg/KyL1UNol8bFxBtArmD4D8rLIyEh69+4t3TTxhg8fzj///MO+ffsoUSLppkJIumXE09OTBw8eWLSbZtu2bbRs2TJXNcelhzVjkJaJ2SwtRheX6C+q+MGK8YY3LcOIpmWYu+syP/z3F21Cgxt5MaiRF1M2nefP43cytb5CZJVBDUvxy/60DR4P+aoVG47fIZ+jlsblC3L14TNazja2zHTyLcr6//5fnJvYkopfbAOgQzUPbj+J5uj1JwBUK+HKiZvP75yr6OHCX8MbcPp2OAv3XuW9luW49jCSN5ceS1Te0VaDZ34Hhjctw7urTgDwz4gGhEfrqVUyn+lzpcaknUTE6DnySTPcXmjNURSFBXuuUMHDhVcrPB/Xo9Pp2Lp1GzueFcfDzYEP/b3Njjl/L4KyhZzQal5Y6PAFx64/YfaOi3zapgLeRYx3kMXX68qDZ5y+HU47H48s+wwMDw+nYMGC0k0DMHLkSDZs2MCePXtSTEQA7OzssLNL/GexVqu1+JdmZpwzp8krMUjqGj9vV5Ev/zlneq5Wq3Gwt+PDNpV4t4U3Nb/aZmqqvzKlrenDo1ONEskmIyXyOyRaQTm/o5bqnvloVL4QtUvl50mUjjd+PZzk8WnloNXIuBdhEWlNRACWHLzBpH+M88T8PbIRCee8WZ/g/8Qr0xOszqxSmxIRwCwRATh39yk3nsTQaf5BAP45ZT6IPWH5yNg4zt+LMCUiAO3mHQCgclFXutYqgY1GRUSMsQXny3/Oc+pWGPP71qJcYWduP4ni8oNnzNxunB9p+3uN2XzqLu2qFWPjiVvMPKQhTjF231Yu7kbnGiX439GbjF1z3PR6iwbW4d0V//JqpcLM7lE9UVIRPwi6/fcHTNt2vN+EsoWcaTXHmLg52tviXyWZO38sLK2f77m6ZURRFEaOHMm6desICAigfPn0364kA1gzh8TAGIOErSOLBtahWYXnq3NeDI1gwKLDDG9Wjl51S5q2h0frqDZha5JjBep45WdY03KMXhVMWJSxr7aYmz2B48zn8Ijv/3e1tyE82rzpOy1CJreh/H+3Twsh0q66Zz6CbzxJU9lNo16hzZzkhxXsfL8JZQo5m21LatkMW42a85Nam+7OeqdpWT5qXdG0/9rDZ+w6F0rPuiWxT9eYmNTJAFaMXTMrVqzgzz//xMXFhbt3jRmvm5sbDg4OVq6dEOaaepvfilmusDP7Pno1UTlXey1nvvTHVqOm/pSdPIiIYVjTshy/+YSpr1fDs4AjwZ+3NH3wpNQcO693TV4pX5A4g8K8XReZvT0EgAF+Xonmw4i3oG9NtBo1Hq723A2PzuDVCpE3pTURATh5K+XJx95bfZwKRVyY2LEKwTee8P7q40mWi40zpHjnVJNvAwB4EBFrWuQ0q+XqZGT+fOPkQE2bNjXbvmjRIgYMGJD1FRIiGZWKuqarDzf+7oCdY5tw41EkVYqZz32gUqmoXSo/R649pnttz0TH26hV6A0KPsXdUKlU2GhUDG1SFlsbNa9WLExFD1cmvFaFBxExTN10jqPXHjOqeXk61Xi+xLnC80ZVzwIO3HgUhX+VImxJcJfQhA6V+XrTOWL1hjRfW3IqFXW1+Cy5feuX5LeD1y16TiEs5cP/nUhxf/CNJwTfeMKqIylP7Aiw81yo6fH8gEv87+hN3mhQijcbPZ+7ZN6ui9QomY/mlYpkvNIZlKuTkVzcAyVyiToFDQQ9UDPy1XKpF06Cq702USISb9HAOhy7/oSGZd0T7Tv+RSuidHHkd7I1bbPXahjW1LweBZ3tmN7NN8nz+1fxYOmBazjaalj7jh8bT9yhc80SeOYP4ed9VwAY0LA0XWt7svfCfZpWKMy0zefYePIOGrWKO2HGVpXSLgpXnj5PxF5cBBGMSc0bfl6JJgFLSX5HLY8jdckmMY3KFeTD1hUlGRF50v2nMUzfeoHpWy+YbR+05IjZnDJZJeVhuUKITNWnnIF9HzSmrU9Ri5/bxV5LE+9C2CQx+t7JzoaCzum4fzkJ49pUYno3X/Z82IzCLvYMaFgaNwctQ5uWpbCLHUOblAXA2c6GNj5FcbDVMOG1Khz+tAVvN34+/fjoqnHM7OaDs50NS9+sS+mCTmYfhsXzOTCgYWlUKhUu9uZ/P71asTClCxpnU37xeraMbsxHrSuyeGAdOlYvlqj+3/WqgW0qdyYAqPPAndbuCZJSIawhV7eMCJHdqVSYZqzMaRxsNXStlfjutILOdhz6pHmK3U596pciLEpPg9L5uHMqkA7VitKphqfZgnJfdqzCpH/OMqtHddO24M9boTcYqPDZZgA6+BalUblC7Dx3zzQb6dNoHQ5aDTYaNe80NSZE3kUSTwZR4L8v4HqlC3DoyiO61y6BokDPuiXpMj8QMA4ILuxqzz8nkr57SaNWMadndUaseD4N/OgW5Rng58X83ZdMk45ZyqsVC5s1t1vK5M5VCYvS8dHakxY/txBpIcmIEMLiUhv/otWoGdWiPDqdjjunjNvULzRB9G/gRZ96pdAk2K5Rq9CoNRwb35Kzd8LxK+uOSqWiR53ndxu52Ce+O2tQo9LE6OII/2+huhoJZt1c9XaDROWPf9GKGF0cBZxseRKlo2QBR+YHXDIrc3JCK7QaNfZaDS72Wt749TCVi7oyuoVxfohxbSrRr34pxqwKxruICwP8vIjRG7jy4BkjU1jD5uC45tSfsoPyhZ0JCX0+i2n87d3lP92ILi71Lug3GpTi2qNIvulSjbpfpzzjqou9ltZVi0oyIgCI0cdhZ5O1M7ZJMiKEyLY0yfSRFHCypWG5gmk+j71Ww3utKqAoCl1rlaBcYecUy7s5aOG/yaoKOtvxQasKpmRkcueqNK9YxCzpaeJdiO3vNaFEfvO79Erkd2TNUD+zbVWLu3Hs+mM2nbzLljGNaTVzN/eeGida7OBbDA83e1M31V/Hb/P5n6eY37eWKcHzcLPnxqPnc8nM71OT34NusOeF9ZImdnw+ZfuqIfUJuvoo0fiAeJWKGm+53PthM24/iaJu6QKm8Tkyp0zek9WJCMiYESFEHqJSqaha3C3dcymo1Sp61vHEv0oRetctiYdb4q61coWd03zeLzpU4eAnzXFz0PLboNpUdzfwTuPSfN25qlm5Dr7FODa+JfXLPB+EPL9PLVzsjH9HvtO0LG18irL0zbqMblGe7rWN3WYJ56UBqFfGnRGvlufbrtUoUyjxiuXxXVaeBRypV8bY2nT8i1aMaeHNplGvpHo95Qo7c2VKW9pXy/jYp26lnyc8TrYaprzug3+VIgSMbZrhc4qcQ1pGhBAiDaZ2qZYp5/Vyd2Kgt4G2LcsnOQHgi11eVYu7cXKiPwaDYta1Fd899FWnqsn+Zduttifdanuy7OA1lgZeZWTz8rySTAuTm4OWUS2ME0U2rVCIgPPmLS/96pfi5K0wgm88oUvNEqhUKr7rWYMyhZz5bkdIovNV9HDh3N2ngLEbzM1Ba5qgq0xBRxp5hNPcrzr/nAplcuequNprEyVVCX3WrhKHrzxi65m0LzgZf7t7WpUr7MzF0IjUC4qXJsmIEELkQC+OsYmXlib2fvVL0a9+qTS/1oK+tTh39ymVi7qy4+w9TtwKY0wLb2LjDBy/8cTUcqNWq2jiXShRMvJmw9IEXnpgeh6/XkvnGsVZ9+8thjUtC7f+pXnFwrT2KU5qfnmjNs0rFeE132KoVSr6NShFw3IFufbwGb0XHuLWE/MlEVYOqU/pgk4UdrFLdHt4fkct49pU4vWaxdEbFKp/uZVonXFenFVD6vPPyTs0Ll+IpgluN3d3suXr133wr+KR5IynyfnAvwKxegMKJJmwpaRLzRLo4gxsOH47XcddmNQG78+y/2zJkowIIYRIkb1WQ3XPfAC08SlKm/9uRbe1UScau1OrVH7m96mJV0EnDl1+SEl3R16tWIR3fjtqahmJN6ObL++19MbDRcvGW8kP6j0xoRXRujjqTt5hel2Awq72LOhXy1SulLsTv71VzzRPzZqhDajumc9scblZPXz5dd9VFvSrhbuTrVnXmo0GzkxsTc+FB3HQaijgZEv/Bl6AMTEZsuwoE16rTOcaz+8i02pUSQ4o/mOYH8HXn7D51F2+6VoNr4Lm3WNrj95MlDS9aGH/2ny75RzTulSjRsn8KIqSpmRkUqeqqFTQp54x4fx9cH16LTxo2p+wlepFWo117mWXZEQIIYRFxScr8QNjwdh95GhrQ+96z2cEVqtVeBZwRKfTpXg+V3strgkGDKtI/gsz4R6f4m6JVrntXKOEWTLxIrVaxaoh9RN1j9Ur407w5y1TvFNs74fNKOxqh61GjUqlombJ/GYznCY0qnl5PlxrnGF1RLNyzNtlXDxPo1YRZ1CoWTIfLSsXoWXl57OhqlQqRrcoz+ztIQxrWpaTt8IwKAr7Lz4E4NLXbZMc9N2grDs1Subj3/8WDNw8ujEHLj3kh4CL7A153mL1SvmCLH2zbrLXl5kkGRFCCJHpCjrbMaN70rP5plflYskvuFYsnwMqlfEuoLRMapeU5BKOpLb3rV+KRfuv0rRCITwLOKb5NbrX8aR+GXdK5HdArVaZkpFZ3XxoUaWoacmHF41u4c2QxmVM+2P0cSw7cI0m3oWSvfsM4Jc36vD6D/tNSzo0KOtOg7Lupm6mqa/70DOFMTqZTZIRIYQQOcKJCa2Iio0z3f2TFFsbNWcmtkalSn5cjSWNa1OJphUKU8crf7qPLemeOHkp4GSbbCISL+F+OxsNb71SJoXSz88b8EGzRNvXvuPHwcsP6ZbEGlZZSZIRIYQQOcKL3TXJcbDNunkybG3UNHlhxe2M+LZLVbYePEHdDCQ1L6NWqfzUKpW1r5kUSUaEEEIIK+tUvRi2t4PTtXp3biKTngkhhBDCqiQZEUIIIYRVSTIihBBCCKuSZEQIIYQQViXJiBBCCCGsSu6mSYWiGKf5DQ8Pt9g5dTodkZGRhIeHJ7kwVl4gMZAYgMQAJAYgMYDcG4P4787479LkSDKSiqdPjfP3e3pad0IYIYQQIqd6+vQpbm5uye5XKamlK3mcwWDg9u3buLi4WOz+7/DwcDw9Pblx4waurslPa5ybSQwkBiAxAIkBSAwg98ZAURSePn1KsWLFUKuTHxkiLSOpUKvVlCiR/KJKL8PV1TVX/dJlhMRAYgASA5AYgMQAcmcMUmoRiScDWIUQQghhVZKMCCGEEMKqJBmxAjs7O7744gvs7OysXRWrkRhIDEBiABIDkBiAxEAGsAohhBDCqqRlRAghhBBWJcmIEEIIIaxKkhEhhBBCWJUkI0IIIYSwKklGrOCHH36gdOnS2NvbU6tWLfbu3WvtKmXInj176NChA8WKFUOlUrF+/Xqz/YqiMGHCBIoVK4aDgwNNmzbl9OnTZmViYmIYOXIkBQsWxMnJiddee42bN2+alXn8+DH9+vXDzc0NNzc3+vXrx5MnTzL56lI3ZcoU6tSpg4uLC4ULF6ZTp06cP3/erExujwHA/PnzqVatmmmypgYNGrBp0ybT/rwQg4SmTJmCSqVi9OjRpm15IQYTJkxApVKZ/Xh4eJj254UYANy6dYu+ffvi7u6Oo6Mj1atX5+jRo6b9eSUO6aaILLVy5UpFq9UqCxcuVM6cOaOMGjVKcXJyUq5du2btqqXbxo0blU8//VRZu3atAijr1q0z2z916lTFxcVFWbt2rXLy5EmlR48eStGiRZXw8HBTmaFDhyrFixdXtm3bphw7dkxp1qyZ4uvrq+j1elOZ1q1bK1WrVlUCAwOVwMBApWrVqkr79u2z6jKT5e/vryxatEg5deqUEhwcrLRr104pWbKkEhERYSqT22OgKIqyYcMG5Z9//lHOnz+vnD9/Xvnkk08UrVarnDp1SlGUvBGDeIcPH1a8vLyUatWqKaNGjTJtzwsx+OKLL5QqVaood+7cMf2Ehoaa9ueFGDx69EgpVaqUMmDAAOXQoUPKlStXlO3btysXL140lckLccgISUayWN26dZWhQ4eabatYsaLy8ccfW6lGlvFiMmIwGBQPDw9l6tSppm3R0dGKm5ubsmDBAkVRFOXJkyeKVqtVVq5caSpz69YtRa1WK5s3b1YURVHOnDmjAMrBgwdNZQ4cOKAAyrlz5zL5qtInNDRUAZTdu3cripI3YxAvf/78ys8//5ynYvD06VOlfPnyyrZt25QmTZqYkpG8EoMvvvhC8fX1TXJfXonBRx99pDRq1CjZ/XklDhkh3TRZKDY2lqNHj9KqVSuz7a1atSIwMNBKtcocV65c4e7du2bXamdnR5MmTUzXevToUXQ6nVmZYsWKUbVqVVOZAwcO4ObmRr169Uxl6tevj5ubW7aLWVhYGAAFChQA8mYM4uLiWLlyJc+ePaNBgwZ5KgbDhw+nXbt2tGjRwmx7XopBSEgIxYoVo3Tp0vTs2ZPLly8DeScGGzZsoHbt2nTr1o3ChQtTo0YNFi5caNqfV+KQEZKMZKEHDx4QFxdHkSJFzLYXKVKEu3fvWqlWmSP+elK61rt372Jra0v+/PlTLFO4cOFE5y9cuHC2ipmiKLz33ns0atSIqlWrAnkrBidPnsTZ2Rk7OzuGDh3KunXrqFy5cp6JwcqVKzl27BhTpkxJtC+vxKBevXosXbqULVu2sHDhQu7evYufnx8PHz7MMzG4fPky8+fPp3z58mzZsoWhQ4fy7rvvsnTpUiDv/C5khKzaawUqlcrsuaIoibblFhm51hfLJFU+u8VsxIgRnDhxgn379iXalxdiUKFCBYKDg3ny5Alr167ljTfeYPfu3ab9uTkGN27cYNSoUWzduhV7e/tky+XmGAC0adPG9NjHx4cGDRpQtmxZlixZQv369YHcHwODwUDt2rX5+uuvAahRowanT59m/vz59O/f31Qut8chI6RlJAsVLFgQjUaTKHMNDQ1NlCnndPGj6FO6Vg8PD2JjY3n8+HGKZe7du5fo/Pfv3882MRs5ciQbNmxg165dlChRwrQ9L8XA1taWcuXKUbt2baZMmYKvry9z5szJEzE4evQooaGh1KpVCxsbG2xsbNi9ezffffcdNjY2pvrl5hgkxcnJCR8fH0JCQvLE7wFA0aJFqVy5stm2SpUqcf36dSBvfSaklyQjWcjW1pZatWqxbds2s+3btm3Dz8/PSrXKHKVLl8bDw8PsWmNjY9m9e7fpWmvVqoVWqzUrc+fOHU6dOmUq06BBA8LCwjh8+LCpzKFDhwgLC7N6zBRFYcSIEfzxxx/s3LmT0qVLm+3PCzFIjqIoxMTE5IkYNG/enJMnTxIcHGz6qV27Nn369CE4OJgyZcrk+hgkJSYmhrNnz1K0aNE88XsA0LBhw0S391+4cIFSpUoBefszIVVZOVpWPL+195dfflHOnDmjjB49WnFyclKuXr1q7aql29OnT5V///1X+ffffxVAmTlzpvLvv/+ablOeOnWq4ubmpvzxxx/KyZMnlV69eiV5C1uJEiWU7du3K8eOHVNeffXVJG9hq1atmnLgwAHlwIEDio+PT7a4he2dd95R3NzclICAALPbGSMjI01lcnsMFEVRxo0bp+zZs0e5cuWKcuLECeWTTz5R1Gq1snXrVkVR8kYMXpTwbhpFyRsxeP/995WAgADl8uXLysGDB5X27dsrLi4ups+2vBCDw4cPKzY2NsrkyZOVkJAQZfny5Yqjo6Py22+/mcrkhThkhCQjVvD9998rpUqVUmxtbZWaNWuabgXNaXbt2qUAiX7eeOMNRVGMt7F98cUXioeHh2JnZ6c0btxYOXnypNk5oqKilBEjRigFChRQHBwclPbt2yvXr183K/Pw4UOlT58+iouLi+Li4qL06dNHefz4cRZdZfKSunZAWbRokalMbo+BoijKm2++afp9LlSokNK8eXNTIqIoeSMGL3oxGckLMYifL0Or1SrFihVTXn/9deX06dOm/XkhBoqiKH/99ZdStWpVxc7OTqlYsaLy008/me3PK3FIL5WiKIp12mSEEEIIIWTMSLqkNv15WiiKwvTp0/H29sbOzg5PT0/TyGshhBAiL5Jbe9Ph2bNn+Pr6MnDgQLp06ZKhc8TfAjh9+nR8fHwICwvjwYMHFq6pEEIIkXNIN00GqVQq1q1bR6dOnUzbYmNj+eyzz1i+fDlPnjyhatWqTJs2jaZNmwJw9uxZqlWrxqlTp6hQoYJ1Ki6EEEJkM9JNY0EDBw5k//79rFy5khMnTtCtWzdat25NSEgIAH/99RdlypTh77//pnTp0nh5efHWW2/x6NEjK9dcCCGEsB5JRizk0qVL/P7776xZs4ZXXnmFsmXLMnbsWBo1asSiRYsA41TB165dY82aNSxdupTFixdz9OhRunbtauXaCyGEENYjY0Ys5NixYyiKgre3t9n2mJgY3N3dAeNUwTExMSxdutRU7pdffqFWrVqcP39eum6EEELkSZKMWIjBYECj0XD06FE0Go3ZPmdnZ8A4VbCNjY1ZwlKpUiUArl+/LsmIEEKIPEmSEQupUaMGcXFxhIaG8sorryRZpmHDhuj1ei5dukTZsmUB41TBgGm6YCGEECKvkbtp0iEiIoKLFy8CxuRj5syZNGvWjAIFClCyZEn69u3L/v37mTFjBjVq1ODBgwfs3LkTHx8f2rZti8FgoE6dOjg7OzN79mwMBgPDhw/H1dWVrVu3WvnqhBBCCOuQAazpcOTIEWrUqEGNGjUAeO+996hRowaff/45AIsWLaJ///68//77VKhQgddee41Dhw7h6ekJgFqt5q+//qJgwYI0btyYdu3aUalSJVauXGm1axLCmkJDQ3n77bcpWbIkdnZ2eHh44O/vz4EDBwAyPLmgECJnkZYRIYTVvPLKK+h0OqZMmUKZMmW4d+8eO3bsoFq1arRr1y7J+XyEELmPtIwIIaziyZMn7Nu3j2nTptGsWTNKlSpF3bp1GTduHO3atcPLywuAzp07o1KpTM/BOGdPrVq1sLe3p0yZMkycOBG9Xm/ar1KpmD9/Pm3atMHBwYHSpUuzZs0a0/7Y2FhGjBhB0aJFsbe3x8vLiylTpmTVpQshXiDJiBDCKpydnXF2dmb9+vXExMQk2h8UFAQYuz/v3Lljer5lyxb69u3Lu+++y5kzZ/jxxx9ZvHgxkydPNjt+/PjxdOnShePHj9O3b1969erF2bNnAfjuu+/YsGEDq1ev5vz58/z2229myY4QImtJN00qDAYDt2/fxsXFBZVKZe3qCJGr/Pnnn7z77rtERUXh6+tLo0aN6NKlC1WrVgXAzc2N5cuX0759e9MxrVu3pmXLlrz//vumbatWrWL8+PGmu9Pc3Nx48803mTVrlqnMq6++SvXq1Zk5cyYffvghZ8+eZcOGDfL/WohMpCgKT58+pVixYqjVybd/SDKSips3b5oGoAohhBAi/W7cuEGJEiWS3S/zjKTCxcUFMAbS1dXVIufU6XRs3bqVVq1aodVqLXLOnEZiIDEAiQFIDEBiALk3BuHh4Xh6epq+S5MjyUgq4ptwXV1dLZqMODo64urqmqt+6dJDYiAxAIkBSAxAYgC5PwapdYfKAFYhhBBCWJUkI0IIIYSwKklGhBBCCGFVMmZEiBwqLi4OnU5n7Wq8FJ1Oh42NDdHR0cTFxVm7OlYhMZAYQM6NgVarTbRSfUZIMmIFR6895o+raprE6MmXCwcqicylKAp3797lyZMn1q7KS1MUBQ8PD27cuJFn5/uQGEgMIGfHIF++fHh4eLxUvSUZsYKePwcBar4PuMyn7atYuzoih4lPRAoXLoyjo2OO++BKyGAwEBERgbOzc4oTIuVmEgOJAeTMGCiKQmRkJKGhoQAULVo0w+eSZMSKrjx4Zu0qiBwmLi7OlIi4u7tbuzovzWAwEBsbi729fY75ALY0iYHEAHJuDBwcHADjCtyFCxfOcJdNzrniXEimvhXpFT9GxNHR0co1EUIIo/jPo5cZwybJiBXJRPwio3Jy14wQInexxOeRJCNWpEjbiBBCCCHJiDVJy4gQ2Y+XlxezZ8+2djWy3IvXrVKpWL9+faac7+rVq6hUKoKDgzN8/oxavHgx+fLly/LXfVHTpk0ZPXp0mstbM2ZZQZIRK5JcROQlAwYMQKVSMXXqVLPt//zzj0XmKUiv5L6UgoKCGDJkSKa+dnq/iCxhwoQJVK9ePdn9mX3dd+7coU2bNpl2/syiUqlS/BkwYECGzvvHH3/w1Vdfpbm8p6cnd+7coWrVqhl6vexO7qaxJslGRB5jb2/PtGnTePvtt8mfP7+1q5OkQoUKWbsKVpHZ1+3h4ZGp588sd+7cMT1etWoVn3/+OefPnzdti7+bJJ5Op0vTQncFChRIVz00Gk2OjWFaSMuIFcmYEZHXtGjRAg8PD6ZMmZJiucDAQBo3boyDgwOenp68++67PHv2/Fb4O3fu0K5dOxwcHChdujQrVqxI1C0wc+ZMfHx8cHJywtPTk2HDhhEREQFAQEAAAwcOJCwszPQX7oQJEwDz7oVevXrRs2dPs7rpdDoKFizIokWLAONcC9988w1lypTBwcEBX19f/ve//71UnNauXUuVKlWws7PDy8uLGTNmmO1Py/WnV2rHf/nllxQpUsTUTZDae/SipLp9Ll++TLNmzXB2dqZRo0YcOHDAbH9qcXj8+DH9+/cnf/78ODo60qZNG0JCQszKLF68mJIlS+Lo6Ejnzp15+PBh6sFIwMPDw/Tj5uaGSqUyPY+OjiZfvnysXr2apk2bYm9vz2+//cbDhw/p1asXJUqUwNHRER8fH37//Xez877YOlamTBlmzJjBoEGDcHFxoWTJkvz000+m/S920wQEBKBSqdixYwe1a9fG0dERPz8/s0QJYNKkSRQuXBgXFxfeeustPv744xRbyKxFkhErkjEjwhIURSEyVp/lP0oGfoE1Gg1ff/01c+fO5ebNm0mWOXnyJP7+/rz++uucOHGCVatWsW/fPkaMGGEq079/f27fvk1AQABr167lp59+Mk28FE+tVvPdd99x6tQplixZws6dO/nwww8B8PPzY/bs2bi6unLnzh3u3LnD2LFjE9WlT58+bNiwwZTEAGzZsoVnz57RpUsXAD777DMWLVrE/PnzOX36NGPGjKFv377s3r073fEBOHr0KN27d6dnz56cPHmSCRMmMH78eBYvXpyu67cURVEYNWoUv/zyC/v27aN69eppeo/S4tNPP2Xs2LEcO3aMcuXK0adPH/R6PZC2OAwYMIAjR46wYcMGDhw4gKIotG3b1nSL6aFDh3jzzTcZNmwYwcHBNGvWjEmTJlksNvE++ugj3n33Xc6ePYu/vz/R0dHUqlWLv//+m1OnTjFkyBD69evHoUOHUjzP999/T+3atfn3338ZNmwY77zzDufOnUvxmE8//ZQZM2Zw5MgRbGxsePPNN037li9fzuTJk5k2bRpHjx6lZMmSzJ8/3yLXbGnSTWNFkosIS4jSxVH58y1Z/rpnvvTH0Tb9HyGdO3emevXqfPHFFyxcuDDR/m+//ZbevXub/mosX7483333HU2aNGH+/PlcvXqV7du3ExQURO3atQH4+eefKV++vNl5Ev7VWbp0ab766iveeecdfvjhB2xtbc3+yk2Ov78/Tk5OrFu3jn79+gGwYsUKOnTogKurK8+ePWPmzJns3LmTBg0aAMa/cPft28ePP/5IkyZN0h2fmTNn0rx5c8aPHw+At7c3Z86c4dtvv2XAgAGcO3cuTddvCXq9nv79+3PkyBH2799PiRIlgNTfI3t7+zSdf+zYsbRr1w6DwcDHH39MgwYNuHjxIhUrVkw1DiEhIWzYsIH9+/fj5+cHGL98PT09Wb9+Pd26dWPOnDn4+/vz8ccfm84RGBjI5s2bLRqn0aNH8/rrrye6tngjR45k8+bNrFmzhnr16iV7npYtW/LOO++gVqv56KOPmDVrFgEBAVSsWDHZYyZPnmz6Pfv4449p164d0dHR2NvbM3fuXAYNGsTAgQMB+Pzzz9m6datZcp1dSMuIFUnLiMirpk2bxpIlSzhz5kyifUePHmXx4sU4Ozubfvz9/TEYDFy5coXz589jY2NDzZo1TceUK1cu0RiUXbt20bJlS4oXL46Liwv9+/fn4cOHKXYlvEir1dKtWzeWL18OwLNnz/jzzz/p06cPAGfOnCE6OpqWLVua1Xfp0qVcunQpI6Hh7NmzNGzY0Gxbw4YNCQkJIS4uLs3XbwljxozhwIED7N2715SIQOrvUVpVq1bN9Dg+KYxv4UktDmfPnsXGxsbsy93d3Z0KFSpw9uxZ0znik8R4Lz63hPikMF5cXByTJ0+mWrVquLu74+zszNatW7l+/XqK56lS5fnyIPGJcmotXgljGD8de/wx58+fp27dumblX3yeXUjLiBXdCYu2dhVELuCg1XDmS3+rvG5GNW7cGH9/fz799FO6d+9uts9gMPD222/z7rvvJjquZMmSifrE4yXsNrp27Rpt27Zl6NChfPXVVxQoUIB9+/YxaNCgdM8S2adPH5o0aUJoaCjbtm3D3t7edFeIwWAAjHcEFS9e3Ow4Ozu7dL1Owut4cRKphNeWXPdYRrrNUtOyZUt+//13tmzZYkrAIPX3KK0SDvSMv+b4mL5MHOKPy4yYJMXJycns+YwZM5g1axazZ882jVsaPXo0sbGxKZ7nxYGvKpXKFI+0HPNiDBNui5dVMUkvSUas6Fms3tpVELmASqXKUHeJtU2dOpXq1atTqlQps+01a9bk9OnTlCtXLsnjKlasiF6v599//6VWrVoAXLx40WwV4yNHjqDX65kxY4ZpnY/Vq1ebncfW1jZNS7X7+fnh6enJqlWr2LRpE926dcPW1haAypUrY2dnx/Xr1zPUJZOUypUrs2/fPrNtgYGBeHt7o9Fo0nT9lvLaa6/RoUMHevfujUajMQ3mTe09soTU4lC5cmX0ej2HDh0yddM8fPiQCxcuUKlSJdM5Dh48aHaOF59nhr1799KxY0f69u0LGJODkJAQU72ySoUKFTh8+LCpixGM/zeyo5z3CZYOEyZMYOLEiWbbihQpwt27d61UI3Ox+pQzXiFyMx8fH3r37p1o3MhHH31E/fr1GT58OIMHD8bJyYmzZ8+ybds25s6dS8WKFWnRogVDhgxh/vz5aLVa3n//fRwcHEx/BZYtWxa9Xs/cuXPp0KED+/fvZ8GCBWav4+XlRUREBDt27MDX1xdHR8ck1/xRqVT07t2bBQsWcOHCBXbt2mXa5+LiwtixYxkzZgwGg4FGjRoRHh5OYGAgzs7OvPHGG8le//379wkODsZgMPDs2TOcnJwoVqwY77//PnXq1OGrr76iR48eHDhwgHnz5vHDDz8ApOn6kxMVFZVo0ixnZ+cUk4rOnTuzbNky+vXrh42NDV27dk31PbKE1OJQvnx5OnbsyODBg/nxxx9xcXHh448/pnjx4nTs2BGAd999Fz8/P7755hs6derE1q1bLT5eJCnlypVj7dq1BAYGkj9/fmbOnMndu3ezPBkZOXIkgwcPpnbt2vj5+bFq1SpOnDhBmTJlsrQeaZHrx4xUqVLFNFr+zp07nDx50tpVMpFkROR1X375ZaJm42rVqrF7925CQkJ45ZVXqFGjBuPHjzdbnnzp0qUUKVKExo0b07lzZwYPHoyLi4tp4GT16tWZOXMm06ZNo2rVqixfvjzR7cR+fn4MHTqUHj16UKhQIb755ptk69mnTx/OnDlD8eLFE41j+Oqrr/j888+ZMmUKlSpVwt/fn7/++ovSpUuneO0rVqygRo0a1KpVi8aNG1OrVi0WLFhAzZo1Wb16NStXrqRq1ap8/vnnfPnll2aTa6V2/cm5cOECNWrUMPt56623UjwGoGvXrixZsoR+/frxxx9/pOk9ellpicOiRYuoVasW7du3p0GDBiiKwsaNG01dF/Xr1+fnn39m7ty5VK9ena1bt/LZZ5+ZvU78LbMBAQEWq/v48eOpWbMm/v7+NG3aFA8PDzp16mSx86dVnz59GDduHGPHjqVmzZpcuXKFAQMGpHmAcVZSKdm1A8kCJkyYwPr1619q+tzw8HDc3NwICwvD1dXVIvXy+vgfAOxs1JyflPNmJLQEnU7Hxo0badu2bZomCMqNMhKD6Ohorly5QunSpbPlB0p6GQwGwsPDcXV1fall02/evImnpyfbt2+nefPmFqxh5rNEDHLy9YPlfg8yIiAggM6dO3P58mWrTsSXVTFo2bIlHh4eLFu2zGLnTOlzKa3fobm6mwYgJCSEYsWKYWdnR7169fj666+zTRNVjLSMCJEhO3fuJCIiAh8fH+7cucOHH36Il5cXjRs3tnbVskRev35L2rx5M5988km2nRH4ZURGRrJgwQL8/f3RaDT8/vvvbN++nW3btlm7aonk6mSkXr16LF26FG9vb+7du8ekSZPw8/Pj9OnTuLu7J3lMTEwMMTExpufh4eGA8a/Y9I7CT04V1VVs0HNOKWmxc+Y08dedV68fMhYDnU6HoigYDIZUR9nnBPENs/HXlFYxMTF88sknXL58GRcXFxo0aMCyZcvQaDQ5Li4ZiUFuun7I+O+BJXz99dcAVo9bZsQgvttq0qRJxMTEUKFCBdasWcOrr75q0es1GAwoioJOp0u0zlRaP99ydTfNi549e0bZsmX58MMPee+995Isk9SgVzD27yY1uC0jmh0biqsqkqYxMxhTP2+ugyEyxsbGBg8PDzw9PU13dAghhDXFxsZy48YN7t69a5pBN15kZCS9e/eWbpqEnJyc8PHxSbR2QULjxo0zS1TCw8Px9PSkVatWFhsz8uyYccS7GuPUxXmRTqdj27ZttGzZMk+PGUlvDKKjo7lx4wbOzs65YsyIoig8ffoUFxeXVO8Eya0kBhIDyNkxiI6OxsHBgcaNGyc5ZiQt8lQyEhMTw9mzZ3nllVeSLWNnZ5fkZEVardZiX5r5VMYZIMuqbqPW2KBR56xfPEuyZFxzqvTEIC4uDpVKhVqtzvKBfpkhvqk4/pryIomBxABydgzUajUqlSrJz7K0frblrCtOp7Fjx7J7926uXLnCoUOH6Nq1K+Hh4Sne+5+VFtrOpOwnG61dDSGEEMKqcnXLyM2bN+nVqxcPHjygUKFC1K9fn4MHDyaa8VEIIYQQ1pOrk5GVK1dauwpCCCGESEWu7qYRQgghRPYnyYgQQiTg5eXF7NmzrV2NLPfidatUKtavX58p54ufgv1lZsfOqMWLF5MvX74sf92mTZsyevRo0/O0/J697Htg6fNkJklGrCwfT61dBSGyxIABA1CpVEydOtVs+z///JNooqSskNyXUlBQEEOGDMnU137xiykrTJgwgerVqye7P7Ov+86dO7Rpk/OWv+jQoQMtWrRIct+BAwdQqVQcO3Ys3efNjHgn9x7nhNhLMmJljsSkXkiIXMLe3p5p06bx+PFja1clWYUKFbLYBIc5SWZft4eHR5LTJmR3gwYNYufOnVy7di3Rvl9//ZXq1atTs2bNdJ83K3/PckLsJRmxgq90fUyPNao4K9ZEiKzVokULPDw8Eq2g+6LAwEAaN26Mg4MDnp6evPvuuzx79sy0/86dO7Rr1w4HBwdKly7NihUrEjV7z5w5Ex8fH5ycnPD09GTYsGFEREQAxsXRBg4cSFhYGCqVCpVKxYQJEwDz5vNevXrRs2dPs7rpdDoKFizIokWLAONkVd988w1lypTBwcEBX19f/ve//71UnNauXUuVKlWws7PDy8uLGTNmmO1Py/WnV2rHf/nllxQpUsTUtZLae/SipLoKLl++TLNmzXB2dqZRo0YcOHDAbH9qcXj8+DH9+/cnf/78ODo60qZNm0STWi5evJiSJUvi6OhI586defjwYerBSKB9+/YULlyYxYsXm22PjIxk1apVDBo0iIcPH9KrVy9KlCiBo6MjPj4+/P777yme98V4h4SE0LZtWxwdHalcuXKS68d89NFHeHt74+joSJkyZRg/frxpuvXFixczceJEjh8/bvqdjq/zi7E/efIkr776Kg4ODri7uzNkyBDT/w0wtmJ26tSJ6dOnU7RoUdzd3Rk+fHimLt8hyYgVhCglTI/f0GzFYMgzM/KLzKAoEPss638ysJKERqPh66+/Zu7cudy8eTPJMidPnsTf35/XX3+dEydOsGrVKvbt28eIESNMZfr378/t27cJCAhg7dq1/PTTT4SGhpqdR61W891333Hq1CmWLFnCzp07+fDDDwHw8/Nj9uzZuLq6cufOHe7cucPYsWMT1aVPnz5s2LDB7IN6y5YtPHv2jC5dugDw2WefsWjRIubPn8/p06cZM2YMffv2Zffu3emOD8DRo0fp3r07PXv25OTJk0yYMIHx48ebfRmm5fotRVEURo0axS+//MK+ffuoXr16mt6jtPj0008ZO3Ysx44do1y5cvTp08c0nXha4jBgwACOHDnChg0bOHDgAIpinNU6/kvz0KFDvPnmmwwbNozg4GCaNWvGpEmT0lVHGxsb+vfvz+LFi0m4esqaNWuIjY2lT58+REdHU6tWLf7++29OnTrFkCFD6NevH4cOHUrTaxgMBrp27YpGoyEwMJAFCxbw0UcfJSrn4uLC4sWLOXPmDHPmzGHhwoXMmjULgB49evD+++9TpUoV0+90jx49Ep0jMjKS1q1bkz9/foKCglizZg3bt29P9N7t2rWLS5cusWvXLpYsWcLixYsTJWQWpYgUhYWFKYASFhZmsXMu/Hm+onzhqihfuCoHx9dVvvrrtMXOnVPExsYq69evV2JjY61dFavJSAyioqKUM2fOKFFRUc83xkSYfp+y9CcmIl3X+8YbbygdO3ZUFEVR6tevr7z55ptKXFyc8ttvvykJP4r69eunDBkyxOzYvXv3Kmq1WomKilLOnj2rAEpQUJBpf0hIiAIos2bNSvb1V69erbi7u5ueL1q0SHFzc0tUrlSpUqbzxMbGKgULFlSWLl1q2t+rVy+lW7duiqIoSkREhGJvb68EBgaanWPQoEFKr169kq1LkyZNlFGjRimKoihxcXHK48ePlbi4OEVRFKV3795Ky5Ytzcp/8MEHSuXKlRVFUTJ8/V988YXi6+ub7P6E160oigIoa9asUfr27atUrFhRuXHjhmlfau9Rcudbt26doiiKcuXKFQVQfv75Z1MMDhw4oADK2bNn0xSHCxcuKICyf/9+0/4HDx4oDg4OyurVqxVFMb5XrVu3NjtHjx49knzfUxIf8507d5q2NW7cOMX3uG3btsr7779vep7wPVcU8/hs2bJF0Wg0yqlTp0y/B5s2bTKLWVK++eYbpVatWqbnyb3HCc/z008/Kfnz51ciIp7///3nn38UtVqt3L17V1EU4//VUqVKKXq93lSmW7duSo8ePZKsR5KfS/9J63eotIxYQb+6xUyP1Rj4ed8VK9ZGiKw3bdo0lixZwpkzZxLtO3r0KIsXL8bZ2dn04+/vj8Fg4MqVK5w/fx4bGxuzfvpy5colWgJ+165dtGzZkuLFi+Pi4kL//v15+PBhil0JL9JqtXTr1o3ly5cDxsU2//zzT/r0MXa1njlzhujoaFq2bGlW36VLl3Lp0qWMhIazZ8/SsGFDs20NGzYkJCSEuLi4NF+/JYwZM4YDBw6wd+9eSpR43qKb2nuUVtWqVTM99vDwADC18KQWh7Nnz2JjY0O9evVM+93d3alQoQJnz541naNBgwZm53jxeVpUrFgRPz8/fv31VwAuXbrE3r17efPNNwHjMg2TJ0+mWrVquLu74+zszNatW7l+/Xqazn/27FlKlixJ8eLFU6zn//73Pxo1aoSHhwfOzs6MHz8+za+R8LV8fX1xcnIybWvYsCEGg4Hz58+btlWpUsVsYHnRokUzrfUNcvmkZ9mVumxT02MtMmZEvCStI3xy2zqvm0GNGzfG39+fTz/9lO7du5vtMxgMvP3227z77ruJjitZsqTZB2ZCSoIm9GvXrtG2bVuGDh3KV199RYECBdi3bx+DBg1Kd793nz59aNKkCaGhoWzbtg17e3vTnQnx64n8888/Zl8kQIYHDCqKkmihtITXpiTTPZbc9pfRsmVLfv/9d7Zs2WJKwCD19yitEq5bEn/N8TF9mTjEH2fJmAwaNIgRI0bw/fffs2jRIkqVKkXz5s0BmDFjBrNmzWL27NmmcUqjR48mNjY2TedOqp4vXvvBgwfp2bMnEydOxN/fHzc3N1auXJloHE1aXiu5hfgSbn9xTRmVSmV6bzKDJCPWoHUwPayuzthfT0KYqFRg65R6uWxm6tSpVK9ePdHyDDVr1uT06dOUK1cuyeMqVqyIXq/n33//pVatWgBcvHiRJ0+emMocOXIEvV7PjBkzTIuOrV692uw8tra2xMWl/seAn58fnp6erFq1ik2bNtGtWzdsbW0BqFy5MnZ2dly/fp0mTZqk+dpTUrlyZfbt22e2LTAwEG9vbzQaTZqu31Jee+01OnToQO/evdFoNKbBvKm9R5aQWhwqV66MXq/n0KFD+Pn5AfDw4UMuXLhApUqVTOc4ePCg2TlefJ5W3bt3Z9SoUaxYsYIlS5YwePBg05f33r176dixI3379gWMCVVISIipHmm51uvXr3Pnzh3T6vAvDubdv38/pUqV4tNPPzVte/EOn7T8TleuXJklS5bw7NkzU+vI/v37UavVeHt7p6m+mUGSESGEVfj4+NC7d28WLlxotv2jjz6ifv36DB8+nMGDB+Pk5MTZs2fZtm0bc+fOpWLFirRo0YIhQ4Ywf/58tFot77//Pg4ODqYvh7Jly6LX65k7dy4dOnRg//79LFiwwOx1vLy8iIiIYMeOHfj6+uLo6JjkrZYqlYrevXuzYMECLly4wK5du0z7XFxcGDt2LGPGjMFgMNCoUSPCw8MJDAzE2dk5xUU579+/T3BwMAaDwfTFUKxYMd5//33q1KnDV199RY8ePThw4ADz5s3jhx9+AEjT9ScnKioq0URjzs7OKSYVnTt3ZtmyZfTr1w8bGxu6du2a6ntkCanFoXz58nTs2JHBgwfz448/4uLiwscff0zx4sXp2LEjAO+++y5+fn588803dOrUia1bt7J58+YM1cfZ2ZkePXrwySefEBYWxoABA0z7ypUrx9q1awkMDCR//vzMnDmTu3fvpjkZadGiBRUqVOCdd95h1qxZREREmCUd8a9x/fp1Vq5cSZ06dfjnn39Yt26dWRkvLy+uXLlCcHAwJUqUwMXFJVELXZ8+ffjiiy944403mDBhAvfv32fkyJH069ePIkWKZCg2FpHiiBKRKQNYY2NjzQYClvrob4udO6eQAawWHMCaQyQcwBrv8uXLip2dnfLiR9Hhw4eVli1bKs7OzoqTk5NSrVo1ZfLkyab9t2/fVtq0aaPY2dkppUqVUlasWKEULlxYWbBgganMzJkzlaJFiyoODg6Kv7+/snTpUgVQHj9+bCozdOhQxd3dXQGUL774QlGUxAMvFUVRTp8+rQBKqVKlFIPBYLbPYDAoc+bMUSpUqKBotVqlUKFCir+/v7J79+5kY9GkSRMFSPQTX4f//e9/SuXKlRWtVquULFlS+fbbb82OT8v1v+iLL75I8jWbNGmS5HXzwuDJVatWKfb29sratWsVRUn9PUrLANZ///1XURTjANarV68qgLJr1y7TManF4dGjR0q/fv0UNzc30/t84cIFszK//PKLUqJECcXBwUHp0KGDMn36dLMBrPF1Sfi6yQkMDFQApVWrVmbbHz58qHTs2FFxdnZWChcurHz22WdK//79zX7fUxrAqijGQbL169dXbG1tFW9vb2Xz5s2J3oMPPvhAcXd3V5ydnZUePXoos2bNMruW6OhopUuXLkq+fPkUQFm0aJGiKInfyxMnTijNmjVT7O3tlQIFCiiDBw9Wnj59atqf1P/VUaNGmX5XXmSJAayq/yoqkhEeHo6bmxthYWGm5rOXpdPp0E4uaHruFb2Cv0c2ompxN4ucPyfQ6XRs3LiRtm3bJuqbzCsyEoPo6GiuXLlC6dKlsbe3z+QaZj6DwUB4eDiurq6m7pSMuHnzJp6enmzfvt3Uj59TWCIGOfn6wXK/BxkREBBA586duXz5cqYMAk4ra8bgZaX0uZTW71DpprGSn/VteMtmk+n5o2dpG+gkhICdO3cSERGBj48Pd+7c4cMPP8TLy4vGjRtbu2pZIq9fvyVt3ryZTz75xKqJiJBkxGrqqs+ZPd8bcp/G3oWsVBshchadTscnn3zC5cuXcXFxwc/Pj+XLl+eZVra8fv2W9OJaScI6JBmxkmhsTY+L8pCFe+HTdpWtWCMhcg5/f3/8/f2tXQ2ryevXL3KfnNUxlYssjGtvenzAfiSORFuxNkIIIYT1SDJiJbZOBcye+6lPW6kmIieScedCiOzCEp9HkoxYyRWV+SyFP9umbxY9kTfFjwmIjIy0ck2EEMIo/vPoZcYsyZgRK1GSmJzoxM0nVCuRL+srI3IMjUZDvnz5TGtEODo6pjrRVXZmMBiIjY0lOjo6x93OaCkSA4kB5MwYKIpCZGQkoaGh5MuXz2wtm/SSZMRKNEl8f5y9Ey7JiEjViwuK5WSKohAVFZWm2UNzK4mBxABydgzy5ctn+lzKKElGrKRREYVlF1vQz2a7adsPAZfoUSfti0yJvEmlUlG0aFEKFy6c7kXfshudTseePXto3Lhxnr0tVWIgMYCcGwOtVvtSLSLxJBmxEhdbhVVxTc2SkWsPZRyASDuNRmORDwFr0mg06PV67O3tc9QHsCVJDCQGIDHIGR1TuVBxR4gl7/3CCSGEEC+SZMRKVCq4qxRIvaAQQgiRy0kyYkXhOFm7CkIIIYTVSTJiRfkdzbtp1BisVBMhhBDCeiQZsaI+dT1pED3X9Ly86qYVayOEEEJYhyQjVhSnKDzCxfS8jvq8FWsjhBBCWIckI1ZkMIAuwd3V+YiwYm2EEEII65BkxIpqlcqHIcFbMMJmvfUqI4QQQliJJCNW1NS7oNnzpzhYqSZCCCGE9eSpZGTKlCmoVCpGjx5t7aoAxmm9PQs8T0DWxzWyYm2EEEII68gzyUhQUBA//fQT1apVs3ZVEgkyeANwXvG0ck2EEEKIrJcnkpGIiAj69OnDwoULyZ8/v7WrY0aFiieK8Y4aG+KsXBshhBAi6+WJhfKGDx9Ou3btaNGiBZMmTUqxbExMDDExMabn4eHhgHFFRUutkBp/HuO/CjqMi53ZEMftRxEUcrGzyOtkZ+YxyJskBhIDkBiAxABybwzSej25PhlZuXIlx44dIygoKE3lp0yZwsSJExNt37p1K46Ojhat27Zt24h8psGJaAA8VI/o8X0AY6vlnRaSbdu2WbsKVicxkBiAxAAkBpD7YhAZmbbV6FWKoiiZXBeruXHjBrVr12br1q34+voC0LRpU6pXr87s2bOTPCaplhFPT08ePHiAq6urReql0+nYtm0bLVu2pM28Q+yO7GTa5xW9gpCvWlnkdbKzhDHIi8tlg8QAJAYgMQCJAeTeGISHh1OwYEHCwsJS/A7N1S0jR48eJTQ0lFq1apm2xcXFsWfPHubNm0dMTAwajcbsGDs7O+zsEneTaLVai/+CaLVa1GpVktvzisyIa04jMZAYgMQAJAaQ+2KQ1mvJ1clI8+bNOXnypNm2gQMHUrFiRT766KNEiYgQQgghsl6uTkZcXFyoWrWq2TYnJyfc3d0TbbeWyZ2rwjJr10IIIYSwnjxxa2925le2IB/ohgCwL64KAAZDrh3GI4QQQiSSq1tGkhIQEGDtKiQSoRhnYdWqjHfR/HXiNh2rF7dmlYQQQogsIy0j2UAUtgDYEwvAqJXBVqyNEEIIkbUkGckGevkZp4P3VV+2ck2EEEKIrCfJSDZQsoi76XEBwq1YEyGEECLrSTKSDVQq/jwZ8VA9smJNhBBCiKwnyUh2oH4+jjjxFGhCCCFE7ibJSHZQsLzpYTX1JStWRAghhMh6koxkBzbPp5+fov0FgKjYvLNYnhBCiLxNkpFs6sc90kIihBAib5BkJJu6GxZt7SoIIYQQWUKSESGEEEJYlSQjQgghhLAqSUayqSPXHpse7zh7jx8CLqIosoCeEEKI3EeSkWxibVwjs+cXQyNMjwctOcI3m89z4NLDrK6WEEIIkekkGckmZuq6mR6XVN1LsszdcBnUKoQQIveRZCSbGNa6hunxHrsxAEzZeJaQe09N21X/Tc96Nyyan/deJixKl6V1FEIIITKDTepFRFbwKOKRaNuPey7z457nK/mq/pssvudPB7j6MJJ/rz/h+z41s6yOQgghRGaQlpFsQq1K+6o0Vx9GArDzXGhmVUcIIYTIMpKMZFNBdu9YuwpCCCFElpBkJJtQUPhR3870vJAqLFGZFxtPonRxROtkDRshhBA5myQj2YSTrQ0/6Dum+7jfDl7LhNoIIYQQWUeSkWyibukCGF54O1QYEpV7sSXkcWRsptZLCCGEyGxyN002oUpiAKsdOqKxMz0ftTKYQY1Km5WRSVmFEELkdNIyko3oX3g7nEg8ydnfJ26bPU8pF3kWoyfw0gPiDJKxCCGEyL4kGclGorA3e37U/h3qqM6ZbQt9GmP23JBC08gbvx6m98JD/LjnkuUqKYQQQliYJCPZzDjdILPnX2t/MXueKPdQ4PrDSH4IuMhbS4IYvPSIaUG9+MX2VgXdyLT6CiGEEC9LxoxkM7eUgmbPy6tvpVheAdrN3cvTaL1p241HUZR0d3xeRnpphBBCZGPSMpLN3FHcE20LsB3DPrt3qf1Clw3AiZtPzBIRAL3BYGodEUIIIbI7aRnJZkKUEom2eamNq/j+z+5LvKJXmO07ePlRovItZ+3h1YqFM6eCQgghhIVJy0g2MqaFd6plDtsN4yftDIrxINkycQaFbWfumZ5ffxTJO78d5fTtxLO6CiGEENYmyUg2MqpFeUrkd2CVvmmyZQqrntBKc5RA+3dxTOLW3+RsOnWXdt/ts0AthRBCCMuSZCSbGdqkLB/ph6Sp7Bn7N3ElIpNrJIQQQmQuSUaymdeqFwMgIM43TeVP2A9hmOZPALxVN1LsvgHovfCgdNcIIYTIVnJ1MjJ//nyqVauGq6srrq6uNGjQgE2bNlm7WilytdcCMEb3TpqP+VC7iq9tFrLV7iMC7d+lrupssmUDLz2U7hohhBDZSq5ORkqUKMHUqVM5cuQIR44c4dVXX6Vjx46cPn3a2lVL1WNc01W+t80u0+PVdl+hxsAc7TwGaTYmWX7k7//Scd4+9HGJF+MTQgghslKuTkY6dOhA27Zt8fb2xtvbm8mTJ+Ps7MzBgwetXbU0aRHzTYaPvWzfl46aQMZrf0ty/1/Hb3P8ZhiHriS+NVgIIYTISnlmnpG4uDjWrFnDs2fPaNCgQbLlYmJiiIl5vv5LeHg4ADqdDp1OZ5G6xJ8ntfNdVEqY5hVRYeCKfd8Mvd5V+95UiF5MDLaJ9gWcu4ebnZoKHi4ZOndGpTUGuZnEQGIAEgOQGEDujUFar0el5PKpOk+ePEmDBg2Ijo7G2dmZFStW0LZt22TLT5gwgYkTJybavmLFChwdHZM4wvJGHUg6R7xo1xcbVca7VSbrerMwrn2S++Y00Ce5XQghhMioyMhIevfuTVhYGK6uyQ8/yPXJSGxsLNevX+fJkyesXbuWn3/+md27d1O5cuUkyyfVMuLp6cmDBw9SDGR66HQ6tm3bRsuWLdFqtYn2P4yIof603Ym2OxOJAzG4qiLZYfdBhl//e/1rfKvvabYt5KtWGT5fRqQWg7xAYiAxAIkBSAwg98YgPDycggULppqM5PpuGltbW8qVKwdA7dq1CQoKYs6cOfz4449Jlrezs8POzi7Rdq1Wa/FfkOTO6ZE/6deJwJEIHLmv5OfVmOnstBubodcdbrOBH/XtCcfZrC4AsXoDtjZZN5QoM+Ka00gMJAYgMQCJAeS+GKT1WnL1ANakKIpi1vKRU11WiuEfM5WPdIMzdPwy26lmz2P1Bg5dfoj3Z5v4cfclS1RRCCGESJNcnYx88skn7N27l6tXr3Ly5Ek+/fRTAgIC6NOnj7Wrlqp5vWukWua8UpJVcc1Mz2OUtDd0+aovM9rmf6bn3p9tosdPxruMpmw6x8aTd4jWxaWjxkIIIUTG5Opk5N69e/Tr148KFSrQvHlzDh06xObNm2nZsqW1q5aq9tWKpbls95jxfKx7iwoxS3k7dkyajxtt8wdTbX6is3pvon3Dlh9j0j9n0nwuIYQQIqNy9ZiRX375xdpVyBKHlUocjqsEwBZDHd6MHcuvttPTdGxPmwB6EsDf0Q3QvfDrsO7YLSZ18rF4fYUQQoiEcnXLSG609p0GfN055QRhp6EmzWO+Tdd5+2q2Jdr2LFa6aYQQQmQ+SUayse3vNeGzdpUo5mYPgIu9DbVKFaCwS+K7fV50SSmOV/RyakQvYJKuD9N13VIs31ETmOT29f/eotG0nQTfeALAg4icP/hXCCFE9pKru2lyunKFnSlX2Bn/Kh58tyOEt5uUASDtE8OoeIwrP8e1A2Csdk2yJaurL1FVdZlTShmz7aNXBQPQ6fv9DG9Wlu93XWJ8+8oMalQ6nVcjhBBCJE1aRnIAzwKOfNvNl3KFjVO2F/2vpSS9VuubpLj/b7vPyMdT6qnOoiLxTK/f7zLe8vvV3+kb2HrubjijVv7L1QfP0nWcEEKIvEGSkRyoanE3Jneumu7j/jC8kmqZYPu3WWX3FV/b/JJkQhLPYFA4eTOMt5cd4fL9CFYFXaf17D3cehKVqOzrPwTyZ/BtBi4OSnedhRBC5H6SjORQfeqVokox49S6Y1p4p+mYg4bKaR7Y2stmF+Nsfk92f5lPNtJh3j7+3959h0dRrQ8c/+5uNpu+BEIaBAgtlCRUgQBSREK34FWRoiiiXARE4IciV8FCkStYUFHRCyooooCiIFUBMaETpYPSkRBKGim7m93z+2PJkCUBAgYWkvfzPHnIzpyZOfNmdvflzDlnlu86xZOfbeH5BTvYm5zJ6z/uJs/uoO8nG2n06gqOnM0i+0JH2EPSMiKEEKIIkozcxr5/phVJL3fk2btrMeVfsdryO6oFcnhyN7a/VHg+lb9UJSbZHgHgBduTV9z/Ux5LOOzVm0+N/8WXwi0e+Q4WSDKyrXa+T/qb9X+eITXbxoMfJhbrXBZuO06ryT+z52RGscoLIYQoPSQZuY15GPSU8/EEoGKBETZfPxUHQKCvJ1UrFH7S8IrAXlTL/ZJ59ruIyp191eN0MGxnlen/rnjbpqC0nIuPjE7JvPLom7NZVk5l5DJi/u+cSMvhuQsdZoUQQpQdkoyUEgUfvqzX67Tflw9vw/fPtHLp9Kq7uBoLnkTmzrnq/sN059hgGlJoeRXdKSqQrr1eu//0FTu4bjh4tkCdocXkNTSfuFpbZs1zFDofIYQQpZskI6VE/XBzkcu9jAYaRJQj4YW7tGV3VC3vUkahJzZ35lWPEaJL4w/TAGJ1fwGKqrpk1pmeY6vXvwnl7FW3B+j18QYcDmeikWErvF4BI+f/Tpd3fsWSJ5OuCSFEWSDzjJQSIQFerP2/dvh7Ff24Zp1Ox8rn2rB0RzJP3hlJBT9PPlhz8em8GfgW6zgBuhwWm14qtHyD11Cq5X5ZrH0o4MjZbF7eWvjyU0qxYNtxANbtP0PHeiGcOW/Bmudg7sYjWPMcjO5cB6NB8mghhCgtJBkpRapWuHJCUSvEn2dDnHOVjO5cxyUZKRmKYNLIxRNvLHQ3JPKFPR4rrglS4l9nGf3t70XuwVHg7syMNX8y7Kvt5Fzy9OAq5X3oF1cNALtDYShwW0oIIcTtR5IRoXEoHXrd9ffVOOzVp9Cyl4xzicqdTQUyOEl5FHr6frrxsvs4ei5b+33b0bQiyxxPdY7s2XjwLI/P3szL3evRq1mV6663EEII95K27jKsfVRFAHo3d36R97O9QIbyZph1CPVy/8dCe+sSOc4+r/4keA3jkFdfFniO423je0z2+JgAzl92my76jazxfI76ukOF1mXkOjubDJ67jWyrnRcW7iiRegohhHAPaRkpw97v05iNh87RskYFfvvzDL+djaGBZSbqQo46wjaYT/K6MsLjG+42bC+RYzbRH6AJBwDo5bGGd/Puo7ouGQc6Vtib8pBhDUNsw5jh+Q4AS0xjWWhvzbf2Ngw0LOEbe1u+2gQ1Kvqh013b7ZnTmRYOnj5P8+oVSuRchBBClAxJRsowH08P2kcFA7D4mdb837e/s2L3KZcyu1U1nrT9HxVs6Wz1+neJ12GYx3fa7/cYnBOk/WEY6FKmp2E9PQ3rAWhv+J1quS14f8lG+hhWs4A2nKQCn64/RHy9ECLKO+dVOW/Jw6EUPkYDBr0Ou0Nxx4RVAISbvUgY06HEz0UIIcT1kWREAGD2MfJBn8bUHPtTkevPYuakKk+Y7txNrllhjxqW86rxMwDuN6yng3Uqr/24G8uyl3kophzlH3yX6HHLAfA3eXBn7SB+P3ZxLpS/03N5/cfd/Kd7PbfUXwghhCvpMyI0HgY9hyd3u+z6f1nG8WFeD1rkTqda7pdUy/2SWrmfF2sW15KUn4gA1NCfJIyzvOTxBYM9FhO053PajM2vj6K5bSNVdn+MMf2gyz4+WX+IPLsDctIgJxWAbUdTOXv+4oyxDofS5kQpilKKKcv2snTHSZRS5FhLZl6U77af4MEPE0jLtpbI/oQQ4lYnLSOi2E5Qkcl5j7gss124hB61Ps/nnm+4o1okeg11ef2p8U2WO5q63AJ6gXkAPGMdxgFViRBdKideG0lVTmplRlimUtGQzTevD+O9nw/w5or99PDcxvByvzL1THOefeY5ooynIKg2DvT8vDdFGx59Z60gfj1whs+eaMYnvx5kZHwUDSPKXdf5DL8wJX7DV1deMTkUQojSQpIRUUidUH/2Jmde0zbrHA2on/spVozY8CCcMzTS/8kIj2+ooXd+4acrH06pQGrrT9yIamui9MeJ0h8vct37nu9edrs1ppEA/D73FPt2QVNdeabr34QM+MBzI8y8uO0Kj/bMymrNYa/X2OSI4pED/6GJ7k8+nr2D3xwx/HrgDIcndXWde18pOPsXZJ4EDxOENipUhyxLXrHO8ex5C++sPsBDTSOIrlT07LtCCHG7kGREFNKyRtA1JyMAWXhrv/9NEH87gki01mOb1yC+yLubcXn9caDnsFdvAHKUJ966W+9WRIMD7zHd88plOuf9QmfTLwA00+/jL69+2rpulom8b3wHXunN9gbjafT7eACSW7xE6IbXLu5kVIFhyzlpfPHdj7z8u5ni3D0du2gny3Yl83niEWk9EULc9iQZEYUoSu4hdecIKDRN/GPW52mv387EvD5UJI3fvJ4FnC0nZl12Ubu5rSwxvaj9np+IAK6JCGB8M5LuOg8M252tIf2Afl6wxN6MGN0h/pP3BOS2BqMPGArMYmu3sWxX8tUrkvE37PsJYv4FRxL4y9wMfx9fggO8yLLkYVeKgEseH5Bnd3A8NYdqQcV7PIAQQpQESUZEIS1rBDHrt8MA/DCkNT3eW1+i+1/raMBaRwPA2Q8lOvcTOum3sNbRgC0Xhg8Psg5nmaMZAw0/4qfL4a28fxU5w+vtzqAK35bpZtgE4OyDM/lCP5w2/wfegWDJhF+nEqf/Pw45QlHo2JucQR1DMnz1MNS7z5mA3DMdvnkMMk7AkhEA1AA6WP7LygkDqX9htNGXA5vTskYQnPwdkr5kyIl4lv2Zy/u9G9MtNuzqJ6AU2LLB0xdsOWD0vvo2AA476A3FKytuvNWvQtoxuPd98LhKs6AQN4BOybParygjIwOz2Ux6ejoBAQElsk+bzcbSpUvp2rUrRmPRD7ZzJ6UUa/afpk6oP2Fmb/YlZ9Lp7XU35dgVSCdKf4wER33AdVKzSN1JfrnQrwPgSetIPvGcelPqdStbY29AO0PRz/opynmdH37qPP2t/0dH/Tb6eKwuumBYA2eSUrU19P8RDv4CHt6cOJtOpcUPF71Nj3dAp3cmRV4X3i+XJB5n5j5F0IGvOdRiApU7PH3194LDAb9/BRHNQdnBqxz4hxQuZ7dBngVMfs7X1ixnknQtHA7Q6y/+brcUP8G6Tm7/PPhzNczp6fy9Skt4fKnz92ucVPCfcHsMbgGlNQbF/Q6VlhFRiE6n0yZDA4gK9efuuiGs2uM6IdrL3etRpbwPT36+pcSOfRYzCY6iO2QeUmGMsz3GKxeG9v7qiOG4CuKwI4S+trF4YSEXT740TqClYXeJ1elWdy2JCICfck7DP9vzv1cuePLCfo+sh1fKaYsrXWmbH5y33Fg8tPC6aneyot4k4g98DUDkhrE4TvzAPcc24ig/HlIPwrbP4L4Z0LA3HN3o/JK0FvHYgLtegp8v3PYauR88feC/tSAvB+7/CBY97VzX/S2oew9YMuDMn+BTAY4mgLkyfNMf2v8H9nwPrYbD0Q2weSZUuxPsVjh24RlKzx92tkoBHEmAM/uhSX/X+thyncmP7yWz+ya+D97lncfPTYfoB5zlDEYIrguAbu+P+Of8faWoXt25g+DhDb5B8NfPzsTNFOBMrBx2SNkNwfUvJloF5Sci4IxN/t967Ckwev2zeomSk5vuTPRN/sUrb8t1XuO17oY7nnQuU+qmJpnXQlpGrqIstowUxeFQ9JyRgNnbSI7NzqZD59j4YgeC/U0kHjyL2dtIt3dL9nZOUYzk8brH/1jniGWJowUG7NjRc2krSn3dYcrrMkhy1KSjfgvrHA2IN2zhRY+5+OlysSgPTLo8vrW3YZRtEJM8ZvKIxy+stDeho2Grtp+ZeV2pqztCa8OuG35uooDWI2D9NHfX4uqa9Ieg2rD8Qj+h5v+Gs386k419S6++fdXWzmQPsI05hXHXfGciF9sL7v/Q+eWh1zvnw/lrNexfAY36QuSdzu2zzsBfv8DCC182vhUh6/TF/fdfAnt+hI0znK/r3QsdX4PAqhfLjL/CaKzx6ZD4Aaz4D/w7AYLrFF3O4XB+yWWdAb+KruuUgty0iwldEa74mXh0o3P0WXhD563ALbOgWitny13qEfAuB15XOIeibgk67HDmAFSMuvyXc/pxOL4Z6t5bdBIHkJtxsQUQnH8naxaYKzmTAaOXs4zJ3xkHh815LgVZzoOnL7a8PNcYZJ9zxkyng+VjIfE9Z/mXzgIKjiZCpabORLwoa96ANROdv489BcvHwJb/wd3jofVzl8TDcflz/IeK+x0qychVSDJyUf6lohTk5tnx8XRtWBuz8A++2nQMgA/7NmHdgdN8ufHoTa9ncQWSQSr+5Ccyehw40PGcx7ekKz9m2Ttpz+kxYcWKBxM8/kdvj58BmJHXg3fyerLX63EAtjlq0lj/p7b/vxxh2rBmIW45Hl6Ql3tt2wRUhuZPOxMwg4fz3/dbgC3rYpmGfSAkGjZ8AOnHLi6/6yXY8S10fAVqxcPmTyA0FiKaYbPksGLpYrqwBr0lA5o/5fwS/3E4ZJ91bn/Hk85t8vVZAHMfcP7+zGYoV8WZCAbXdbYg5FmcLW0/jYaub8IvEyHnkhmkox9wJn7VWjtvAb7TwNlq5h8G+5c5y5SrAoN+c56LJROObQKDJyx73rm+/v3OZe3GwOIhF/e7c0HRMXxmE/gEOROT7V/Az69Do37Yur7FwU8HUEt3FP3JAs8CqxLnTDzyPbECDiyHXy/coh6X5kxY7Hnw65sQ2QYCI2HaZRJHcCa0DftC2hFY91/nlAN+IXDnSGfsS5AkIyVEkpHi+z7pBM/OSwLQhptuPZLKnA1HWLT9xs4tcrMEkMVzHt/yvb0VSapmgTX5byOdy7JW+p3kKBMnVQVOUoHBhu8xksc5/HnNOPvmVVwIcUuzNx+MYeMH17dxwduW/9QDnzpH4JUQSUZKiCQjxaeUYtnOZKIrmbUH1hV06EwWIQEm+nyykT+Op2O/wlTr+d54IIb2UcGcSMvh/g8SbkS13aaVfgdzPSfxo70FUbpjLHPcwQL7nXhgJw8Dh1UYzXV7mO45nWBd2j8+3g/2FvQwbPjnFRdClG7j069eppikA6u46XQ6HV1iLj8cNPLC3BWLBrfCarUye+FP1IhtxvMLd9GyRgUW/150J77gAC+CA1w70k35Vyyjv/1De31Pg/DLbn+r+s0RQ8Pcj0jDj0v7vOTbqOrS0vIuTXQHOKRCOYOZBNNQQnWpTLX9i2WOZtxr+I2f7M0I0mVwp/4PnvS4+LDDJ6yjiNYdBmCmvStDbcO0SeeuZpejKrl40kR/wGX5EUcwlXWnMeicyeSXeXdpt66EEOJ6SDIi3EKn0xHiDW1qBbHlP3cDFJlM1Am9mEm/dm99Xvp+F0+3rc5DTSNckpExXeuQlmNj3f7ThfZxK0vj6j3j8/Bgo6qrvW5heR8TViw454N4M+/CMFvlnMNlct4jtNDvwRMbPzsa8zONXfbX3fI6UbrjTPX8EMBlUjodDprq9rNXVeE8XugAX3LJxZM4/S4CyGaNowHn8aaJbj/HVDApBJKOL//2+AGA1pa36aHfQJKqwQFHZeZ4TqSO/hhFOegIpbredQK3FFUOX3JIVuV5Pa8vsy6M+tnjiODtvAfoa1jFnYadV43bEOtQ3vOcftVyLrzMzlELxTEuzWWU0W0v5kHY8Y27ayHKKElGxC3jlXvqM26xc9TKf7rVpUZFPxoUeNhcv7hqdKwXSkiAszf6phc78O7PB6gd4pwPpW6o/3UnI7VD/Nh/qoghpLeo/ESkKHl4sN4Rc9n1O1V1dqrqbLJEYVGu+1Ho2azqFHgNmThvua27MFFdvq0qSvv9jbxH2OGIxEdn4bgKZob9Hm1dZ+tkKutOc0IFMdX4IT0NztEjy+1Nedo2gpnGN+lo2EaT3BmcpfCoiEtn8M3CmzsNO9nsqE0f61iseOBHDll4YcROEOmcJQALRp50LKGh/iCPq/FstVQiA19GVNyKf+YBTtTsy3/+fAiAxfY46jfvSNBdQzFPcR0N0t3yOjtVdfb0zsN74aMAJAfFEarTQd+FF4fGlq8BVeOYmdGcqbv86G7YwMR2/njW7QKVmzrL5KRxxys/8qjHSoYWeJCjy9/A5I+uzWhnYpD8R5Fl/hGDyTl/SgG/+HXj8c338/njE3lj9nzeNn5ArRv8DCkhCirVfUYmTZrEwoUL2bt3L97e3rRs2ZI33niDqKioq298gfQZuTEuF4Mcqx1vz+ubmTPbmsf7v/xJp/qh3PPebwCYPPRY8hxX3K5ljQpkW+0kHUu7ruOKa6PHQUPdn+xS1a6YVF1JhO4UyaqC9tToKzFhJU9vKrKP0gc9Qvl6yXLWOmJ5qGkE87ccJ4Dz/OHlHFEQlTtbq+MHfRrTdYEzUXvD1ovgri/Qt0VVjHsWwZ8/Q5fJJByz0PuTjdr+dToY36M+j7WsRmqWFT8vD2qN/QkdDqrrTmLBk77eG6hSvzUd73mYHu8nsjc5ky+fbE7LmkE0fGEeVoxE6pKppktmuud76ClwPT/6PayZDMpxcV6UZk87R4KkHblY7smfITTaOQpEp3MO5dz7AxxJ4HRGNnds73xJZBQzjG/T2WcfOksG9P7G2Wq0byn89raziF+IMxn7sNVV/waAc0jxkQTYf+E2YsU6cHovAPamT2LYcmGkTFhDOJl0+f08twvequ+6rPFjUKsj1OkOB1Y659coOMLncio1gRMXh/Iz8BcwR8CbNS+/TVEa9nE+fuHgL0WvNwU455q5iqPlWxPWezrG9wo/RBOAnp9AwruAguQdRZcJjITUQ4WXNx0AWz69/MFbj4A9i6HZU84RUyVEOrACnTt3plevXtxxxx3k5eUxduxYduzYwe7du/H1Ld7MjJKM3Bg3OgaLth/n92PpPNWmOv+es5UdJ9KpUdGPAymFWz8ebFKZJ++sftNmmRW3A4UOpQ3tzldfd5i2+t/52N6NvAuJ0NQHG/BAk8pk5NqIHb+iyL3991+x/N+3RbdyVPTz5D8x2XTt2pVaL13c/vDkblR7YYlL2S5VFTOi9zuHrdaOd36ZgnP22c2foiLvZFdeZWr42/FO3QuVmzlbQS7MRJtnd2DQ69BdmFtj54l0uk+//PxATasGMr13Iyr4mvD0uBCL95vD6b3saTaJjDoP07yizbmsYhT0W+R8lpLdCnuX8HuGL+/u8eWV+xtRufyFz9zNn8LBNfDAJ84huA47NgwsXbKErt26OT8PDq5xzp9y13+cT7n2C3UOrS1f3ZlM5Vnhk7sufiG/dMb1+U1wcf6U9mOdj1NY9DT88fWFdekXJwD7rAccWudMrGp2cK5P3umc3C66wIRwh9Y5E5dWw52vrecvzh+SP1fJnh+ciZDjksc8jEuDnFRnuTeqFfiD/heObYCOr2HzCb74mZhzGma0ck7+1+Fl5/Bf3yBo9ezFbTNPOZOfyLbOxPDTu0HvAU8sv1gfpZzXii0bfMpf3DY3A9ZNgVO74eEvrn2m4msgyUgRTp8+TXBwMGvXrqVNmzbF2kaSkRvDHTFQShE5xnUiqphKZj5/ohmBvp6FPpjf6dWQUxm5rN6TwsZD5y7dnRCah5pWZv6W49e1bQVfT4ZFZTNum2srz5sPNmDUN66z61Yq582vo9s7v48dCqPBNVlatP04z33t3GbJsNbUD7942yvHaufOKb9QLzyAz59oxl+nz9Nh6tpi1TEyyJdfRrVzvshNJ/Xgdhp9fh7QcWBCFzz0Oo6dyyGivLeW6Ow5mUGXd37V9vHbC3dRqVzRU+tf1+eBUs5J1nT6wjPf5q+3ZFycEC37HKydAg16OSdQy2e3OVs1Ck4E908o5ZxUzW6BP+Y75zAJqnVx/YltztmNm/R3mXCtUAyu9flN+RPP3WIzrMpomiKkpzs7ppUvX/6yZSwWCxbLxfupGRnOpjWbzYbNZiuReuTvp6T2dzu6FWKw95WOGPQ6rR5G3cW8vFWNCnSt75wS//G4Kpw5b6G8jyer954mzOzFuWwrn64/THz9EMb/sKfI/R94LR67Q1Fn3Ept2ZYX27P+z7MMn38D+gIIt7neRATgbJa1UCICFEpEAE6k5VD9xYsJ9bjudWhQ2cyek5nM2XiMPcmZ2rpu767n7joV+et0Fv1bVuX7309y5ryFdftPM3X5Hv5OL/6EZ4fOZPHG0t3M23KcD/s0wuQbAziHiff9ZAPR4QF8+tsRRneqRXy9EH778yxvr/7TZR9vLN3D1AdjcDgUnyYcpmmVQBpVKQf8g88Dk3N7itgu25rHsXN2aodYnQmS0R/uds7FYcmx8NtfZ2lWLRA/kwf4hRe5j4KyLHn4mq7hK1PnCQ36Fq5fcIzzJ8+19aTIGNivfIv5dlDcv2mZaRlRSnHvvfeSmprKr7/+etly48eP55VXXim0/Msvv8TH5zLT7orbxpbTOr7404BRp3izhb3Q+sVH9JzOhX41HRS360rSWR2z9htoF+agRoDip2N6+tWyE37hcnk20fkB9q9IO3eGOt9uJ7Jgyh+uH2zRgQ52pt6YKZmFcLcgL0XTIEWgSfHVX8431ztxF7+QLXZYdUJPbbMi0l+h0zmXeRngf/v0VPZVdI4o/HWVdFaHUQ/1AxUnssCoh2BvmJhk4FSOjqfq2KlXTvFXBoT5QJ6Cl7defO/9t1leke/1PIfzfRrhB4sO61mXrGdY/TxqlEwDeZmRnZ1N79695TZNvmeeeYYlS5awfv16KleufNlyRbWMREREcObMmRK9TbNy5Uo6duxYpm/TuCMGzicSn6F+eADB/qarb1BMqdlWynkbtSbqgv46ncWmw+d4sHElPAo0qxfsHwAwuG11+jaPoOWUyzed1wr25UBKMTrmCXGL0usgvy9x5XJefPHEHcz89SDfbj2O1VH4/VPRz5PT562As7Uxx2rHw6DDaNBz9ryFFm843y/Lh7Wi07vOjuv7X+1I7ZedLZI9YkO5u04wz87/g/K+RppUCWTlnhRt//1aVOHlbnWw2Oz8fiKdxhHl8DDoGTR3O6v3nub/4mvx3xXOuXaaVi3Hs3fVpFawL5OW7efQmSy+HtjM5X0NMHfTMQ6ezuI/XaOK/Ew4nWnB38sDL+PFLCj/M9FcqylmHy+iK13f901mro1fD5ylfVTFIgcD2B1KaxG+GTIyMggKCpLbNABDhw5l8eLFrFu37oqJCIDJZMJkKvwlZTQaS/xL80bs83bjjhjER4eX+D6DzZc/hzrh5agTXq7Q8oIfsgAGg57w8n4cntyNLYfP8a8PLz6P4sO+jWlRvQLlfDz5ZV8Kj8/afF317BoTyonUHH4/XnIzLApxLQoOajqelkv7afkt1UV/QRZ8j+QpPQ1fX4FDwV8Tu5KVd/E/jvmJCEDi4YvXt06n59kLt0XPZdnYffLirSyALzYc5bX7Ymgy4WcycvMw6HUuI6/yExGALUfS6DfL9Snlzy/azf5Tmbz1cENqBvthdyjt1m3DKoGkZdt4+I4I7RbP32k5tJyyljCzFwkv3EVqto3yvp78mXKeFcd1LElMAmDva53xMhpIycgl8eBZPk88wr+aVOaRZlXYeuQcNruiRfXCfWUGz9rChoPn6Fw/lNgIM+v2n2b2483wMhoY9/1OFm0/waoRbQtNJHmjFPfzvVS3jCilGDp0KIsWLWLNmjXUqlXr6htdQjqw3hgSA0jPyqHBaxdnLn2xax2ealNDe/3p+kO89uNu186DwN7kDDq/XfStxmoVfKgXHsDSHRcnEgs3e/H103EE+Zm0/yldOkrjWi0c3JKepWx6fnF7qVLeh6Pnst1djWLp26IK53PzOHQ2mza1gpj+s7M/TeVAb46n5mA06LDZXb+KdTr4Y1w8MZcZoQWw9T93U8HP9T/PRb23ezevwsT7Y7R1/25Xg+c7uz5I759Mq3Al0oEV562ZL7/8ku+//x5/f3+Sk50f0GazGW/vont1C3GzXPrU434tqrm87t+yGjUq+tKwwMRv4JyV9s0HGxBm9qJPgTktAAa3q0m32DC6xoQx5Evnkz91Ol2RzwoCeL93Yw6fzaJ2iD/fbj3G8l2nilX3xlUCCfQxkppddjthC/e6XRIRgDkbLj69/PcC8xkdT80BKJSIgHNQTuJfZ6+436U7TlI7xJ/m1Stgdyj2Jhc9l8mXG4/Sp3mVy+7n9R9388n6Q3wzKI47ql1+gMeNVKqTkRkzZgDQrl07l+WzZs2if//+N79CQlxGvbCAQv8rMeh1tIsKLrL8v5o4bzd+8mhTVu9N4eXu9UjOyNWe/9M9NlxLRioHXj7xrhbkQ7dY5/OEokL82XkigyfvjKRP86qcPm/hyJksbRKvmEpmPujTWEtstHknrkCnc36oCiGu3VNfbL3i+pe+d85Y3bFeCCt3X/k/Et3evThtwc4T6Rw9m02AtwflfDz5ZL1zkrQHP0wkccxdhJlv/n/WS3XXfaVUkT+SiIhbTWzlwtOgF8fd9UKY1DMGb0+Dlojk+/qpFsTXC2Haww0LbfdBn8aM7VrXZR6KKhV8+O2Fu3i8VSSeHnoqlfOmZc0gDk7sym8v3MXCwS1dWlgCfS7Onjr78TuoGezHd8+0onXNIG35oUndtGXzn44r1jkN61D07dQVzxVvbqBr8fvL8SW+TyFutqslIpf69cAZ2vz3Fxq+upL/rXedrfV6+6P9U6U6GRHiVvdCgzwGt63Oi93qXr3wNWpevQIfP9q0yImmusaEMbBN9WLtR6/XUamcd6EJtt7r3YhGVcox6/E7aBcVzKoRbWkYUY7HWlZzKdcwohxznmxOs8jyHJrUlYMTu/Jo3MUJpkbF5HFHtUAAejaqxIiOtdkwpoO2PtzsxaFJXakdcvWHChb07iONqBzozazH7yiUqAF8MaAZHoZba4IoIW62V3/c7fJ6b3LmZUreWKX6No0Qt7owHxhwd83bshNvzWB/Fg0u/FySu+sG83G/JtQNK9xZTafTodPBM+1rsmxnMg82qUSEZT8zejTk17/OEV8vFIBQsxfVKvhw+Gw2naJDteGR855qwfajabyxzPlMk8fiqtIuKpi3Vu1n4v0xpGTm8vXmY3SPDadHg3DuaeAcObU46W8OnXEdEn1nrYo4inheTUV/E6czL47SyO9keC0m9Yxh4pI9ZFryrl74FvB85zos23lSRlkJt5FkRAhRonQ6HfH1Q69YJiTAi40vdiAvL4+lS/dj9jZyfyPXYfffDGrJ2v2n6X6hTwtAi+oVaFG9AjUq+rJo+wlGdIzC7GOkfZ38vjVm7qoTUuh4IzrW5tcDpzlTYJgoOFt9fh8Xz4aDZ2lTqyJWuwN/kwefrD/IpkOp/LtdDSx5dp7+fGuhxGLKA7EEeBvpHB3K5J/28uHavwDY/WonfDw9eLhpBEt2nGToV86+O/0vtBjtP5VJwhU6Jt5VJ5if96YUWj7h/mgebBJB7f/8dNlti/J+78Y88+W2K5aJrhTA022qu8zuKsoum91RqCX0RpNkRAjhFkVNBlVQRX+T1lH3UvH1Q6+a8BQUUd6HzWPvJiMnj8nL9tKzcSVtndnbSKcL+/LG2Yn4qTY1eKpAF5WkcfHUuPBFHRXiz5N3RvJg0wht/bMdamHJs9Opfqg2Skqv19GjQTjdY8Ow5DlcJrjKH2L59sMNGf51krY8yM+T//W/gzPnnZNitZ2yhuSMXPo0r0Kf5s5bW+V8jKQVYxTTXxO7cjI9h8qBPnyyvhzbj6ZdtmyQnwm9Xser99Zn65FUet1RhUdmbrjqMUTppHfD822kz4gQokzQ6XSYfYxM6hlzzcMXC05Y+c2/41wSEQBvTwPjetQvchIqnU7nkogAJL3ckcVDWnFfo0pM6RmtLf9f/zsAZ3Jg8jCw/Lk2vNe7ES91r6eV6X9Jn5zDk7ux//UueBldP84Neh2VA50djhcNbsXhyd2KvHUGUCfU2R/n0bhqvNOrEXE1KjDtoQYA2r9X4mnQM6R9zauWuxIfj6KHXT0WV0IPsBPFdjNnaM0nLSNCCHEVOp2OhBfuwprnIMDrn/fvKefjSbkLo5HubxSO4UQS93QvPAGg2dtI91jXGYOHtK9J88gK/J2WQ7NIZ1Ll6aEn6cLIoMVJf9PkQofgS/0wpBU5Njud3/6VE2k56HXwUb+mRbZS9WxcmfsbVUKn0zFifuGH9hXUsmYFRnWKonuDMPp9usmlz02+AC8PMnKdt7rGdKlD5+hQ2v53jbZ+TAM7a7PCWLX3NAsHt6RRRDnSc2yU8/Hks8QjhfZXtYIPR87ePnONiCuTlhEhhCiG8HLeVCtiVE5JKMaULRfLGvTE1ajAA00quwy19jIa8DIaeOiOCGpU9Lvstv5eRpYOu5Ovn2rBXxO70rFe4T42+fKTlO+facWDTSrzfu/GAPibPFj/fHu+fqoFXWNCmdwzFnBOyPdi1zpF7iu8wKiup9vWoGqFi7G8t0EYAZ7w/iMN2fZSRxpXCUSn02kJ26U61Q/hm6fj+OTRpgA0rlKOGX0aE3+ZcwnyM/FUm+qsf779Zc/1q4EtWHnJ8PGFg1tSO8SPx1tVK3KbKf+Kvez+imK6lj90CVnw75Y3/ZjXQ1pGhBCijDH7GGlexC2ly2kQUY4GF2YC7hbbTXvYWuVAn0L76RYTzrdbj9Mwohw/7UjmWGo2q0a05ekiJvBaPrwNC7cd58lWVUlYcwy9Xkd538ItT+/0asjpTAuvL3E+86Vvi6oEB3hxdz0vNo+9myA/T3Q6HV1iwlye3XRfw3AGtqnuMp9OdKUAdp7I4M0HG2CzO7ijWnlqBl9M3j55tClPfu58/kxsJTMrnmsLwK4TGWw6fI7YymbG9ahHTKVyeHroeX7BH0VO7NctJowlO04CUL2iL+/2akTdsACseQ4A6r687Kpxb1o1kC1HUp3Hf6UTJ9JyiH9r3VW3y7f2/9pRtYIvz91dm7dW7S/2du4gyYgQQohrcqU+BZ4eeuY+2QKAUfEXn1r7Yte6PPq/TTzZOlIrGxXqz5iudbHZrtwh996Gzg7H+cmIrsBD9Spe8vTtagVaXCY/EFuov878p+M4cOo8sZXNRd6eurteCN890woPvc7labyfD2jGqj2nuLNmRcw+FxMmo16P1e5MMJ5sHUmdsADqhvlTP9zMFEseJ9JyXObIyZ9puWtMqMszpIoyd2BzDpw6T/3wAHQ63VXn2pn2UAPaRQVT3te1RenpttVdkpGVz7Vh7sajzE44XGgfiwa7pyVFkhEhhBA3RMEv+za1K7JjfDz+JdDnJrCI1pN8AV4Xv9aKSpp8PD20Vp7LufR5UOC8DXZp/x2AiPLe/HXaOYfNfwp0NAbwNXlcNoGYcF8MlQN9qB8eQMsaQdwxYRUAQ9pV51SmlcHta2LyMBBdyXV25t9euIvlO5O1JwEfO5dN3083MqB1JD0bFz36zMto4LMnmvHY/zYBUCvEn/H31OfFrnW1oeJPto7kxa510buh8ypIMiKEEOIm+aeJyDu9GnIyPdfltsulKviZePeRRnga9DdlroyZjzZl4tK9DLnr2kYTBfp68mLXwjMv1wn1Z1TnopMKgErlvHmiQOtSRHkf1v7f5fvC5GtTK4gvn2xOjQK3pDw9nKOgFm0/waB2NdyWiIAkI0IIIW4T+bdrriZ/5t2boXpFPz55rOk/3k/jKuX441gqLWsUvy/PtdDpdLQs8NyofKM6RTEyvvZV5/250WQ0jRBCCOFmXw24gzea2fH3uvltBO5ORECSESGEEMLt9HrdNQ3xLm3K8KkLIYQQ4lYgyYgQQggh3EqSESGEEEK4lSQjQgghhHArGdp7FerCPL8ZGRkltk+bzUZ2djYZGRmFHoxVVkgMJAYgMQCJAUgMoPTGIP+7UxU1Z34BkoxcRWZmJgARERFXKSmEEEKIomRmZmI2X36yOp26WrpSxjkcDv7++2/8/f1LbCx2RkYGERERHDt2jICAgBLZ5+1GYiAxAIkBSAxAYgClNwZKKTIzMwkPD0evv3zPEGkZuQq9Xk/lypefmvefCAgIKFUX3fWQGEgMQGIAEgOQGEDpjMGVWkTySQdWIYQQQriVJCNCCCGEcCtJRtzAZDIxbtw4TCaTu6viNhIDiQFIDEBiABIDkBhIB1YhhBBCuJW0jAghhBDCrSQZEUIIIYRbSTIihBBCCLeSZEQIIYQQbiXJiBt88MEHREZG4uXlRZMmTfj111/dXaXrsm7dOnr06EF4eDg6nY7vvvvOZb1SivHjxxMeHo63tzft2rVj165dLmUsFgtDhw4lKCgIX19f7rnnHo4fP+5SJjU1lX79+mE2mzGbzfTr14+0tLQbfHZXN2nSJO644w78/f0JDg7mvvvuY9++fS5lSnsMAGbMmEFsbKw2WVNcXBw//fSTtr4sxKCgSZMmodPpGD58uLasLMRg/Pjx6HQ6l5/Q0FBtfVmIAcCJEyfo27cvFSpUwMfHh4YNG7J161ZtfVmJwzVT4qaaN2+eMhqNaubMmWr37t3q2WefVb6+vurIkSPurto1W7p0qRo7dqxasGCBAtSiRYtc1k+ePFn5+/urBQsWqB07dqiHH35YhYWFqYyMDK3MoEGDVKVKldTKlSvVtm3bVPv27VWDBg1UXl6eVqZz584qOjpaJSQkqISEBBUdHa26d+9+s07zsjp16qRmzZqldu7cqZKSklS3bt1UlSpV1Pnz57UypT0GSim1ePFitWTJErVv3z61b98+9eKLLyqj0ah27typlCobMci3adMmVa1aNRUbG6ueffZZbXlZiMG4ceNU/fr11cmTJ7WflJQUbX1ZiMG5c+dU1apVVf/+/dXGjRvVoUOH1KpVq9Sff/6plSkLcbgekozcZM2aNVODBg1yWVanTh31wgsvuKlGJePSZMThcKjQ0FA1efJkbVlubq4ym83qww8/VEoplZaWpoxGo5o3b55W5sSJE0qv16tly5YppZTavXu3AtSGDRu0MomJiQpQe/fuvcFndW1SUlIUoNauXauUKpsxyBcYGKg++eSTMhWDzMxMVatWLbVy5UrVtm1bLRkpKzEYN26catCgQZHrykoMnn/+edW6devLri8rcbgecpvmJrJarWzdupX4+HiX5fHx8SQkJLipVjfGoUOHSE5OdjlXk8lE27ZttXPdunUrNpvNpUx4eDjR0dFamcTERMxmM82bN9fKtGjRArPZfMvFLD09HYDy5csDZTMGdrudefPmkZWVRVxcXJmKwTPPPEO3bt24++67XZaXpRgcOHCA8PBwIiMj6dWrFwcPHgTKTgwWL15M06ZNefDBBwkODqZRo0bMnDlTW19W4nA9JBm5ic6cOYPdbickJMRleUhICMnJyW6q1Y2Rfz5XOtfk5GQ8PT0JDAy8Ypng4OBC+w8ODr6lYqaUYsSIEbRu3Zro6GigbMVgx44d+Pn5YTKZGDRoEIsWLaJevXplJgbz5s1j27ZtTJo0qdC6shKD5s2b8/nnn7N8+XJmzpxJcnIyLVu25OzZs2UmBgcPHmTGjBnUqlWL5cuXM2jQIIYNG8bnn38OlJ1r4XrIU3vdQKfTubxWShVaVlpcz7leWqao8rdazIYMGcIff/zB+vXrC60rCzGIiooiKSmJtLQ0FixYwGOPPcbatWu19aU5BseOHePZZ59lxYoVeHl5XbZcaY4BQJcuXbTfY2JiiIuLo0aNGnz22We0aNECKP0xcDgcNG3alIkTJwLQqFEjdu3axYwZM3j00Ue1cqU9DtdDWkZuoqCgIAwGQ6HMNSUlpVCmfLvL70V/pXMNDQ3FarWSmpp6xTKnTp0qtP/Tp0/fMjEbOnQoixcv5pdffqFy5cra8rIUA09PT2rWrEnTpk2ZNGkSDRo04J133ikTMdi6dSspKSk0adIEDw8PPDw8WLt2Le+++y4eHh5a/UpzDIri6+tLTEwMBw4cKBPXAUBYWBj16tVzWVa3bl2OHj0KlK3PhGslychN5OnpSZMmTVi5cqXL8pUrV9KyZUs31erGiIyMJDQ01OVcrVYra9eu1c61SZMmGI1GlzInT55k586dWpm4uDjS09PZtGmTVmbjxo2kp6e7PWZKKYYMGcLChQv5+eefiYyMdFlfFmJwOUopLBZLmYhBhw4d2LFjB0lJSdpP06ZN6dOnD0lJSVSvXr3Ux6AoFouFPXv2EBYWViauA4BWrVoVGt6/f/9+qlatCpTtz4Srupm9ZcXFob2ffvqp2r17txo+fLjy9fVVhw8fdnfVrllmZqbavn272r59uwLUtGnT1Pbt27VhypMnT1Zms1ktXLhQ7dixQz3yyCNFDmGrXLmyWrVqldq2bZu66667ihzCFhsbqxITE1ViYqKKiYm5JYaw/fvf/1Zms1mtWbPGZThjdna2Vqa0x0AppcaMGaPWrVunDh06pP744w/14osvKr1er1asWKGUKhsxuFTB0TRKlY0YjBw5Uq1Zs0YdPHhQbdiwQXXv3l35+/trn21lIQabNm1SHh4easKECerAgQNq7ty5ysfHR82ZM0crUxbicD0kGXGD999/X1WtWlV5enqqxo0ba0NBbze//PKLAgr9PPbYY0op5zC2cePGqdDQUGUymVSbNm3Ujh07XPaRk5OjhgwZosqXL6+8vb1V9+7d1dGjR13KnD17VvXp00f5+/srf39/1adPH5WamnqTzvLyijp3QM2aNUsrU9pjoJRSTzzxhHY9V6xYUXXo0EFLRJQqGzG41KXJSFmIQf58GUajUYWHh6uePXuqXbt2aevLQgyUUuqHH35Q0dHRymQyqTp16qiPP/7YZX1ZicO10imllHvaZIQQQgghpM+IEEIIIdxMkhEhhBBCuJUkI0IIIYRwK0lGhBBCCOFWkowIIYQQwq0kGRFCCCGEW0kyIoQQQgi3kmRECCGEEG4lyYgQQggh3EqSESGE26SkpPD0009TpUoVTCYToaGhdOrUicTERMD5mPTvvvvOvZUUQtxwHu6ugBCi7HrggQew2Wx89tlnVK9enVOnTrF69WrOnTvn7qoJIW4iaRkRQrhFWloa69ev54033qB9+/ZUrVqVZs2aMWbMGLp160a1atUAuP/++9HpdNprgB9++IEmTZrg5eVF9erVeeWVV8jLy9PW63Q6ZsyYQZcuXfD29iYyMpJvvvlGW2+1WhkyZAhhYWF4eXlRrVo1Jk2adLNOXQhxCUlGhBBu4efnh5+fH9999x0Wi6XQ+s2bNwMwa9YsTp48qb1evnw5ffv2ZdiwYezevZuPPvqI2bNnM2HCBJftX3rpJR544AF+//13+vbtyyOPPMKePXsAePfdd1m8eDHz589n3759zJkzxyXZEULcXPLUXiGE2yxYsICBAweSk5ND48aNadu2Lb169SI2NhZwtnAsWrSI++67T9umTZs2dOnShTFjxmjL5syZw+jRo/n777+17QYNGsSMGTO0Mi1atKBx48Z88MEHDBs2jF27drFq1Sp0Ot3NOVkhxGVJn5GrcDgc/P333/j7+8uHlhAlrGPHjuzdu5eEhAQ2bdrEqlWreOONN3jvvffo06cPANnZ2WRkZGjbbNmyhU2bNvH6669ry+x2OxaLheTkZHx8fABo2LChy3aNGzdmx44dZGRk8K9//Ys5c+ZQs2ZNOnbsSKdOnejQocNNOmshyg6lFJmZmYSHh6PXX/5mjLSMXMXx48eJiIhwdzWEEEKI29axY8eoXLnyZddLy8hV+Pv7A85ABgQElMg+bTYbK1asID4+HqPRWCL7vN1IDCQGIDEAiQFIDKD0xiAjI4OIiAjtu/RyJBm5ivxbMwEBASWajPj4+BAQEFCqLrprITGQGIDEACQGIDGA0h+Dq3VzkNE0QgghhHArSUaEEEII4VZym6aE2O12bDZbscrabDY8PDzIzc3Fbrff4JrdmiQGEgMouRgYjUYMBkMJ1kwIcTNJMvIPKaVITk4mLS3tmrYJDQ3l2LFjZXa4sMRAYgAlG4Ny5coRGhpaZmN5vY6ezSY4wISXUZI54T6SjPxD+YlIcHAwPj4+xfogdDgcnD9/Hj8/vyuOuy7NJAYSAyiZGCilyM7OJiUlBYCwsLCSrGKp9vuxNO59/zeqlPdh3ej27q6OKMMkGfkH7Ha7lohUqFCh2Ns5HA6sViteXl5l+ktIYiAxKKkYeHt7A86nAAcHB8stm2JasuMkAEfPZbu5JqKsK5ufgCUkv49I/oyPQgj3yX8fFrfvlhDi1iHJSAmQe9RCuJ+8D4W4fUkyIoQQQgi3kmRE3HTt2rXjueeec3c1yrz+/fu7PA23OHQ6Hd99990NqY8QouySZKQMKupL6Ntvv8XLy4spU6YAMH78eBo2bFjsfc6ePRudTodOp8NgMBAYGEjz5s159dVXSU9Pdym7cOFCXn311X96GmVGtWrVtNgW9dOuXbvr2u8777zD7Nmzr2mbkydP0qVLl+s6nrj1yI0tcauQ0TSCTz75hGeeeYb333+fJ5988rr3ExAQwL59+1BKkZaWRkJCApMmTWLWrFn89ttvhIeHA1C+fHkcDofL491Lms1mKzXPd9i8ebM2IVhCQgIPPPAA+/bt056V5Onp6VK+uOduNpuvuS6hoaHXvI0QQlyNtIyUcVOmTGHIkCF8+eWX/ygRAWcTfmhoKGFhYdStW5cBAwaQkJDA+fPnGT16tFau4G2aF198kRYtWhTaV2xsLOPGjdNez5o1i7p16+Ll5UWdOnX44IMPtHWHDx9Gp9Mxf/582rVrh5eXF3PmzCEvL49hw4ZRrlw5KlSowPPPP89jjz3m0iqklGLKlClUr14db29vGjRowLfffqutX7NmDTqdjtWrV9O0aVN8fHxo2bIl+/btc6nv4sWLadq0KV5eXgQFBdGzZ09tndVqZfTo0VSqVAlfX1+aN2/OmjVrih3XihUrEhoaSmhoKOXLlwcgODhYW1ahQgU+/PBD7r33Xnx9fXn99dex2+0MGDCAyMhIvL29iYqK4p133nHZ76UtZO3atWPYsGGMHj2a8uXLExoayvjx4122KXibJj/uCxcupH379vj4+NCgQQMSExNdtpk5cyYRERH4+Phw//33M23aNMqVK1fs8xdClH6SjJQgpRTZ1rxi/eRY7cUuW5wfpdQ11/eFF17gtdde48cff+SBBx64ARFxfmn26dOHxYsXFzndd+/evdm4cSN//fWXtmzXrl3s2LGDPn36AM4vs7FjxzJhwgT27NnDxIkTeemll/jss89c9vX8888zbNgw9uzZQ6dOnXjjjTeYO3eu1jKTkZFRqL/Df/7zH2bNmsWMGTPYtWsXzz33HH379mXt2rUu5caOHcvUqVPZsmULHh4ePPHEE9q6JUuW0LNnT7p168b27du1xCXf448/zm+//ca8efP4448/ePDBB+ncuTMHDhy47rheaty4cdx7773s2LGDJ554AofDQeXKlZk/fz67d+/m5Zdf5sUXX2T+/PlX3M9nn32Gr68vGzduZMqUKbz66qusXLnyituMHTuWUaNGkZSURO3atXnkkUfIy8sD4LfffmPQoEE8++yzJCUl0bFjRyZMmFBi5y2EKB3kNk0JyrHZqffycrcce/ernfDxLP6f86effuL7779n9erV3HXXXTewZlCnTh0yMzM5e/YswcHBLuuio6OJjY3lyy+/5KWXXgJg7ty53HHHHdSuXRuA1157jalTp2qtDZGRkezevZuPPvqIxx57TNvX8OHDXVokpk+fzpgxY7j//vsBeO+991i6dKm2Pisri2nTpvHzzz8TFxcHQPXq1Vm/fj0fffQRbdu21cpOmDBBe/3CCy/QrVs3cnNz8fLyYsKECfTq1YtXXnlFK9+gQQMA/vrrL7766iuOHz+u3aYaNWoUy5YtY/bs2Tz//PP/JLSa3r17uyRIgEt9IiMjSUhIYP78+Tz00EOX3U/BFqlatWrx3nvvsXr1ajp27HjZbUaNGkW3bt20Y9avX58///yTOnXqMH36dLp06cKoUaMAqF27NgkJCfz444/Xfa5CiNJHWkbKqNjYWKpVq8bLL79MZmbmDT1WfqvN5eaB6NOnD3PnztXKfvXVV1qryOnTpzl27BgDBgzAz89P+3n99dddWlMAl9aI9PR0Tp06RbNmzbRlBoOBJk2aaK93795Nbm4uHTt2dNn3559/XmjfsbGx2u/5043nTz+elJREhw4dijy3bdu2oZSidu3aLsdYu3ZtoWP8EwXPPd+HH35I06ZNqVixIn5+fsycOZOjR49ecT8FzxOc55p/nsXZ5tLY7Nu3z+VvABR6LYQQ0jJSgryNBna/2umq5RwOB5kZmfgH+JfYNODe1/iQq0qVKrFgwQLat29P586dWbZsGf7+/iVSl0vt2bOHgICAy06Z37t3b1544QW2bdtGTk4Ox44do1evXoAzVuC8VdO8eXOX7S6d8tvX17fQvi9NgArezsrf95IlS6hUqZJLOZPJ5PK6YIfQ/H3mb58/FXlRHA4HBoOBrVu3FqpvSc7ce+m5z58/n+eee46pU6cSFxeHv78///3vf9m4ceMV93Npx1edTqedZ3G2uTQ2Sqkr/g2EEAIkGSlROp2uWLdKHA4HeZ4GfDw93PpMkipVqrB27Vrat29PfHw8y5cv10ZolJSUlBS+/PJL7rvvvsuea+XKlWnTpg1z584lJyeHu+++m5CQEABCQkKoVKkSBw8e1FpLisNsNhMSEsKmTZu48847AeezhLZv364NWa5Xrx4mk4mjR4+63JK5VrGxsaxevZrHH3+80LpGjRpht9tJSUnR6pHvRo4o+vXXX2nZsiWDBw/WlpVkS0xx1alTh02bNrks27Jly02vhxDi1ibJSBlXuXJl1qxZ45KQ5A/5zMnJISkpyaW8n58fNWvWLHJfSimSk5O1ob2JiYlMnDgRs9nM5MmTr1iPPn36MH78eKxWK2+99ZbLuvHjxzNs2DACAgLo0qULFouFLVu2kJqayogRIy67z6FDhzJp0iRq1qyp9V9ITU3V/qfu7+/PqFGjeO6553A4HLRu3ZqMjAwSEhLw8/Nz6Y9yJePGjaNDhw7UqFGDXr16kZeXx08//cTo0aOpXbs2ffr04dFHH2Xq1Kk0atSIM2fO8PPPP1O/fn1at25drGNcq5o1a/L555+zfPlyIiMj+eKLL9i8eTORkZE35HiXM3ToUNq0acO0adPo0aMHP//8Mz/99JNM3S6EcCF9RgSVKlVi7dq1pKWl0bFjR9LS0gDYv38/jRo1cvm50vDfjIwMwsLCqFSpEnFxcVoH0+3bt1/1se4PPvggZ8+eJTs7u9CEbE8++SSffPIJs2fPJiYmhrZt2zJ79uyrfrE+//zzPPLIIzz66KPExcXh5+dHp06d8PLy0sq89tprvPzyy0yaNIm6devSqVMnfvjhh2v60m7Xrh3ffPMNixcvpmHDhtx1110ut0NmzZrFo48+ysiRI4mKiuKee+5h48aNREREaGV0Ot01T0B2JYMGDaJnz548/PDDNG/enLNnz7q0ktwsrVq14sMPP2TatGk0aNCAZcuW8dxzz7n8DYQQQqfkBu4VZWRkYDabSU9PL3QLIzc3l0OHDhEZGXlNH675zfMBAQFl+tHxNzsGDoeDunXr8tBDD/Haa6/dlGNerT4ZGRmcO3eOqKgodu/eTa1atdxdrRtu4MCB7N27l19//bVEr4PrfT+6m81mY+nSpXTt2vWmT9Q36ac9fLT2IACHJ3e7qccuyJ0xuFWU1hhc6Tu0oGt690+aNIk77rgDf39/goODue+++wpN/qSUYvz48YSHh+Pt7U27du3YtWuXSxmLxcLQoUMJCgrC19eXe+65h+PHj7uUSU1NpV+/fpjNZsxmM/369dP+x57v6NGj9OjRA19fX4KCghg2bBhWq9WlzI4dO2jbti3e3t5UqlSJV199VTrQlRFHjhxh5syZ7N+/nx07dvDvf/+bQ4cO0bt3b3dXzcWyZct46qmnSm0i8uabb/L777/z559/Mn36dD777LNi3wITQpQN15SMrF27lmeeeYYNGzawcuVK8vLyiI+PJysrSyszZcoUpk2bxnvvvcfmzZsJDQ2lY8eOLsNHhw8fzqJFi5g3bx7r16/n/PnzdO/e3WVSrN69e5OUlMSyZctYtmwZSUlJ9OvXT1tvt9vp1q0bWVlZrF+/nnnz5rFgwQJGjhyplcnIyKBjx46Eh4ezefNmpk+fzptvvsm0adOuK1ji9qLX65k9ezZ33HEHrVq1YseOHaxatYq6deu6u2ouBg0axPvvv+/uatwwmzZtomPHjsTExPDhhx/y7rvv/uPZfoUQpYz6B1JSUhSg1q5dq5RSyuFwqNDQUDV58mStTG5urjKbzerDDz9USimVlpamjEajmjdvnlbmxIkTSq/Xq2XLlimllNq9e7cC1IYNG7QyiYmJClB79+5VSim1dOlSpdfr1YkTJ7QyX331lTKZTCo9PV0ppdQHH3ygzGazys3N1cpMmjRJhYeHK4fDUaxzTE9PV4C2z4JycnLU7t27VU5OTrH2lc9ut6vU1FRlt9uvabvSRGIgMVCqZGNwve9Hd7Nareq7775TVqv1ph974tLdqurzP6qqz/94049dkDtjcKsorTG40ndoQf9oNE3+01jzn5dx6NAhkpOTiY+P18qYTCbatm1LQkICTz/9NFu3bsVms7mUCQ8PJzo6moSEBDp16kRiYiJms9llXokWLVpgNptJSEggKiqKxMREoqOjtVktATp16oTFYmHr1q20b9+exMRE2rZt6zJnRKdOnRgzZgyHDx8uspOixWLBYrFor/OHXtpsNmw2m0tZm82GUgqHw3HVuRgKUhduE+VvWxZJDCQGULIxcDgcKKWw2WyF5nS5leV/rlz6+XIzOOwXY+6O4196bHfWwd1KawyKez7XnYwopRgxYgStW7cmOjoagOTkZABtjoh8ISEhHDlyRCvj6elJYGBgoTL52ycnJxeaNhyczzkpWObS4wQGBuLp6elSplq1aoWOk7+uqGRk0qRJLtNo51uxYkWhSao8PDwIDQ3l/PnzhfqqFMeNnvn0diAxkBhAycTAarWSk5PDunXrtGfj3E6u9gygG+HgET35d+sLPirBXdwRg1tNaYtBdnZ2scpddzIyZMgQ/vjjD9avX19oXVEzLl5tXoFLyxRVviTKqKtMTT5mzBiXuSsyMjKIiIggPj6+yNE0x44dw8/P75p67yulyMzMxN/fv8zOtyAxkBhAycYgNzcXb29v2rRpc9uNplm5ciUdO3a86aModi7fz+q/DwPQtWvXm3rsgtwZg1tFaY1BcSd2vK5kZOjQoSxevJh169ZRuXJlbXloaCjgbHUoOK9ESkqK1iIRGhqK1WolNTXVpXUkJSWFli1bamVOnTpV6LinT5922c+lU1unpqZis9lcyuS3khQ8DhRuvclnMpkKTQUOzimvL71A7HY7Op0OvV5/TcMS85uj87ctiyQGEgMo2Rjo9Xp0Ol2R79XbgTvqrTdcjPmtELPb9W9XkkpbDIp7Ltf07ldKMWTIEBYuXMjPP/9c6DZHZGQkoaGhLs1MVquVtWvXaolGkyZNMBqNLmVOnjzJzp07tTJxcXGkp6e7TCO9ceNG0tPTXcrs3LmTkydPamVWrFiByWTSHoYWFxfHunXrXG6hrFixgvDw8EK3b4QQQgjhHteUjDzzzDPMmTOHL7/8En9/f5KTk0lOTiYnJwdw/u9m+PDhTJw4kUWLFrFz50769++Pj4+PNreD2WxmwIABjBw5ktWrV7N9+3b69u1LTEwMd999NwB169alc+fODBw4kA0bNrBhwwYGDhxI9+7diYqKAiA+Pp569erRr18/tm/fzurVqxk1ahQDBw7Ubqf07t0bk8lE//792blzJ4sWLWLixImMGDGizDaLCyGEELeaa0pGZsyYQXp6Ou3atSMsLEz7+frrr7Uyo0ePZvjw4QwePJimTZty4sQJVqxY4fJE2Lfeeov77ruPhx56iFatWuHj48MPP/zg0gN+7ty5xMTEEB8fT3x8PLGxsXzxxRfaeoPBwJIlS/Dy8qJVq1Y89NBD3Hfffbz55ptaGbPZzMqVKzl+/DhNmzZl8ODBjBgx4orPMxE3Xrt27XjuuefcXY0yp3///i5T7bdr147hw4dfcZtq1arx9ttv/+Njl9R+RMnSIf8pE7eGa+ozoooxc6lOp2P8+PGMHz/+smW8vLyYPn0606dPv2yZ8uXLM2fOnCseq0qVKvz4449XLBMTE8O6deuuWKas6d+/P2lpaXz33Xfasm+//Za+ffvy6quvMnr0aMaPH893331X6EF5lzN79mztqbV6vZ6AgABq165Nt27dePbZZ7WH7wEsXLgQg8EgM+EW09ChQ1m2bBkHDhwotO7EiRNUqVKFb775hp49e17TfhcuXFji96Znz57N8OHDC82WvHnzZnx9fUv0WEKI0qNs9poTLj755BP69OnDe++9x+jRo697PwEBAZw8eZLjx4+TkJDAU089xeeff07Dhg35+++/tXLly5d3aSm7EUrTWP0BAwbw559/8uuvvxZaN3v2bCpUqECPHj2ueb834++Qr2LFioWGxgshRD5JRsq4KVOmMGTIEL788st/PEW3TqcjNDSUsLAw6taty4ABA0hISOD8+fMuSU7B2zQvvvgiLVq0KLSv2NhYxo0bp72eNWsWdevWxcvLizp16vDBBx9o6w4fPoxOp2P+/Pm0a9cOLy8v5syZQ15eHsOGDaNcuXJUqFCB559/nscee8zlVoVSiilTplC9enW8vb1p0KAB3377rbZ+zZo16HQ6Vq9eTdOmTfHx8aFly5aFnsm0ePFimjZtipeXF0FBQS6tFFarldGjR1OpUiV8fX1p3rw5a9asKXZcGzZsSOPGjfnf//5XaN3s2bN59NFH0ev1DBgwgMjISLy9vYmKiuKdd9654n4vvU2TkpJCjx498Pb2JjIykrlz5xbaZtq0acTExODr60tERASDBw/m/PnzWqwef/xx0tPT0el0WispFL5Nc/ToUe69914CAgKoUqUKDz/8sMsIuvHjx9OwYUO++OILqlWrhtlsplevXjInSwlTSOukuDVIMlKSlAJrVvF+bNnFL1ucn+u45fHCCy/w2muv8eOPP/LAAw/cgIA4J6rr06cPixcvdnn2UL7evXuzceNG/vrrL23Zrl272LFjB3369AFg5syZjB07lgkTJrBnzx4mTpzISy+9xGeffeayr+eff55hw4axZ88eOnXqxBtvvMHcuXOZNWsWv/32GxkZGS63pgD+85//MGvWLGbMmMGuXbt47rnn6Nu3L2vXrnUpN3bsWKZOncqWLVvw8PDgiSee0NYtWbKEnj170q1bN60zddOmTbX1jz/+OL/99hvz5s3jjz/+4MEHH6Rz585F3na5nAEDBvDNN99oX/zgfFbUn3/+yRNPPIHD4aBy5crMnz+f3bt38/LLL/Piiy8yf/78Yh+jf//+HD58mJ9//plvv/2WDz74QBsKn0+v1/Puu++yc+dOPvvsM37++Wct0WzZsiVvv/221kJ28uRJRo0aVeg4Sinuu+8+zp07xy+//MLChQs5ePAgDz/8sEu5v/76i++++44ff/yRH3/8kbVr1zJ58uRin48Q4vbxj6aDF5ewZcPE8KsW0wPlSvrYL/4NnsW/J//TTz/x/fffs3r1au66666Sro2LOnXqkJmZydmzZwvNrBsdHU1sbCxffvklL730EuDsvHzHHXdQu3ZtAF577TWmTp2qtTZERkaye/duPvroI5envw4fPtylRWL69OmMGTOG+++/H4D33nvPZZbJrKwspk2bxs8//0xcXBwA1atXZ/369Xz00Ue0bdtWKzthwgTt9QsvvEC3bt3Izc3Fy8uLCRMm0KtXL5eZexs0aAA4v1C/+uorjh8/rj26YNSoUSxbtozZs2fz/PPPFyuGvXv3ZuTIkXzzzTda35z//e9/xMXFUa9ePQCX40dGRpKQkMD8+fN56KGHrrr//fv389NPP7FhwwbtMQyffvppoYcKFmxJiYyM5LXXXuPf//43H3zwAZ6enpjNZq2F7HJWrVrFH3/8waFDh6hUqRIZGRl89tlnxMTEsHnzZu644w7AOQfJ7NmztVtJ/fr1Y/Xq1UyYMKEYERPFIR1Yxa1CWkbKqNjYWKpVq8bLL798w5u+rzbrbZ8+fbRbAkopvvrqK61V5PTp0xw7dowBAwbg5+en/bz++usurSmAS2tEeno6p06dolmzZtoyg8GgzUEDsHv3bnJzc+nYsaPLvj///PNC+46NjdV+z5/QL7/VICkpiQ4dOhR5btu2bUMpRe3atV2OsXbt2kLHuJJy5crRs2dP7VZNZmYmCxYscGmh+fDDD2natCkVK1bEz8+PmTNncvTo0WLtf8+ePXh4eLjEsE6dOpQrV86l3C+//ELHjh2pVKkS/v7+PProo5w9e9blyd3FOVZERAQRERHasnr16lGuXDn27NmjLatWrZpLn5awsLBCLTVCiNJBWkZKktHH2UJxFQ6Hg4zMTAL8/Utu5k3jtXUOrFSpEgsWLKB9+/Z07tyZZcuW3bDOjHv27CEgIIAKFSoUub5379688MILbNu2jZycHI4dO0avXr2AizN0zpw50+XBiUChh6EVNVrjco8DKLjvJUuWUKlSJZdyl87CW3DUSf4+87f39vYu8rzyyxgMBrZu3VqovtfaoXPAgAF06NCBAwcOaLeR8m9tzJ8/n+eee46pU6cSFxeHv78///3vfwvNUnw5V0sYAY4cOULXrl0ZNGgQr732GuXLl2f9+vUMGDDgmjoMX+7xEJcuv3Skj06nK7MPFBSitJNkpCTpdMW7VeJwgNHuLOvGacCrVKnC2rVrad++PfHx8SxfvrzQ83f+qZSUFL788kvuu+++yyZelStXpk2bNsydO5ecnBzuvvtubbr+kJAQKlWqxMGDB7XWkuIwm82EhISwadMm7rzzTsA5ff/27dtp2LAh4PzfuMlk4ujRoy63ZK5VbGwsq1ev1m6fFNSoUSPsdjspKSlaPfI5HI5iP7cBoH379lSvXp3Zs2fzyy+/8NBDD2kJ5K+//krLli0ZPHiwVv5aWl7q1q1LXl4eW7Zs0VqT9u3b5zJEd8uWLeTl5TF16lTtb3lpnxRPT88i+wYVVK9ePY4ePcqxY8e0JHD37t2kp6cXui0khCgbJBkp4ypXrsyaNWtcEpL8OUFycnIKzTPi5+dHzZo1i9yXUork5GSUUqSlpZGYmMjEiRMxm81X7XjYp08fxo8fj9Vq5a233nJZN378eIYNG0ZAQABdunTBYrGwZcsWUlNTrziB3dChQ5k0aRI1a9akTp06TJ8+ndTUVO1/3/7+/owaNYrnnnsOh8NB69atycjIICEhAT8/P5f+KFcybtw4OnToQI0aNejVqxd5eXn89NNPjB49mtq1a9OnTx8effRRpk6dSqNGjThz5gw///wz9evXp3Xr1sU6BjhbBh5//HGmTZtGamoq//3vf7V1NWvW5PPPP2f58uVERkbyxRdfsHnz5iKfTF2UqKgobdbjjz/+GA8PD4YPH+7S6lOjRg3y8vKYPn06PXr04LfffuPDDz902U+1atU4f/48q1evpkGDBvj4+BRqAbr77ruJjY2lT58+TJs2jfT0dJ5//nnatm3rcptICFF2SJ8RQaVKlVi7di1paWl07NhR+9/w/v37adSokcvPlYb/ZmRkEBYWRqVKlYiLi9M6mG7fvt3lwYlFefDBBzl79izZ2dkuQ28BnnzyST755BNmz55NTEwMbdu2Zfbs2Vf9on3++ed55JFHePTRR4mLi8PPz49OnTq5PNH1tdde4+WXX2bSpEnUrVuXTp068cMPPxT7SxycQ2S/+eYbFi9eTMOGDbnrrrtcbo/MmjWLRx99lJEjRxIVFcU999zDxo0bXfpM6HQ6Zs+efdVj9e/fn/T0dKKiomjVqpW2fNCgQfTs2ZOHH36Y5s2bc/bsWZdWkuKYNWsWERERtG3blp49e/LUU0+5dDhu2LAh06ZN44033iA6Opq5c+cyadIkl320bNmSQYMG8fDDD1OxYkWmTJlS6Dg6nY7vvvuOwMBA2rVrx/33309kZKTLTM7i5pCnYohbhU7JNJhXlJGRgdlsJj09vdAtjNzcXA4dOkRkZOQ1PbI8v3k+ICCgTD+t9WbHwOFwULduXR566CFee+21m3LMq9UnIyODc+fOERUVxe7du6lVq5a7q3VTleR1cL3vR3ez2WwsXbqUrl273vSntb6xbC8z1jhv5x2e3O2mHrsgd8bgVlFaY3Cl79CC5DaNKLWOHDnCihUraNu2LRaLhffee49Dhw5pD228VSxbtoynnnqqzCUiQgiRT5IRUWrp9Xpmz57NqFGjUEoRHR3NqlWrbrlOkoMGDSqzLWTCvaRdXNwqJBkRpVZERAS//fabu6shhBDiKuS/Y0IIUUZJB1Zxq5BkRAghhBBuJclICZABSUK4n7wPhbh9STLyD+QPv8rOznZzTYQQ+e/D0jQsUoiyQjqw/gMGg4Fy5cppD+/y8fG54rM98jkcDqxWK7m5uWV2FIXEQGIAJRMDpRTZ2dmkpKRQrly5Qs8AEkLc+iQZ+YfyH5V+LU8TVUqRk5ODt7d3sZKX0khiIDGAko1BuXLltPejKJ6yedWJW5EkI/+QTqcjLCyM4ODgYj+51GazsW7dOtq0aVNmm5QlBhIDKLkYGI1GaRER4jYmyUgJMRgMxf4wNBgM5OXl4eXlVWa/hCQGEgOQGAghnMrmjWohhBDI+CNxq5BkRAghhBBuJcmIEEKUUdKBVdwqJBkRQgghhFtdczKybt06evToQXh4ODqdju+++85lff/+/dHpdC4/LVq0cCljsVgYOnQoQUFB+Pr6cs8993D8+HGXMqmpqfTr1w+z2YzZbKZfv36kpaW5lDl69Cg9evTA19eXoKAghg0bhtVqdSmzY8cO2rZti7e3N5UqVeLVV1+VmRqFEEKIW8g1JyNZWVk0aNCA995777JlOnfuzMmTJ7WfpUuXuqwfPnw4ixYtYt68eaxfv57z58/TvXt37Ha7VqZ3794kJSWxbNkyli1bRlJSEv369dPW2+12unXrRlZWFuvXr2fevHksWLCAkSNHamUyMjLo2LEj4eHhbN68menTp/Pmm28ybdq0az1tIYQQQtwg1zy0t0uXLnTp0uWKZUwm02UnH0pPT+fTTz/liy++4O677wZgzpw5REREsGrVKjp16sSePXtYtmwZGzZsoHnz5gDMnDmTuLg49u3bR1RUFCtWrGD37t0cO3aM8PBwAKZOnUr//v2ZMGECAQEBzJ07l9zcXGbPno3JZCI6Opr9+/czbdo0RowYUWYnmhJCCCFuJTdknpE1a9YQHBxMuXLlaNu2LRMmTCA4OBiArVu3YrPZiI+P18qHh4cTHR1NQkICnTp1IjExEbPZrCUiAC1atMBsNpOQkEBUVBSJiYlER0driQhAp06dsFgsbN26lfbt25OYmEjbtm0xmUwuZcaMGcPhw4eJjIwsVHeLxYLFYtFeZ2RkAM7JmYo7qdnV5O+npPZ3O5IYSAxAYgDujYFyOArVwx3kOii9MSju+ZR4MtKlSxcefPBBqlatyqFDh3jppZe466672Lp1KyaTieTkZDw9PQkMDHTZLiQkhOTkZACSk5O15KWg4OBglzIhISEu6wMDA/H09HQpU61atULHyV9XVDIyadIkXnnllULLV6xYgY+PTzGjUDwrV64s0f3djiQGEgOQGIB7YvDnUT35d+svvZ3uDnIdlL4YFPdBsiWejDz88MPa79HR0TRt2pSqVauyZMkSevbsedntlFIut02KuoVSEmXyO69e7hbNmDFjGDFihPY6IyODiIgI4uPjCQgIuGz9r4XNZmPlypV07NixzM46KTGQGIDEANwbgz0rD7DyxCEAunbtelOPXZBcB6U3Bvl3F67mhk8HHxYWRtWqVTlw4ADgfLCc1WolNTXVpXUkJSWFli1bamVOnTpVaF+nT5/WWjZCQ0PZuHGjy/rU1FRsNptLmfxWkoLHAQq1quQzmUwut3XyGY3GEr9AbsQ+bzcSA4kBSAzAPTEo+KTkWyH+ch2UvhgU91xu+DwjZ8+e5dixY4SFhQHQpEkTjEajS1PUyZMn2blzp5aMxMXFkZ6ezqZNm7QyGzduJD093aXMzp07OXnypFZmxYoVmEwmmjRpopVZt26dy3DfFStWEB4eXuj2jRBCCCHc45qTkfPnz5OUlERSUhIAhw4dIikpiaNHj3L+/HlGjRpFYmIihw8fZs2aNfTo0YOgoCDuv/9+AMxmMwMGDGDkyJGsXr2a7du307dvX2JiYrTRNXXr1qVz584MHDiQDRs2sGHDBgYOHEj37t2JiooCID4+nnr16tGvXz+2b9/O6tWrGTVqFAMHDtRup/Tu3RuTyUT//v3ZuXMnixYtYuLEiTKSRgghAPkYFLeKa75Ns2XLFtq3b6+9zu9f8dhjjzFjxgx27NjB559/TlpaGmFhYbRv356vv/4af39/bZu33noLDw8PHnroIXJycujQoQOzZ892eert3LlzGTZsmDbq5p577nGZ28RgMLBkyRIGDx5Mq1at8Pb2pnfv3rz55ptaGbPZzMqVK3nmmWdo2rQpgYGBjBgxwqVPiBBCCCHc65qTkXbt2l1xBtPly5dfdR9eXl5Mnz6d6dOnX7ZM+fLlmTNnzhX3U6VKFX788ccrlomJiWHdunVXrZMQQggh3EOeTSOEEEIIt5JkRAghhBBuJcmIEEKUUTqkB6u4NUgyIoQQQgi3kmRECCHKKMXlByMIcTNJMiKEEEIIt5JkRAghhBBuJcmIEEKUUdKBVdwqJBkRQgghhFtJMiKEEEIIt5JkRAghhBBuJcmIEEIIIdxKkhEhhCijdNJ/VdwiJBkRQgghhFtJMiKEEGWUkglYxS1CkhEhhBBCuJUkI0IIIYRwK0lGhBCijJIOrOJWIcmIEEIIIdxKkhEhhBBCuJUkI0IIIYRwK0lGhBBCCOFWkowIIUQZJf1Xxa1CkhEhhCijZM4zcauQZEQIIYQQbnXNyci6devo0aMH4eHh6HQ6vvvuO5f1SinGjx9PeHg43t7etGvXjl27drmUsVgsDB06lKCgIHx9fbnnnns4fvy4S5nU1FT69euH2WzGbDbTr18/0tLSXMocPXqUHj164OvrS1BQEMOGDcNqtbqU2bFjB23btsXb25tKlSrx6quvomQOZCGEEOKWcc3JSFZWFg0aNOC9994rcv2UKVOYNm0a7733Hps3byY0NJSOHTuSmZmplRk+fDiLFi1i3rx5rF+/nvPnz9O9e3fsdrtWpnfv3iQlJbFs2TKWLVtGUlIS/fr109bb7Xa6detGVlYW69evZ968eSxYsICRI0dqZTIyMujYsSPh4eFs3ryZ6dOn8+abbzJt2rRrPW0hhBBC3CAe17pBly5d6NKlS5HrlFK8/fbbjB07lp49ewLw2WefERISwpdffsnTTz9Neno6n376KV988QV33303AHPmzCEiIoJVq1bRqVMn9uzZw7Jly9iwYQPNmzcHYObMmcTFxbFv3z6ioqJYsWIFu3fv5tixY4SHhwMwdepU+vfvz4QJEwgICGDu3Lnk5uYye/ZsTCYT0dHR7N+/n2nTpjFixAh0Mv2gEKIMk09Acau45mTkSg4dOkRycjLx8fHaMpPJRNu2bUlISODpp59m69at2Gw2lzLh4eFER0eTkJBAp06dSExMxGw2a4kIQIsWLTCbzSQkJBAVFUViYiLR0dFaIgLQqVMnLBYLW7dupX379iQmJtK2bVtMJpNLmTFjxnD48GEiIyMLnYPFYsFisWivMzIyALDZbNhsthKJU/5+Smp/tyOJgcQAJAbg3hjYHY5C9XAHuQ5KbwyKez4lmowkJycDEBIS4rI8JCSEI0eOaGU8PT0JDAwsVCZ/++TkZIKDgwvtPzg42KXMpccJDAzE09PTpUy1atUKHSd/XVHJyKRJk3jllVcKLV+xYgU+Pj5Fn/h1WrlyZYnu73YkMZAYgMQA3BODP4/qyb9bv3Tp0pt+/EvJdVD6YpCdnV2sciWajOS79PaHUuqqt0QuLVNU+ZIok9959XL1GTNmDCNGjNBeZ2RkEBERQXx8PAEBAVc8h+Ky2WysXLmSjh07YjQaS2SftxuJgcQAJAbg3hjsX/0ny08cBKBr16439dgFyXVQemOQf3fhako0GQkNDQWcrQ5hYWHa8pSUFK1FIjQ0FKvVSmpqqkvrSEpKCi1bttTKnDp1qtD+T58+7bKfjRs3uqxPTU3FZrO5lMlvJSl4HCjcepPPZDK53NbJZzQaS/wCuRH7vN1IDCQGIDEA98TAoL84huFWiL9cB6UvBsU9lxKdZyQyMpLQ0FCXZiar1cratWu1RKNJkyYYjUaXMidPnmTnzp1ambi4ONLT09m0aZNWZuPGjaSnp7uU2blzJydPntTKrFixApPJRJMmTbQy69atcxnuu2LFCsLDwwvdvhFCiDJHOvGLW8Q1JyPnz58nKSmJpKQkwNlpNSkpiaNHj6LT6Rg+fDgTJ05k0aJF7Ny5k/79++Pj40Pv3r0BMJvNDBgwgJEjR7J69Wq2b99O3759iYmJ0UbX1K1bl86dOzNw4EA2bNjAhg0bGDhwIN27dycqKgqA+Ph46tWrR79+/di+fTurV69m1KhRDBw4ULud0rt3b0wmE/3792fnzp0sWrSIiRMnykgaIYQAkDmXxC3imm/TbNmyhfbt22uv8/tXPPbYY8yePZvRo0eTk5PD4MGDSU1NpXnz5qxYsQJ/f39tm7feegsPDw8eeughcnJy6NChA7Nnz8ZgMGhl5s6dy7Bhw7RRN/fcc4/L3CYGg4ElS5YwePBgWrVqhbe3N7179+bNN9/UypjNZlauXMkzzzxD06ZNCQwMZMSIES59QoQQQgjhXtecjLRr1+6KM5jqdDrGjx/P+PHjL1vGy8uL6dOnM3369MuWKV++PHPmzLliXapUqcKPP/54xTIxMTGsW7fuimWEEEII4T7ybBohhBBCuJUkI0IIUVZJ3zlxi5BkRAghhBBuJcmIEEIIIdxKkhEhhBBCuJUkI0IIIYRwK0lGhBCijJLuq+JWIcmIEEKUUTL/qrhVSDIihBBCCLeSZEQIIYQQbiXJiBBCCCHcSpIRIYQoo6QDq7hVSDIihBBCCLeSZEQIIYQQbiXJiBBCCCHcSpIRIYQQQriVJCNCCCGEcCtJRoQQQgjhVpKMCCGEEMKtJBkRQgghhFtJMiKEEEIIt5JkRAghyiidTMEqbhGSjAghhBDCrSQZEUIIIYRbSTIihBBCCLcq8WRk/Pjx6HQ6l5/Q0FBtvVKK8ePHEx4ejre3N+3atWPXrl0u+7BYLAwdOpSgoCB8fX255557OH78uEuZ1NRU+vXrh9lsxmw2069fP9LS0lzKHD16lB49euDr60tQUBDDhg3DarWW9CkLIYQQ4h+4IS0j9evX5+TJk9rPjh07tHVTpkxh2rRpvPfee2zevJnQ0FA6duxIZmamVmb48OEsWrSIefPmsX79es6fP0/37t2x2+1amd69e5OUlMSyZctYtmwZSUlJ9OvXT1tvt9vp1q0bWVlZrF+/nnnz5rFgwQJGjhx5I05ZCCGEENfJ44bs1MPDpTUkn1KKt99+m7Fjx9KzZ08APvvsM0JCQvjyyy95+umnSU9P59NPP+WLL77g7rvvBmDOnDlERESwatUqOnXqxJ49e1i2bBkbNmygefPmAMycOZO4uDj27dtHVFQUK1asYPfu3Rw7dozw8HAApk6dSv/+/ZkwYQIBAQE34tSFEEIIcY1uSDJy4MABwsPDMZlMNG/enIkTJ1K9enUOHTpEcnIy8fHxWlmTyUTbtm1JSEjg6aefZuvWrdhsNpcy4eHhREdHk5CQQKdOnUhMTMRsNmuJCECLFi0wm80kJCQQFRVFYmIi0dHRWiIC0KlTJywWC1u3bqV9+/ZF1t1isWCxWLTXGRkZANhsNmw2W4nEJ38/JbW/25HEQGIAEgNwbwwcdkeheriDXAelNwbFPZ8ST0aaN2/O559/Tu3atTl16hSvv/46LVu2ZNeuXSQnJwMQEhLisk1ISAhHjhwBIDk5GU9PTwIDAwuVyd8+OTmZ4ODgQscODg52KXPpcQIDA/H09NTKFGXSpEm88sorhZavWLECHx+fq53+NVm5cmWJ7u92JDGQGIDEANwTg/3HdIABgKVLl970419KroPSF4Ps7OxilSvxZKRLly7a7zExMcTFxVGjRg0+++wzWrRoAYDukpl2lFKFll3q0jJFlb+eMpcaM2YMI0aM0F5nZGQQERFBfHx8id3asdlsrFy5ko4dO2I0Gktkn7cbiYHEACQG4N4Y/PXzXyw7/hcAXbt2vanHLkiug9Ibg/y7C1dzQ27TFOTr60tMTAwHDhzgvvvuA5ytFmFhYVqZlJQUrRUjNDQUq9VKamqqS+tISkoKLVu21MqcOnWq0LFOnz7tsp+NGze6rE9NTcVmsxVqMSnIZDJhMpkKLTcajSV+gdyIfd5uJAYSA5AYgHtiYDAYXI7vbnIdlL4YFPdcbvg8IxaLhT179hAWFkZkZCShoaEuzVBWq5W1a9dqiUaTJk0wGo0uZU6ePMnOnTu1MnFxcaSnp7Np0yatzMaNG0lPT3cps3PnTk6ePKmVWbFiBSaTiSZNmtzQcxZCCCFE8ZV4y8ioUaPo0aMHVapUISUlhddff52MjAwee+wxdDodw4cPZ+LEidSqVYtatWoxceJEfHx86N27NwBms5kBAwYwcuRIKlSoQPny5Rk1ahQxMTHa6Jq6devSuXNnBg4cyEcffQTAU089Rffu3YmKigIgPj6eevXq0a9fP/773/9y7tw5Ro0axcCBA2UkjRBCCHELKfFk5Pjx4zzyyCOcOXOGihUr0qJFCzZs2EDVqlUBGD16NDk5OQwePJjU1FSaN2/OihUr8Pf31/bx1ltv4eHhwUMPPUROTg4dOnRg9uzZLk2Kc+fOZdiwYdqom3vuuYf33ntPW28wGFiyZAmDBw+mVatWeHt707t3b958882SPmUhhBBC/AMlnozMmzfviut1Oh3jx49n/Pjxly3j5eXF9OnTmT59+mXLlC9fnjlz5lzxWFWqVOHHH3+8YhkhhBBCuJc8m0YIIYQQbiXJiBBCCCHcSpIRIYQQQriVJCNCCCGEcCtJRoQQQgjhVpKMCCFEGXWVp3AIcdNIMiKEEEIIt5JkRAghhBBuJcmIEEIIIdxKkhEhhBBCuJUkI0IIIYRwK0lGhBBCCOFWkowIIYQQwq0kGRFCCCGEW0kyIoQQQgi3kmRECCHKKJmAVdwqJBkRQgghhFtJMiKEEEIIt5JkRAghhBBuJcmIEEIIIdxKkhEhhBBCuJUkI0IIIYRwK0lGhBBCCOFWkowIIYQQwq0kGRFCCCGEW5WJZOSDDz4gMjISLy8vmjRpwq+//uruKgkhhNvpZApWcYso9cnI119/zfDhwxk7dizbt2/nzjvvpEuXLhw9etTdVdMopcix2t1dDSGEEMItSn0yMm3aNAYMGMCTTz5J3bp1efvtt4mIiGDGjBnurprm++/nc/r1KOb/5x7+NWYqiVu3Yc04gyU3mzy7A7tDYbM7tPJKKZRSOBzKZdn1sDuub7tbieM2O4f8v9W1/s2u929cUvu35NmLLKOUwu5Ql90+f7nd4Vru0vJXOv7V6pb/nrhabHNtdpdyBbe9lv1frf6X1iP/3zy7A0ueHcclcci1gyXPUeh9nWXJIzPXRl6B9/+Vzjf/X4fj4n6KisnFZRf3WbB8fv1sdgfWPIfL8kvrcennUP5nSlHXhP1CvewORXqOTftdKYVDudY//2+Vf91Z8uzk2i7+p83huPLf0WZ3kGd3kGuzF1n20pgUrGP+Nvn1LVi+4O+OAudjdxSORcFrv+C1Z7M7tO0AUrOsF2J3MW55dofLPvK3yV+X/52QvzzXZtd+z7tw7kopl/PP3/bSv1X+uvOWvELxuFl06kZ/wrmR1WrFx8eHb775hvvvv19b/uyzz5KUlMTatWsLbWOxWLBYLNrrjIwMIiIiOHPmDAEBASVSr03/G0n22b8J8DHi4bDSJGPVZcvalAEDDvLQowNy8cT5B3O2ryrAgR4FKHQ40MGFf1WBf3Uo7V/Qo9eBvcCfXkfhy8CBHsOFPaDTg4K8Ih6t5aHXOd9AgAGHdsx8Bp0Ou1LocaAK1Cf/uAodNuXhPJZOYdQ5sCoP9Ni1/ehQGHUKh1LY0WPUKfIuVNnjwjHR6Z0fEJccQ6HDU+fArrhw9s595O9Xx8Xl+fVxoEOv04FyYL+wRn8h0nk4/yaKiw8a02lnBnkXyucf26C7GF+HuvjXc1woY8CBHlAXjl1QHgbtuAYufiHpcWDHUOhvkf9XdFw4P+e2jgv1za/lxRrrdGjfSPnnfem1ULBOBWPqgb3AMXVafZ3LlXZMHQo7Bi22BfdYsEaudbh4beTH2bXmrvXRocjBhAd2jORpddEViKkOhQd27BjIQ6/9vfP//h7YL0S6cAzy/1ZWjHhi0645Bzr0OK9tB3rtWilYr4vRQStX0KXHKvz6UoXfq5eWudZ9Flx/6e/6Io536RLX61Z3yTrX41gxulxH+es9yUOvRbpoVjy0I+RfqzrAfuGzKv9z0Igd+4W/R1HX2MVrS4eRPO0zNP/vn/+39cCB4cK+8vfpQHfhPaswXHgP2PDAAwe2C9ecAceFY7vGQRW4Xi59XxV93kp7n3uQh7pwTvl1KHhedvQu13D++96BDjsGPC58ejs/Uy58jpKnvWd1F5alm0LxfW4bnh4l01aRkZFBUFAQ6enpV/wO9SiRo92izpw5g91uJyQkxGV5SEgIycnJRW4zadIkXnnllULLV6xYgY+PT4nUq/3f3xCgywar6/JsZeIc/gSRjpfOBoBR57zYPS9c9EZySqQOwLU/svNy5dUV1hX3WIU/Ha9erqgyVzrO9dwfL+l76rfiPfpbsU7XwUy2u6sgisHE9f/v28iteTs7//PZhO0G7L1gvK73/C/u49IYFnztgQNLroVVS5bha7zOQ10iO7t478tSnYzk013SS0spVWhZvjFjxjBixAjtdX7LSHx8fMm1jJzqRVrqWQIqhICnL5nGIGq0uIfqlcMIcij2nMzE7AU+5HL45GlOZdoI9NZTwccTvbKSmmXjZFoWVcr7EODlgc3uYPPBs+h1ULmcJza7Az9PPQ6HwpbnvAj1OmfOkJZto06oHx4GHTY77Dt1nlB/E8dSczhvsWMy6qla3puz53MJN5vQG4ycPm/F11OPn8nA4dOZGAweeOhhf8p57A7oXD+EPLuDs+etnMvJo1ZFb1CKVXtO0yk6FB2Kg6ezSMnKw8/T2SqTbc0j+8wJGtSLYuuRNOpUNJGdp8PHZKSi2Qed3Uq2XYe3h54Ve05zV1QQ/t5enM22YLfZCPD1Jj0rF5tdoTMYSc/OJTLIBz1w6Mx59EBFP0/+PJNDXl4eDatVxGa3czbTwtHUHCr4Gjl6Lpv2UcHkWB1sP3aOigHe+JqMmAw6vD10VPAzcjbbjrcHmAx6/jyTTUR5H46fy6KirwceHkY2Hk6lcqA3Ff29yLDY8TYa8DUqcqwOjAY9ASYDnh469Ho9Op2e9FwbiQdT8TcZ8PaA3X8dpXHdmlQq78upjFwOncmiXlgAPp4enD2fC8qOn5eJM1k2ggK82Hb4HOGBvviYPFD2PGwOqBLozb7kTLw9DQT5ebL3VCaBXgb8vYwcPJtD3bBynMnOIyTAE4MO8vIUej3odYqKvp4cOpdzoRnXwcHT2YQEmFA6Hedz8wgN8MRqV9QL9cdogF8PnMXb5EFenp1Afx/OZVlJzbYR7OtBpsVOq0gzJzKsnMuxE+BlZOkff+Pn402zKn7o9AaS03OIDPLF02BAp9eRZbGxddcBusTFcua8FR+jjhOpOaCDzFw7YWYT3p4eZObkYVeKLEseuXkQXSkAo4eOzBw7DiD5XAYoO+lWHXXDy2O355FjteFl9MDDoMPLaODIuRzOZOZi8vCgdkUTxzOsOJQei83OuSwrbaJCOHbuPHqdDk8PA6EBJuf/ZpXCZNDhUIqsrGy8fbyxKgNHzpznXGYONgeYfb3IstgID/AkyNdI0vEMWtesgKeHniyLnS1H0ijnY8Sg1+PrqaeCnxdnzlsx6HVk5do4eOggsXVrY1fO6y7PwYVrwEJ6bh5BfiaC/U0cT83BoNeh1+vIzLUT7G9Cp3PeQsu2KoweOkL9vUjNsZKWk4evpwcpmbmYvZzHtilFrtVOgLeRAylZ+JoMBPoYqVLeh9w8B+V9PDlvsWPQ6zmWmk2tEH8yc/MI9HV+Rpw5b6FyOW+8jHqOns3m4NlsagT5UKW8D/5eBnKsdpQCvU7HibRscm0OKvp7YjToqehvIsdi40zGecr7epOabSXI10hqtpXULAt79h2gYtUo6lUKJCXTQkR5H85mWTAZ9FjsDo6eySLE1xm/tGwrdUL9ybDYOZ+bh6+nHn9vE+ctVo6fy6JKUDl2/Z1GkLcHmVYbdUPLgQ7O51op7+NJltWOJc/O0XPZRFTwJzTARHJGDgEmA8fPZWHQQbbFRq0Qf7LydPibDGRYFAad4nRGLsEBXpT39+ZEutXZTqHsWOyQa7FSwc8LD4MHZ87noDcY8DcZOJmWg7enAS8PPYE+nuTmOUjJyMVqV4SafUjLtqLX69i7eyexsTEo9JTzNvLHiXSaVzVz3mLjfJ6esAATRp2Dc5k5HE+3YvI0cj7Xiq/JA0+dwtfXh1NpWaRnWwj0NVEjpBwmD9hzPBVPkxfJGbmY9A7OZtuoZDZRzscLT4MiDyO5eXZOpmUTV6MiD1apXiLfdeD8Di0OuU1zFRkZGZjN5qs2MV0Lm83G0qVL6dq1K0ZjCaWftxmJgcQAJAYgMQCJAZTeGBT3O7RUd2D19PSkSZMmrFy50mX5ypUradmypZtqJYQQQoiCSv1tmhEjRtCvXz+aNm1KXFwcH3/8MUePHmXQoEHurpoQQgghKAPJyMMPP8zZs2d59dVXOXnyJNHR0SxdupSqVau6u2pCCCGEoAwkIwCDBw9m8ODB7q6GEEIIIYpQqvuMCCGEEOLWVyZaRv6J/MFGxR2eVBw2m43s7GwyMjJKVa/payExkBiAxAAkBiAxgNIbg/zvzqsN3JVk5CoyMzMBiIiIcHNNhBBCiNtTZmYmZrP5sutL9TwjJcHhcPD333/j7+9/2YnSrlX+RGrHjh0rsblLbjcSA4kBSAxAYgASAyi9MVBKkZmZSXh4OHr95XuGSMvIVej1eipXrnxD9h0QEFCqLrrrITGQGIDEACQGIDGA0hmDK7WI5JMOrEIIIYRwK0lGhBBCCOFWkoy4gclkYty4cZhMJndXxW0kBhIDkBiAxAAkBiAxkA6sQgghhHAraRkRQgghhFtJMiKEEEIIt5JkRAghhBBuJcmIEEIIIdxKkhE3+OCDD4iMjMTLy4smTZrw66+/urtK12XdunX06NGD8PBwdDod3333nct6pRTjx48nPDwcb29v2rVrx65du1zKWCwWhg4dSlBQEL6+vtxzzz0cP37cpUxqair9+vXDbDZjNpvp168faWlpN/jsrm7SpEnccccd+Pv7ExwczH333ce+fftcypT2GADMmDGD2NhYbbKmuLg4fvrpJ219WYhBQZMmTUKn0zF8+HBtWVmIwfjx49HpdC4/oaGh2vqyEAOAEydO0LdvXypUqICPjw8NGzZk69at2vqyEodrpsRNNW/ePGU0GtXMmTPV7t271bPPPqt8fX3VkSNH3F21a7Z06VI1duxYtWDBAgWoRYsWuayfPHmy8vf3VwsWLFA7duxQDz/8sAoLC1MZGRlamUGDBqlKlSqplStXqm3btqn27durBg0aqLy8PK1M586dVXR0tEpISFAJCQkqOjpade/e/Wad5mV16tRJzZo1S+3cuVMlJSWpbt26qSpVqqjz589rZUp7DJRSavHixWrJkiVq3759at++ferFF19URqNR7dy5UylVNmKQb9OmTapatWoqNjZWPfvss9ryshCDcePGqfr166uTJ09qPykpKdr6shCDc+fOqapVq6r+/furjRs3qkOHDqlVq1apP//8UytTFuJwPSQZucmaNWumBg0a5LKsTp066oUXXnBTjUrGpcmIw+FQoaGhavLkydqy3NxcZTab1YcffqiUUiotLU0ZjUY1b948rcyJEyeUXq9Xy5YtU0optXv3bgWoDRs2aGUSExMVoPbu3XuDz+rapKSkKECtXbtWKVU2Y5AvMDBQffLJJ2UqBpmZmapWrVpq8nKtzwAACaZJREFU5cqVqm3btloyUlZiMG7cONWgQYMi15WVGDz//POqdevWl11fVuJwPeQ2zU1ktVrZunUr8fHxLsvj4+NJSEhwU61ujEOHDpGcnOxyriaTibZt22rnunXrVmw2m0uZ8PBwoqOjtTKJiYmYzWaaN2+ulWnRogVms/mWi1l6ejoA5cuXB8pmDOx2O/PmzSMrK4u4uLgyFYNnnnmGbt26cffdd7ssL0sxOHDgAOHh4URGRtKrVy8OHjwIlJ0YLF68mKZNm/Lggw8SHBxMo0aNmDlzpra+rMThekgychOdOXMGu91OSEiIy/KQkBCSk5PdVKsbI/98rnSuycnJeHp6EhgYeMUywcHBhfYfHBx8S8VMKcWIESNo3bo10dHRQNmKwY4dO/Dz88NkMjFo0CAWLVpEvXr1ykwM5s2bx7Zt25g0aVKhdWUlBs2bN+fzzz9n+fLlzJw5k+TkZFq2bMnZs2fLTAwOHjzIjBkzqFWrFsuXL2fQoEEMGzaMzz//HCg718L1kKf2uoFOp3N5rZQqtKy0uJ5zvbRMUeVvtZgNGTKEP/74g/Xr1xdaVxZiEBUVRVJSEmlpaSxYsIDHHnuMtWvXautLcwyOHTvGs88+y4oVK/Dy8rpsudIcA4AuXbpov8fExBAXF0eNGjX47LPPaNGiBVD6Y+BwOGjatCkTJ04EoFGjRuzatYsZM2bw6KOPauVKexyuh7SM3ERBQUEYDIZCmWtKSkqhTPl2l9+L/krnGhoaitVqJTU19YplTp06VWj/p0+fvmViNnToUBYvXswvv/xC5cqVteVlKQaenp7UrFmTpk2bMmnSJBo0aMA777xTJmKwdetWUlJSaNKkCR4eHnh4eLB27VreffddPDw8tPqV5hgUxdfXl5iYGA4cOFAmrgOAsLAw6tWr57Ksbt26HD16FChbnwnXSpKRm8jT05MmTZqwcuVKl+UrV66kZcuWbqrVjREZGUloaKjLuVqtVtauXauda5MmTTAajS5lTp48yc6dO7UycXFxpKens2nTJq3Mxo0bSU9Pd3vMlFIMGTKEhQsX8vPPPxMZGemyvizE4HKUUlgsljIRgw4dOrBjxw6SkpK0n6ZNm9KnTx+SkpKoXr16qY9BUSwWC3v27CEsLKxMXAcArVq1KjS8f//+/VStWhUo258JV3Uze8uKi0N7P/30U7V79241fPhw5evrqw4fPuzuql2zzMxMtX37drV9+3YFqGnTpqnt27drw5QnT56szGazWrhwodqxY4d65JFHihzCVrlyZbVq1Sq1bds2dddddxU5hC02NlYlJiaqxMREFRMTc0sMYfv3v/+tzGazWrNmjctwxuzsbK1MaY+BUkqNGTNGrVu3Th06dEj98ccf6sUXX1R6vV6tWLFCKVU2YnCpgqNplCobMRg5cqRas2aNOnjwoNqwYYPq3r278vf31z7bykIMNm3apDw8PNSECRPUgQMH1Ny5c5WPj4+aM2eOVqYsxOF6SDLiBu+//76qWrWq8vT0VI0bN9aGgt5ufvnlFwUU+nnssceUUs5hbOPGjVOhoaHKZDKpNm3aqB07drjsIycnRw0ZMkSVL19eeXt7q+7du6ujR4+6lDl79qzq06eP8vf3V/7+/qpPnz4qNTX1Jp3l5RV17oCaNWuWVqa0x0AppZ544gnteq5YsaLq0KGDlogoVTZicKlLk5GyEIP8+TKMRqMKDw9XPXv2VLt27dLWl4UYKKXUDz/8oKKjo5XJZFJ16tRRH3/8scv6shKHa6VTSin3tMkIIYQQQkifESGEEEK4mSQjQgghhHArSUaEEEII4VaSjAghhBDCrSQZEUIIIYRbSTIihBBCCLeSZEQIIYQQbiXJiBBCCCHcSpIRIYTbpKSk8PTTT1OlShVMJhOhoaF06tSJxMREwPlk0u+++869lRRC3HAe7q6AEKLseuCBB7DZbHz22WdUr16dU6dOsXr1as6dO+fuqgkhbiJpGRFCuEVaWhrr16/njTfeoH379lStWpVmzZoxZswYunXrRrVq1QC4//770el02muAH374gSZNmuDl5UX16tV55ZVXyMvL09brdDpmzJhBly5d8Pb2JjIykm+++UZbb7VaGTJkCGFhYXh5eVGtWjUmTZp0s05dCHEJSUaEEG7h5+eHn58f3333HRaLpdD6zZs3AzBr1ixOnjypvV6+fDl9+/Zl2LBh7N69m48++ojZs2czYcIEl+1feuklHnjgAX7//Xf69u3LI488wp49ewB49913Wbx4MfPnz2ffvn3MmTPHJdkRQtxc8qA8IYTbLFiwgIEDB5KTk0Pjxo1p27YtvXr1IjY2FnC2cCxatIj77rtP26ZNmzZ06dKFMWPGaMvmzJnD6NGj+fvvv7XtBg0axIwZM7QyLVq0oHHjxnzwwQcMGzaMXbt2sWrVKnQ63c05WSHEZUnLiBDCbR544AH+/vtvFi9eTKdOnVizZg2NGzdm9uzZl91m69atvPrqq1rLip+fHwMHDuTkyZNkZ2dr5eLi4ly2i4uL01pG+vfvT1JSElFRUQwbNowVK1bckPMTQhSPJCNCCLfy8vKiY8eOvPzyyyQkJNC/f3/GjRt32fIOh4NXXnmFpKQk7WfHjh0cOHAALy+vKx4rvxWkcePGHDp0iNdee42cnBweeugh/vWvf5XoeQkhik+SESHELaVevXpkZWUBYDQasdvtLusbN27Mvn37qFmzZqEfvf7iR9qGDRtcttuwYQN16tTRXgcEBPDwww8zc+ZMvv76axYsWCCjeIRwExnaK4Rwi7Nnz/Lggw/yxBNPEBsbi7+/P1u2bGHKlCnce++9AFSrVo3Vq1fTqlUrTCYTgYGBvPzyy3Tv3p2IiAgefPBB9Ho9f/zxBzt27OD111/X9v/NN9/QtGlTWrduzdy5c9m0aROffvopAG+99RZhYWE0bNgQvV7PN998Q2hoKOXKlXNHKIQQSggh3CA3N1e98MILqnHjxspsNisfHx8VFRWl/vOf/6js7GyllFKLFy9WNWvWVB4eHqpq1aratsuWLVMtW7ZU3t7eKiAgQDVr1kx9/PHH2npAvf/++6pjx47KZDKpqlWrqq+++kpb//HHH6uGDRsqX19fFRAQoDp06KC2bdt2085dCOFKRtMIIUqdokbhCCFuXdJnRAghhBBuJcmIEEIIIdxKOrAKIUodufssxO1FWkaEEEII4VaSjAghhBDCrSQZEUIIIYRbSTIihBBCCLeSZEQIIYQQbiXJiBBCCCHcSpIRIYQQQriVJCNCCCGEcCtJRoQQQgjhVv8P45JDMQNRUewAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x800 with 3 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, axs = plt.subplots(nrows=3, ncols=1, figsize=[6,8])\n",
     "ax = axs.reshape(-1)\n",
@@ -1483,7 +2919,6 @@
    "cell_type": "markdown",
    "id": "e7ea7b78-bb2d-4709-af00-44b3901539ac",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -1537,18 +2972,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 88,
+   "id": "91babadd-f018-4d45-8e88-c336015c7856",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(vae_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
    "id": "89a68d24-8676-4432-9bbb-ecd773f382cb",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Load trained VAE\n",
-    "vae = valdo.VAE.load(vae_path + run_prefix + 'trained_vae.pkl')"
+    "vae = valdo.VAE.load(vae_path + run_prefix + 'trained_vae.pkl')\n",
+    "# vae = valdo.VAE.load(vae_path+\"run_20_11231_trained_vae.pkl\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 90,
    "id": "c3b5ae3e-b02b-4ade-807a-1a9852fa080c",
    "metadata": {},
    "outputs": [],
@@ -1563,7 +3017,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 91,
    "id": "85e34fa3-7d56-4061-acaa-772d1577c7a3",
    "metadata": {},
    "outputs": [],
@@ -1579,7 +3033,7 @@
     "else:\n",
     "    recons = recons.detach().cpu().numpy()\n",
     "    \n",
-    "np.save(vae_reconstructed_path + 'recons', recons)"
+    "np.save(vae_reconstructed_path + 'recons.npy', recons)"
    ]
   },
   {
@@ -1594,23 +3048,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 92,
    "id": "2b2c5ef8-1c50-49f2-9fac-b093d4be808b",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1617\n",
+      "(1617, 77821)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1617/1617 [02:44<00:00,  9.82it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2min 39s, sys: 4.13 s, total: 2min 43s\n",
+      "Wall time: 2min 45s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Re-scale the reconstructed files accordingly and creates the `diff` column\n",
     "# Function is valdo.preprocessing.rescale\n",
     "\n",
-    "ncpu_temp=10#ncpu/2\n",
+    "ncpu_temp=8 #ncpu/2\n",
     "\n",
     "with open(os.path.join(vae_path, 'filtered_file_list.pkl'),'rb') as f:\n",
     "    file_list = pickle.load(f)\n",
     "\n",
     "print(len(file_list))\n",
     "\n",
-    "if ncpu > 1:\n",
+    "if False: #ncpu > 1:\n",
     "    valdo.preprocessing.rescale_pool(recons_path=vae_reconstructed_path + 'recons.npy', \n",
     "                intersection_path=intersection_path, \n",
     "                union_path=union_path, \n",
@@ -1696,12 +3183,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "8b6af73e-66c7-4f3a-bd1a-0b3cd7758c45",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/reconstructed_w_phases/\n",
+      "\n",
+      "Working with 1617 MTZs containing reconstructed (apo-like) amplitudes.\n",
+      "\n",
+      "CPU times: user 3.47 ms, sys: 0 ns, total: 3.47 ms\n",
+      "Wall time: 4.88 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "print(phasing_path)\n",
@@ -1709,7 +3210,7 @@
     "\n",
     "# List of reconstructed mtz files without phases to add phases to\n",
     "file_list = glob.glob(vae_reconstructed_path + \"*.mtz\")\n",
-    "# file_list = file_list[:10]\n",
+    "\n",
     "file_list_w_phases = file_list.copy()\n",
     "print(\"\\nWorking with \" + str(len(file_list)) + \" MTZs containing reconstructed (apo-like) amplitudes.\\n\")"
    ]
@@ -1725,14 +3226,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 94,
    "id": "0e477345-e4f4-4828-9c51-b5be398a6307",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/\n",
+      "1488_1.mtz\n",
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/reconstructed/1488_1.mtz\n",
+      "('/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/refine_1488_1_001.mtz', 3)\n"
+     ]
+    }
+   ],
    "source": [
     "print(phasing_path)\n",
     "print(apo_phases_parser(file_list[0]))\n",
-    "print(valdo.helper.find_phase_file(file_list[0], phasing_path, parser=apo_phases_parser))"
+    "print(file_list[0])\n",
+    "print(valdo.helper.find_phase_file(file_list[0], phasing_path, parser=apo_phases_parser))\n",
+    "# print(valdo.helper.find_phase_file(\"/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/reconstructed/0130_1.mtz\", phasing_path, parser=apo_phases_parser))"
    ]
   },
   {
@@ -1740,18 +3254,36 @@
    "id": "e0fe3271-91fb-4e79-8f73-aed18bbbf9c3",
    "metadata": {},
    "source": [
-    "#### adding phases"
+    "#### Adding phases"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 95,
    "id": "61c46eda-4cdc-41a8-9999-fef2dc9dd207",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1617/1617 [00:26<00:00, 60.65it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done. No phases found for 0 starting MTZs.\n",
+      "CPU times: user 62.3 ms, sys: 2.86 s, total: 2.92 s\n",
+      "Wall time: 40.2 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "if ncpu > 1:\n",
     "    no_phases_files = valdo.helper.add_phases_pool(\n",
     "        file_list, \n",
@@ -1784,11 +3316,43 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2c0159ad-68fb-43d8-af14-f27826cca65e",
+   "metadata": {},
+   "source": [
+    "#### Adding weights"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 96,
    "id": "0ade1fba-70f6-48d5-b0f0-5bb62565d020",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Working with 1617 MTZs containing reconstructed (apo-like) amplitudes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████| 1617/1617 [00:02<00:00, 666.65it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added weights and weighted differences to 1617 MTZ files.\n",
+      "CPU times: user 59.5 ms, sys: 2.63 s, total: 2.68 s\n",
+      "Wall time: 8.61 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "file_list = glob.glob(vae_reconstructed_with_phases_path + \"*.mtz\")\n",
@@ -1805,11 +3369,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "a1a18d6a-d04b-448c-ae90-553146ad4379",
+   "metadata": {},
+   "source": [
+    "#### Adding extrapolated structure factor amplitudes"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "1651d6e0-f791-45e0-8a30-bc5ebe7d3c36",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████| 1617/1617 [00:08<00:00, 192.93it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Calculated extrapolated structure factor amplitudes for 1617 MTZ files.\n",
+      "\n",
+      "CPU times: user 49.8 ms, sys: 120 ms, total: 169 ms\n",
+      "Wall time: 13.6 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "file_list = glob.glob(vae_reconstructed_with_phases_path + \"*.mtz\")\n",
@@ -1822,9 +3412,61 @@
     "                                wt_col=\"WT\", \\\n",
     "                                redo=True, \\\n",
     "                                weighted=False, \\\n",
-    "                                extrapolate_factors=[2,4,8,16], \\\n",
+    "                                extrapolate_factors=[2,4,6,8,16], \\\n",
     "                                ncpu=ncpu)\n",
     "print(\"Calculated extrapolated structure factor amplitudes for \" + str(sum(result)) + \" MTZ files.\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c5f7889-9965-4639-bd2a-3383478b8f67",
+   "metadata": {},
+   "source": [
+    "In case if NaNs in the MTZ (should not occur--this is a bandaid):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1960feaa-e912-4164-aa6d-d117659f57d8",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1617/1617 [02:13<00:00, 12.16it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for file in tqdm(file_list):\n",
+    "    ds=rs.read_mtz(file)\n",
+    "    num_nans=np.count_nonzero(ds.isnull()) #ds.shape[0] - ds.dropna().shape[0]\n",
+    "    if num_nans>0:\n",
+    "        ds.dropna().write_mtz(file)\n",
+    "        # print(f\"{file} contained {num_nans} NaNs.\")\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "417d30b7-4ce5-4b7f-935f-e180202a452d",
+   "metadata": {},
+   "source": [
+    "#### Adding test set (Rfree) flags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c79c99c2-59ae-40c2-ada9-bdc53d166a2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# not currently implemented"
    ]
   },
   {
@@ -1847,10 +3489,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "840accda-3fda-4f7e-8d43-40a13193c896",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retrieving 1617 files for blob analysis.\n"
+     ]
+    }
+   ],
    "source": [
     "# List of reconstructed mtz files (with phases) to identify blobs in\n",
     "# tmp=\"/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline_run2/vae/reconstructed_w_phases/\"\n",
@@ -1870,16 +3520,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "b972c767-ac5e-460c-a032-a26d48fe1299",
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████| 1617/1617 [00:54<00:00, 29.84it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Done generating blobs with starmap/pool and wrote /n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/blobs/run_23_11231_blob_stats.pkl\n",
+      "CPU times: user 278 ms, sys: 63.7 ms, total: 341 ms\n",
+      "Wall time: 1min 49s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Function in valdo.blobs that generates a list of blobs\n",
-    "tmp_ncpu=12\n",
+    "tmp_ncpu=5\n",
     "if ncpu>1:\n",
     "    valdo.blobs.generate_blobs_pool(\n",
     "        input_files=file_list, \n",
@@ -1933,15 +3601,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "c4330dcd-7e7c-435b-b883-467d4b28e80e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "phyllis_dir=\"/n/holyscratch01/hekstra_lab/phyllis/\"\n",
-    "bound_models_path=phyllis_dir + \"PTP1B_DK/all_bound_models_reindexed_v2/\"\n",
-    "bound_models_path=\"/n/holyscratch01/hekstra_lab/dhekstra/phyllis/PTP1B_DK/all_bound_models_reindexed_v2\"\n",
-    "bound_sample_ids =phyllis_dir + \"bound_sample_ids.txt\""
+    "# phyllis_dir=\"/n/holyscratch01/hekstra_lab/phyllis/\"\n",
+    "# bound_models_path=phyllis_dir + \"PTP1B_DK/all_bound_models_reindexed_v2/\"\n",
+    "bound_models_path=\"/n/hekstra_lab/projects/valdo/Keedy_Ginn_bound_state_models/all_bound_models_reindexed_v2/short/\"\n",
+    "bound_sample_ids =\"/n/hekstra_lab/projects/valdo/bound_models_ex_Skaist_20240122.txt\""
    ]
   },
   {
@@ -1954,13 +3622,71 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 28,
+   "id": "efa64286-a14e-48e2-bbd1-74819ac455e1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/data/bound_models_reindexed/\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(bound_models_standardized_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "id": "1e958250-cfb1-4274-8ffb-3d51eb545444",
+   "id": "41ac8c55-cf02-42fa-bc2a-453431b5702b",
    "metadata": {},
    "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0296a72f-7439-464f-b9df-03999c497094",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "1e958250-cfb1-4274-8ffb-3d51eb545444",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████████| 168/168 [00:01<00:00, 146.37it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No match for exclude\n",
+      "CPU times: user 31.7 ms, sys: 69 ms, total: 101 ms\n",
+      "Wall time: 1.15 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
-    "bSkip=True\n",
+    "bSkip=False\n",
     "\n",
     "if not bSkip:\n",
     "    # Define the source and destination folders\n",
@@ -2028,10 +3754,121 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "b50b2d69-ab5f-4c68-a953-86f74ba1ad17",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample</th>\n",
+       "      <th>peakz</th>\n",
+       "      <th>peak</th>\n",
+       "      <th>score</th>\n",
+       "      <th>cenx</th>\n",
+       "      <th>ceny</th>\n",
+       "      <th>cenz</th>\n",
+       "      <th>volume</th>\n",
+       "      <th>radius</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1488_1</td>\n",
+       "      <td>15.779</td>\n",
+       "      <td>15.779</td>\n",
+       "      <td>3061.747</td>\n",
+       "      <td>43.687</td>\n",
+       "      <td>17.737</td>\n",
+       "      <td>10.808</td>\n",
+       "      <td>582.258</td>\n",
+       "      <td>5.180</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1488_1</td>\n",
+       "      <td>16.734</td>\n",
+       "      <td>16.734</td>\n",
+       "      <td>2903.690</td>\n",
+       "      <td>7.750</td>\n",
+       "      <td>49.098</td>\n",
+       "      <td>24.999</td>\n",
+       "      <td>540.365</td>\n",
+       "      <td>5.053</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1488_1</td>\n",
+       "      <td>7.136</td>\n",
+       "      <td>7.136</td>\n",
+       "      <td>448.032</td>\n",
+       "      <td>15.106</td>\n",
+       "      <td>41.170</td>\n",
+       "      <td>23.162</td>\n",
+       "      <td>97.144</td>\n",
+       "      <td>2.852</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1488_1</td>\n",
+       "      <td>4.936</td>\n",
+       "      <td>4.936</td>\n",
+       "      <td>139.682</td>\n",
+       "      <td>15.278</td>\n",
+       "      <td>44.311</td>\n",
+       "      <td>17.316</td>\n",
+       "      <td>34.810</td>\n",
+       "      <td>2.026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1488_1</td>\n",
+       "      <td>5.981</td>\n",
+       "      <td>5.981</td>\n",
+       "      <td>108.761</td>\n",
+       "      <td>44.720</td>\n",
+       "      <td>-3.698</td>\n",
+       "      <td>0.417</td>\n",
+       "      <td>24.893</td>\n",
+       "      <td>1.811</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sample   peakz    peak     score    cenx    ceny    cenz   volume  radius\n",
+       "0  1488_1  15.779  15.779  3061.747  43.687  17.737  10.808  582.258   5.180\n",
+       "1  1488_1  16.734  16.734  2903.690   7.750  49.098  24.999  540.365   5.053\n",
+       "2  1488_1   7.136   7.136   448.032  15.106  41.170  23.162   97.144   2.852\n",
+       "3  1488_1   4.936   4.936   139.682  15.278  44.311  17.316   34.810   2.026\n",
+       "4  1488_1   5.981   5.981   108.761  44.720  -3.698   0.417   24.893   1.811"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "blob_df = pd.read_pickle(blob_path + run_prefix + 'blob_stats.pkl')\n",
     "blob_df.head(5)"
@@ -2049,7 +3886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "e3488259-cb23-4d7a-8bf4-d10f8da48c50",
    "metadata": {},
    "outputs": [],
@@ -2071,12 +3908,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "53bfa05c-337c-4aa6-a46a-a0b26c23ab8e",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████| 16486/16486 [00:05<00:00, 2940.83it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 120 ms, sys: 180 ms, total: 300 ms\n",
+      "Wall time: 7.7 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "#with one CPU, this takes about 40 sec\n",
@@ -2099,12 +3952,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "61046323-1918-4491-ad08-8b38274dab46",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████| 16486/16486 [00:00<00:00, 74918.90it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 142 ms, sys: 165 ms, total: 307 ms\n",
+      "Wall time: 672 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "blob_df = valdo.tag.tag_lig_blobs(blob_df, \n",
@@ -2122,10 +3991,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "85978d50-d318-4314-811b-214c1c3c54fb",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|████████████████████████████████████| 16486/16486 [00:38<00:00, 432.29it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4.04 s, sys: 366 ms, total: 4.41 s\n",
+      "Wall time: 51.5 s\n"
+     ]
+    }
+   ],
    "source": [
     "%%time\n",
     "# Identifies all possible cartesian coordinates after symmetry operations\n",
@@ -2136,10 +4021,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "2fc0a7b0-1e17-4926-8ca8-24bb0dc6f1b0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 481 ms, sys: 9.2 ms, total: 490 ms\n",
+      "Wall time: 501 ms\n"
+     ]
+    }
+   ],
    "source": [
     "%%time \n",
     "# <1 sec\n",
@@ -2157,10 +4051,197 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "73633b48-d768-4ba7-ab87-44e1af19a6f2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>peakz</th>\n",
+       "      <th>peak</th>\n",
+       "      <th>score</th>\n",
+       "      <th>cenx</th>\n",
+       "      <th>ceny</th>\n",
+       "      <th>cenz</th>\n",
+       "      <th>volume</th>\n",
+       "      <th>radius</th>\n",
+       "      <th>bound</th>\n",
+       "      <th>cys215</th>\n",
+       "      <th>ligand</th>\n",
+       "      <th>duplicate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "      <td>16486.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>5.617</td>\n",
+       "      <td>5.617</td>\n",
+       "      <td>271.167</td>\n",
+       "      <td>3.685</td>\n",
+       "      <td>41.123</td>\n",
+       "      <td>15.527</td>\n",
+       "      <td>57.876</td>\n",
+       "      <td>2.018</td>\n",
+       "      <td>0.063</td>\n",
+       "      <td>0.093</td>\n",
+       "      <td>0.015</td>\n",
+       "      <td>0.041</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>2.533</td>\n",
+       "      <td>2.533</td>\n",
+       "      <td>738.104</td>\n",
+       "      <td>16.277</td>\n",
+       "      <td>15.483</td>\n",
+       "      <td>13.739</td>\n",
+       "      <td>130.285</td>\n",
+       "      <td>0.824</td>\n",
+       "      <td>0.243</td>\n",
+       "      <td>0.290</td>\n",
+       "      <td>0.122</td>\n",
+       "      <td>0.198</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>3.696</td>\n",
+       "      <td>3.696</td>\n",
+       "      <td>36.220</td>\n",
+       "      <td>-43.972</td>\n",
+       "      <td>-3.698</td>\n",
+       "      <td>-10.637</td>\n",
+       "      <td>10.003</td>\n",
+       "      <td>1.337</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>4.512</td>\n",
+       "      <td>4.512</td>\n",
+       "      <td>56.945</td>\n",
+       "      <td>-7.831</td>\n",
+       "      <td>35.199</td>\n",
+       "      <td>1.732</td>\n",
+       "      <td>14.215</td>\n",
+       "      <td>1.503</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>5.024</td>\n",
+       "      <td>5.024</td>\n",
+       "      <td>90.452</td>\n",
+       "      <td>1.963</td>\n",
+       "      <td>42.818</td>\n",
+       "      <td>11.158</td>\n",
+       "      <td>22.359</td>\n",
+       "      <td>1.748</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>5.792</td>\n",
+       "      <td>5.792</td>\n",
+       "      <td>183.601</td>\n",
+       "      <td>11.204</td>\n",
+       "      <td>50.201</td>\n",
+       "      <td>29.214</td>\n",
+       "      <td>44.792</td>\n",
+       "      <td>2.203</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>43.262</td>\n",
+       "      <td>43.262</td>\n",
+       "      <td>10039.979</td>\n",
+       "      <td>52.831</td>\n",
+       "      <td>80.980</td>\n",
+       "      <td>49.009</td>\n",
+       "      <td>1998.753</td>\n",
+       "      <td>7.814</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>1.000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           peakz       peak      score       cenx       ceny       cenz  \\\n",
+       "count  16486.000  16486.000  16486.000  16486.000  16486.000  16486.000   \n",
+       "mean       5.617      5.617    271.167      3.685     41.123     15.527   \n",
+       "std        2.533      2.533    738.104     16.277     15.483     13.739   \n",
+       "min        3.696      3.696     36.220    -43.972     -3.698    -10.637   \n",
+       "25%        4.512      4.512     56.945     -7.831     35.199      1.732   \n",
+       "50%        5.024      5.024     90.452      1.963     42.818     11.158   \n",
+       "75%        5.792      5.792    183.601     11.204     50.201     29.214   \n",
+       "max       43.262     43.262  10039.979     52.831     80.980     49.009   \n",
+       "\n",
+       "          volume     radius      bound     cys215     ligand  duplicate  \n",
+       "count  16486.000  16486.000  16486.000  16486.000  16486.000  16486.000  \n",
+       "mean      57.876      2.018      0.063      0.093      0.015      0.041  \n",
+       "std      130.285      0.824      0.243      0.290      0.122      0.198  \n",
+       "min       10.003      1.337      0.000      0.000      0.000      0.000  \n",
+       "25%       14.215      1.503      0.000      0.000      0.000      0.000  \n",
+       "50%       22.359      1.748      0.000      0.000      0.000      0.000  \n",
+       "75%       44.792      2.203      0.000      0.000      0.000      0.000  \n",
+       "max     1998.753      7.814      1.000      1.000      1.000      1.000  "
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "blob_df.describe()"
    ]
@@ -2175,10 +4256,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "68c165e2-1a22-4560-940f-3bd596af5ee1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of blobs with end_corr < 0.55 = 0\n"
+     ]
+    }
+   ],
    "source": [
     "# In this case, no blobs are removed\n",
     "metrics_df = pd.read_pickle(scaled_path + run_prefix + \"scaling_metrics.pkl\")\n",
@@ -2192,7 +4281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "4c497905-2710-41ff-9262-371fa5847266",
    "metadata": {},
    "outputs": [],
@@ -2211,7 +4300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "07f1dc04-ae37-43bd-a002-2eeeba6d225f",
    "metadata": {},
    "outputs": [],
@@ -2221,7 +4310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "0b794a6d-7781-493a-be20-0eed978338c5",
    "metadata": {},
    "outputs": [],
@@ -2238,13 +4327,13 @@
    "source": [
     "# Remove all samples where Helen Ginn does not include a bound state model\n",
     "# In this case, there are no blobs.\n",
-    "hg_no_lig = ['0060', '1429', '1733', '1791', '0225', '0432', '0710']\n",
-    "blob_df = blob_df[~blob_df['sample_id'].isin(hg_no_lig)] "
+    "# hg_no_lig = ['0060', '1429', '1733', '1791', '0225', '0432', '0710']\n",
+    "# blob_df = blob_df[~blob_df['sample_id'].isin(hg_no_lig)] "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "d54f2246-d2ac-408e-aab1-aed7e9d03c39",
    "metadata": {},
    "outputs": [],
@@ -2264,17 +4353,204 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "ca34f668-57cc-43e9-a3ca-b5751036f3c5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>peakz</th>\n",
+       "      <th>peak</th>\n",
+       "      <th>score</th>\n",
+       "      <th>cenx</th>\n",
+       "      <th>ceny</th>\n",
+       "      <th>cenz</th>\n",
+       "      <th>volume</th>\n",
+       "      <th>radius</th>\n",
+       "      <th>bound</th>\n",
+       "      <th>cys215</th>\n",
+       "      <th>ligand</th>\n",
+       "      <th>duplicate</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.0</td>\n",
+       "      <td>14309.000</td>\n",
+       "      <td>14309.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>5.488</td>\n",
+       "      <td>5.488</td>\n",
+       "      <td>219.463</td>\n",
+       "      <td>3.194</td>\n",
+       "      <td>40.875</td>\n",
+       "      <td>14.504</td>\n",
+       "      <td>47.644</td>\n",
+       "      <td>1.936</td>\n",
+       "      <td>0.061</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.013</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>2.184</td>\n",
+       "      <td>2.184</td>\n",
+       "      <td>607.253</td>\n",
+       "      <td>16.738</td>\n",
+       "      <td>15.981</td>\n",
+       "      <td>13.696</td>\n",
+       "      <td>107.366</td>\n",
+       "      <td>0.721</td>\n",
+       "      <td>0.240</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.115</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>3.696</td>\n",
+       "      <td>3.696</td>\n",
+       "      <td>36.220</td>\n",
+       "      <td>-43.761</td>\n",
+       "      <td>-3.698</td>\n",
+       "      <td>-9.908</td>\n",
+       "      <td>10.003</td>\n",
+       "      <td>1.337</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>4.504</td>\n",
+       "      <td>4.504</td>\n",
+       "      <td>55.411</td>\n",
+       "      <td>-8.733</td>\n",
+       "      <td>34.528</td>\n",
+       "      <td>1.450</td>\n",
+       "      <td>13.853</td>\n",
+       "      <td>1.490</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>5.001</td>\n",
+       "      <td>5.001</td>\n",
+       "      <td>84.714</td>\n",
+       "      <td>0.291</td>\n",
+       "      <td>41.831</td>\n",
+       "      <td>8.598</td>\n",
+       "      <td>20.980</td>\n",
+       "      <td>1.711</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>5.742</td>\n",
+       "      <td>5.742</td>\n",
+       "      <td>158.604</td>\n",
+       "      <td>11.852</td>\n",
+       "      <td>50.958</td>\n",
+       "      <td>29.341</td>\n",
+       "      <td>38.796</td>\n",
+       "      <td>2.100</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>43.262</td>\n",
+       "      <td>43.262</td>\n",
+       "      <td>10039.979</td>\n",
+       "      <td>52.831</td>\n",
+       "      <td>80.980</td>\n",
+       "      <td>49.009</td>\n",
+       "      <td>1978.535</td>\n",
+       "      <td>7.788</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           peakz       peak      score       cenx       ceny       cenz  \\\n",
+       "count  14309.000  14309.000  14309.000  14309.000  14309.000  14309.000   \n",
+       "mean       5.488      5.488    219.463      3.194     40.875     14.504   \n",
+       "std        2.184      2.184    607.253     16.738     15.981     13.696   \n",
+       "min        3.696      3.696     36.220    -43.761     -3.698     -9.908   \n",
+       "25%        4.504      4.504     55.411     -8.733     34.528      1.450   \n",
+       "50%        5.001      5.001     84.714      0.291     41.831      8.598   \n",
+       "75%        5.742      5.742    158.604     11.852     50.958     29.341   \n",
+       "max       43.262     43.262  10039.979     52.831     80.980     49.009   \n",
+       "\n",
+       "          volume     radius      bound   cys215     ligand  duplicate  \n",
+       "count  14309.000  14309.000  14309.000  14309.0  14309.000    14309.0  \n",
+       "mean      47.644      1.936      0.061      0.0      0.013        0.0  \n",
+       "std      107.366      0.721      0.240      0.0      0.115        0.0  \n",
+       "min       10.003      1.337      0.000      0.0      0.000        0.0  \n",
+       "25%       13.853      1.490      0.000      0.0      0.000        0.0  \n",
+       "50%       20.980      1.711      0.000      0.0      0.000        0.0  \n",
+       "75%       38.796      2.100      0.000      0.0      0.000        0.0  \n",
+       "max     1978.535      7.788      1.000      0.0      1.000        0.0  "
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "blob_df.describe()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "d8741a6e-8ee9-45ba-bac7-2fc55686be3d",
    "metadata": {},
    "outputs": [],
@@ -2285,12 +4561,515 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "058ca000-9f0b-477d-8ab0-ddfffce22e12",
+   "id": "f4feb7b8-5217-4dfa-893c-0810b92e85ad",
    "metadata": {},
    "outputs": [],
    "source": [
+    "blob_df = pd.read_pickle(blob_path + run_prefix +'filtered_blob_stats_tagged.pkl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "066ddf84-d5da-4280-b934-c31871a3710a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sample</th>\n",
+       "      <th>peakz</th>\n",
+       "      <th>score</th>\n",
+       "      <th>bound</th>\n",
+       "      <th>ligand</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>13589</th>\n",
+       "      <td>1227_0</td>\n",
+       "      <td>21.452</td>\n",
+       "      <td>1052.345</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6016</th>\n",
+       "      <td>1525_1</td>\n",
+       "      <td>21.408</td>\n",
+       "      <td>4809.380</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>27</th>\n",
+       "      <td>0714_0</td>\n",
+       "      <td>21.284</td>\n",
+       "      <td>1942.200</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16223</th>\n",
+       "      <td>0205_1</td>\n",
+       "      <td>21.281</td>\n",
+       "      <td>7414.799</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6284</th>\n",
+       "      <td>1549_1</td>\n",
+       "      <td>21.281</td>\n",
+       "      <td>2367.889</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13355</th>\n",
+       "      <td>1316_0</td>\n",
+       "      <td>21.229</td>\n",
+       "      <td>3977.842</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9137</th>\n",
+       "      <td>1252_0</td>\n",
+       "      <td>21.121</td>\n",
+       "      <td>1935.243</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7357</th>\n",
+       "      <td>0180_0</td>\n",
+       "      <td>21.014</td>\n",
+       "      <td>7316.743</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7573</th>\n",
+       "      <td>1886_1</td>\n",
+       "      <td>20.883</td>\n",
+       "      <td>2125.104</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7012</th>\n",
+       "      <td>0652_1</td>\n",
+       "      <td>20.576</td>\n",
+       "      <td>6236.932</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5024</th>\n",
+       "      <td>0995_0</td>\n",
+       "      <td>20.572</td>\n",
+       "      <td>2479.002</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14205</th>\n",
+       "      <td>1317_1</td>\n",
+       "      <td>20.458</td>\n",
+       "      <td>4126.022</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3393</th>\n",
+       "      <td>1559_0</td>\n",
+       "      <td>20.411</td>\n",
+       "      <td>3167.417</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8049</th>\n",
+       "      <td>0118_0</td>\n",
+       "      <td>20.404</td>\n",
+       "      <td>4023.063</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11440</th>\n",
+       "      <td>1318_0</td>\n",
+       "      <td>20.253</td>\n",
+       "      <td>3538.773</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4751</th>\n",
+       "      <td>0175_0</td>\n",
+       "      <td>20.218</td>\n",
+       "      <td>2451.201</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15203</th>\n",
+       "      <td>1589_1</td>\n",
+       "      <td>20.149</td>\n",
+       "      <td>5325.159</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6797</th>\n",
+       "      <td>1710_0</td>\n",
+       "      <td>20.135</td>\n",
+       "      <td>2365.174</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13531</th>\n",
+       "      <td>0209_0</td>\n",
+       "      <td>20.017</td>\n",
+       "      <td>5774.076</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2499</th>\n",
+       "      <td>0997_1</td>\n",
+       "      <td>19.851</td>\n",
+       "      <td>858.152</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4244</th>\n",
+       "      <td>0904_1</td>\n",
+       "      <td>19.845</td>\n",
+       "      <td>5658.720</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10030</th>\n",
+       "      <td>0847_1</td>\n",
+       "      <td>19.743</td>\n",
+       "      <td>3548.238</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4289</th>\n",
+       "      <td>0835_0</td>\n",
+       "      <td>19.689</td>\n",
+       "      <td>2733.679</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12428</th>\n",
+       "      <td>1192_1</td>\n",
+       "      <td>19.680</td>\n",
+       "      <td>4858.033</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11804</th>\n",
+       "      <td>0270_0</td>\n",
+       "      <td>19.509</td>\n",
+       "      <td>1418.160</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2712</th>\n",
+       "      <td>0058_0</td>\n",
+       "      <td>19.469</td>\n",
+       "      <td>5921.016</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12599</th>\n",
+       "      <td>1815_1</td>\n",
+       "      <td>19.420</td>\n",
+       "      <td>1822.286</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3376</th>\n",
+       "      <td>1740_1</td>\n",
+       "      <td>19.375</td>\n",
+       "      <td>2014.695</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11950</th>\n",
+       "      <td>1292_0</td>\n",
+       "      <td>19.369</td>\n",
+       "      <td>1792.566</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5891</th>\n",
+       "      <td>1417_0</td>\n",
+       "      <td>19.278</td>\n",
+       "      <td>3282.802</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3827</th>\n",
+       "      <td>0821_1</td>\n",
+       "      <td>19.237</td>\n",
+       "      <td>1577.498</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11139</th>\n",
+       "      <td>0713_1</td>\n",
+       "      <td>19.179</td>\n",
+       "      <td>2640.951</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14467</th>\n",
+       "      <td>0623_0</td>\n",
+       "      <td>19.152</td>\n",
+       "      <td>2231.004</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2653</th>\n",
+       "      <td>1960_0</td>\n",
+       "      <td>19.112</td>\n",
+       "      <td>1291.189</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6858</th>\n",
+       "      <td>1114_1</td>\n",
+       "      <td>19.059</td>\n",
+       "      <td>647.105</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5481</th>\n",
+       "      <td>0935_0</td>\n",
+       "      <td>19.036</td>\n",
+       "      <td>3406.919</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12643</th>\n",
+       "      <td>0579_0</td>\n",
+       "      <td>18.938</td>\n",
+       "      <td>4183.276</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14549</th>\n",
+       "      <td>1045_1</td>\n",
+       "      <td>18.934</td>\n",
+       "      <td>1397.476</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11047</th>\n",
+       "      <td>0294_1</td>\n",
+       "      <td>18.856</td>\n",
+       "      <td>4581.245</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2822</th>\n",
+       "      <td>0933_1</td>\n",
+       "      <td>18.687</td>\n",
+       "      <td>1500.988</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1311</th>\n",
+       "      <td>1095_1</td>\n",
+       "      <td>18.681</td>\n",
+       "      <td>1678.772</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16234</th>\n",
+       "      <td>0822_0</td>\n",
+       "      <td>18.534</td>\n",
+       "      <td>1649.853</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1390</th>\n",
+       "      <td>1957_1</td>\n",
+       "      <td>18.478</td>\n",
+       "      <td>4849.318</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4432</th>\n",
+       "      <td>1264_1</td>\n",
+       "      <td>18.457</td>\n",
+       "      <td>7644.919</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4490</th>\n",
+       "      <td>0932_0</td>\n",
+       "      <td>18.382</td>\n",
+       "      <td>3041.379</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11691</th>\n",
+       "      <td>1781_1</td>\n",
+       "      <td>18.238</td>\n",
+       "      <td>2643.981</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13351</th>\n",
+       "      <td>1242_0</td>\n",
+       "      <td>18.046</td>\n",
+       "      <td>4460.611</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9851</th>\n",
+       "      <td>0597_0</td>\n",
+       "      <td>18.039</td>\n",
+       "      <td>6770.364</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8805</th>\n",
+       "      <td>1652_1</td>\n",
+       "      <td>17.991</td>\n",
+       "      <td>2752.616</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3263</th>\n",
+       "      <td>0072_0</td>\n",
+       "      <td>17.974</td>\n",
+       "      <td>1462.695</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       sample   peakz     score  bound  ligand\n",
+       "13589  1227_0  21.452  1052.345      0       0\n",
+       "6016   1525_1  21.408  4809.380      1       1\n",
+       "27     0714_0  21.284  1942.200      0       0\n",
+       "16223  0205_1  21.281  7414.799      1       1\n",
+       "6284   1549_1  21.281  2367.889      0       0\n",
+       "13355  1316_0  21.229  3977.842      1       1\n",
+       "9137   1252_0  21.121  1935.243      0       0\n",
+       "7357   0180_0  21.014  7316.743      1       1\n",
+       "7573   1886_1  20.883  2125.104      0       0\n",
+       "7012   0652_1  20.576  6236.932      1       1\n",
+       "5024   0995_0  20.572  2479.002      0       0\n",
+       "14205  1317_1  20.458  4126.022      1       1\n",
+       "3393   1559_0  20.411  3167.417      0       0\n",
+       "8049   0118_0  20.404  4023.063      1       1\n",
+       "11440  1318_0  20.253  3538.773      1       1\n",
+       "4751   0175_0  20.218  2451.201      1       1\n",
+       "15203  1589_1  20.149  5325.159      1       1\n",
+       "6797   1710_0  20.135  2365.174      1       1\n",
+       "13531  0209_0  20.017  5774.076      0       0\n",
+       "2499   0997_1  19.851   858.152      0       0\n",
+       "4244   0904_1  19.845  5658.720      0       0\n",
+       "10030  0847_1  19.743  3548.238      1       0\n",
+       "4289   0835_0  19.689  2733.679      1       1\n",
+       "12428  1192_1  19.680  4858.033      0       0\n",
+       "11804  0270_0  19.509  1418.160      0       0\n",
+       "2712   0058_0  19.469  5921.016      1       1\n",
+       "12599  1815_1  19.420  1822.286      0       0\n",
+       "3376   1740_1  19.375  2014.695      0       0\n",
+       "11950  1292_0  19.369  1792.566      0       0\n",
+       "5891   1417_0  19.278  3282.802      1       1\n",
+       "3827   0821_1  19.237  1577.498      0       0\n",
+       "11139  0713_1  19.179  2640.951      0       0\n",
+       "14467  0623_0  19.152  2231.004      1       1\n",
+       "2653   1960_0  19.112  1291.189      0       0\n",
+       "6858   1114_1  19.059   647.105      0       0\n",
+       "5481   0935_0  19.036  3406.919      1       1\n",
+       "12643  0579_0  18.938  4183.276      1       1\n",
+       "14549  1045_1  18.934  1397.476      0       0\n",
+       "11047  0294_1  18.856  4581.245      0       0\n",
+       "2822   0933_1  18.687  1500.988      0       0\n",
+       "1311   1095_1  18.681  1678.772      0       0\n",
+       "16234  0822_0  18.534  1649.853      1       1\n",
+       "1390   1957_1  18.478  4849.318      1       1\n",
+       "4432   1264_1  18.457  7644.919      1       1\n",
+       "4490   0932_0  18.382  3041.379      0       0\n",
+       "11691  1781_1  18.238  2643.981      1       1\n",
+       "13351  1242_0  18.046  4460.611      1       1\n",
+       "9851   0597_0  18.039  6770.364      0       0\n",
+       "8805   1652_1  17.991  2752.616      1       1\n",
+       "3263   0072_0  17.974  1462.695      1       1"
+      ]
+     },
+     "execution_count": 49,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "sorted_blobs = blob_df.sort_values(by=\"peakz\",axis=0,ascending=False)\n",
-    "sorted_blobs.iloc[250:300,:][[\"sample\",\"peakz\",\"score\",\"bound\",\"ligand\"]]"
+    "sorted_blobs.to_csv(blob_path + run_prefix +'filtered_blob_stats_tagged.csv')\n",
+    "sorted_blobs.iloc[50:100,:][[\"sample\",\"peakz\",\"score\",\"bound\",\"ligand\"]]"
    ]
   },
   {
@@ -2313,7 +5092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "75577c49-4b83-42fc-966b-e55ce46ea26e",
    "metadata": {},
    "outputs": [],
@@ -2336,10 +5115,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "id": "1859f451-23a3-4ffa-a16e-9d8a50172f2c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/n/holyscratch01/hekstra_lab/dhekstra/valdo-tests/pipeline/vae/blobs/run_23_11231_filtered_blob_stats_tagged.pkl\n",
+      "Total Number of Blobs: 14309\n",
+      "Total Number of Unique Samples: 1613\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD/CAYAAAAddgY2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8pXeV/AAAACXBIWXMAAA9hAAAPYQGoP6dpAAA5B0lEQVR4nO3deVxU9f4/8NcAMwwgyFWUTQRESclMhVTwmmWAgamXm0ppLggmoilQcF36JlpJWSFuuCSCet3KtQWVSU1BLBXxWtItSxJlycBYZBlm+fz+4MdcxxlwzjDDwMz7+Xjw0PnM55x5v2fgzeFzPudzeIwxBkIIISbBzNABEEII6ThU9AkhxIRQ0SeEEBNCRZ8QQkwIFX1CCDEhVPQJIcSEUNEnhBATYmHoADqaXC5HaWkpbG1twePxDB0OIYS0G2MMtbW1cHFxgZlZ28fyJlf0S0tL4ebmZugwCCFE5+7cuYM+ffq02cfkir6trS2A5jfHzs5O4+0kEgmys7MRHBwMPp+vr/AMythzNPb8AOPPkfJTr6amBm5ubor61haTK/otQzp2dnaci761tTXs7OyM8psNMP4cjT0/wPhzpPzapsmQNZ3IJYQQE0JFnxBCTIhBi/758+cxceJEuLi4gMfj4dixY4/d5ty5c/D19YVQKES/fv2wdetW/QdKCCFGwqBFv66uDk8//TQ2bdqkUf+ioiKEhoZizJgxKCgowPLly7F48WIcPnxYz5ESQohxMOiJ3JCQEISEhGjcf+vWrejbty9SU1MBAIMGDcKVK1fw8ccf4+WXX9ZTlIQQY8QYQ4NEZugwlEgkUohlzbHpS5eavXPx4kUEBwcrtY0fPx7p6emQSCRqz3aLxWKIxWLF45qaGgDNZ8klEonGr93Sl8s2XY2x52js+QEdm6MhimZLUayuawSfL9V6P4wBr+64jJ/Ka3UYna5YYNw4MbpzuHiUy+fdpYp+eXk5HB0dldocHR0hlUpRUVEBZ2dnlW2Sk5OxatUqlfbs7GxYW1tzjkEkEnHepqsx9hy7Wn6MAU1ybtt8dVL/Oa7/0Rwl9Ya4qt0CuHTeAK/bcc6cOQNLc83719fXa9y3SxV9QHUeasufQa3NT122bBni4+MVj1suYggODuY8T18kEiEoKMgo5wcDxp+jIfJr79Fw5z4i7foGOdlif9Qz6CwrskgkUpw5cwYTxgdCIBBovF3LCIYmulTRd3JyQnl5uVLbvXv3YGFhgZ49e6rdxtLSEpaWlirtfD5fqx98bbfrSrpSjlyKqoTxIJY1/wum/59yxoCpW79DYZnmP5BdjY+zHT6P9u+woimRSHDqVDbGj9fNFblWfPNOtQaXRCKBpTkgEAg45celb5cq+v7+/vjyyy+V2rKzs+Hn59dlihTR3OMKenNRvcixqFog8dKZ9gfXwTQtrrouio/T0UVTwmOwNAesBRbg87tU+eo0DPquPXjwAL/++qvicVFREa5du4YePXqgb9++WLZsGUpKSrB7924AQHR0NDZt2oT4+HjMmzcPFy9eRHp6Ovbv32+oFIgOqCvu2hX0zkkXR8OaFlcqiuRxDPpdceXKFTz//POKxy1j77Nnz0ZmZibKyspQXFyseN7T0xNZWVmIi4vD5s2b4eLigg0bNtB0zU5MP0fryjrrUXCLzjaEQEybQYv+c8891+Z81MzMTJW2sWPH4urVq3qMimhDX0frmhR0OgomRHP0nU9apelJUn0WdzpKJkS3qOgbOU6zW/7/hS/1TVJYyHk6G1PX5dE6IaR9qOh3YrqY492Rs1voaJ2Qzo+KfifFGMOUrReRf/svg8bBZeYJFXdCOj8q+p1My9F9fZNMZwW/PbNbqJATYlyo6HcCLYW+teGYK28HwlrAYSGOR9DsFkJIC/rJNpDHFfoWfu5/Q08bAR1tE0J0gop+B3j0hOzjCv3DwzE0vEII0SUq+nqm6QlZKvSEkI5ARV+PGGOorGtqteBToSeEdDQq+nqi7gj/0ROyVOgJIR2Nir6eNEiUp1zSCVlCSGdARb8DXHk7kAo+IaRTMDN0AMaIMYb6pv/N1rEW0DAOIaRzoCN9HessyycQQog6dKSvY+rG8q342l9NSwghukRH+jr28D1haCyfENLZ0JG+DsnlDC9tzFU8prF8QkhnQ0VfRxhrLvhFFXUAmi+8omEdQkhnQ0VfRxokMsVaOp4ONvjqjb/TUT4hpNPRquhLpVJ888032LZtG2prawEApaWlePDggU6D60oeHsv/6o2/w8yMCj4hpPPhfCL39u3bePHFF1FcXAyxWIygoCDY2tpi7dq1aGxsxNatW/URZ6fGGMPUrRcVj+kAnxDSWXE+0l+yZAn8/Pzw119/wcrKStEeFhaG06dP6zS4ruLhoR0ayyeEdGacj/Rzc3Nx4cIFCAQCpXZ3d3eUlJToLLCuqnnVTDrUJ4R0TpyP9OVyOWQymUr73bt3YWtryzmAtLQ0eHp6QigUwtfXFzk5OW3237t3L55++mlYW1vD2dkZERERqKys5Py6uvTweD7Ve0JIZ8a56AcFBSE1NVXxmMfj4cGDB1i5ciVCQ0M57evgwYOIjY3FihUrUFBQgDFjxiAkJATFxcVq++fm5mLWrFmIjIzEjRs38Pnnn+Py5cuIiorimobOPDqeTwghnRnnor9u3TqcO3cOPj4+aGxsxPTp0+Hh4YGSkhJ8+OGHnPaVkpKCyMhIREVFYdCgQUhNTYWbmxu2bNmitv93330HDw8PLF68GJ6envj73/+O+fPn48qVK1zT0Jn6JhrPJ4R0HZzH9F1cXHDt2jUcOHAA+fn5kMvliIyMxIwZM5RO7D5OU1MT8vPzsXTpUqX24OBg5OXlqd0mICAAK1asQFZWFkJCQnDv3j0cOnQIEyZMaPV1xGIxxGKx4nFNTXOBlkgkkEgkGsfb0vfhbRhjmLLlO8XjfZF+kEqlGu+zs1GXozEx9vwA48+R8mt7O03wGHt4RPrxzp8/j4CAAFhYKP++kEqlyMvLw7PPPqvRfkpLS+Hq6ooLFy4gICBA0b5mzRrs2rULP//8s9rtDh06hIiICDQ2NkIqlWLSpEk4dOgQ+Hy+2v5JSUlYtWqVSvu+fftgbW2tUaytEcuAxEvN74OrNUPCEBmN6RNCOlx9fT2mT5+O6upq2NnZtdmXc9E3NzdHWVkZevfurdReWVmJ3r17qz3Jq05L0c/Ly4O/v7+i/f3338eePXvw3//+V2WbwsJCBAYGIi4uDuPHj0dZWRkSEhLwzDPPID09Xe3rqDvSd3NzQ0VFxWPfnIdJJBKIRCIEBQUpfsHUN0nx9LtnAADX3h4HG8uuvX6duhyNibHnBxh/jpSfejU1NXBwcNCo6HOuUowxtVMSKysrYWNjo/F+HBwcYG5ujvLycqX2e/fuwdHRUe02ycnJGD16NBISEgAAQ4YMgY2NDcaMGYP33nsPzs7OKttYWlrC0tJSpZ3P52v1TfPwdnz2v/dBIOCDz+/aRb+Ftu9NV2Hs+QHGnyPlp9pfUxpXqX/+858AmmfrzJkzR6mQymQyXL9+XWmY5nEEAgF8fX0hEokQFhamaBeJRJg8ebLaberr61WGlczNm0+ccvyDRScM8JKEENIuGhf97t27A2gurra2tkonbQUCAUaNGoV58+ZxevH4+HjMnDkTfn5+8Pf3x/bt21FcXIzo6GgAwLJly1BSUoLdu3cDACZOnIh58+Zhy5YtiuGd2NhYjBgxAi4uLpxeu71oqiYhpCvSuOhnZGQAADw8PPDWW29xGsppTXh4OCorK7F69WqUlZVh8ODByMrKgru7OwCgrKxMac7+nDlzUFtbi02bNuHNN9+Evb09xo0bx3mqqC7QVE1CSFfEeRB65cqVOg0gJiYGMTExap/LzMxUaXvjjTfwxhtv6DQGrh49yqelFwghXYVWZx4PHTqEzz77DMXFxWhqalJ67urVqzoJrDN7dIE1awEd5RNCugbOV+Ru2LABERER6N27NwoKCjBixAj07NkTt27dQkhIiD5i7NToKJ8Q0pVwLvppaWnYvn07Nm3aBIFAgMTERIhEIixevBjV1dX6iLHToQXWCCFdFeeiX1xcrJiaaWVlpbhz1syZM7F//37dRtcJ0awdQkhXxrnoOzk5KZYydnd3x3ffNa89U1RUZJC58h2NbphCCOnKOBf9cePG4csvvwQAREZGIi4uDkFBQQgPD1e6yMoU0Hg+IaSr4Tx7Z/v27ZDL5QCA6Oho9OjRA7m5uZg4caLioipTQfWeENLVcC76ZmZmMDP73x8I06ZNw7Rp0wAAJSUlcHV11V10hBBCdIrz8I465eXleOONN9C/f39d7I4QQoieaFz0q6qqMGPGDPTq1QsuLi7YsGED5HI53nnnHfTr1w/fffcddu7cqc9YCSGEtJPGwzvLly/H+fPnMXv2bJw8eRJxcXE4efIkGhsbceLECYwdO1afcRJCCNEBjYv+119/jYyMDAQGBiImJgb9+/eHt7e30k3SCSGEdG4aD++UlpbCx8cHANCvXz8IhUJERUXpLTBCCCG6p3HRl8vlSndnMTc318nyyoQQQjqOxsM7jDGlO2Y1NjYiOjpapfAfOXJEtxESQgjRGY2L/uzZs5Uev/baazoPhhBCiH5xvnOWqTOB5YUIIUZMJxdnmQrGgFd3XDZ0GIQQojUq+hw0yYGfypuXkqYVNgkhXREVfS3RCpuEkK6Iir6WqN4TQroiKvqEEGJCtCr6e/bswejRo+Hi4oLbt28DAFJTU3H8+HGdBkcIIUS3OBf9LVu2ID4+HqGhoaiqqoJMJgMA2Nvb0zo8hBDSyXEu+hs3bsSnn36KFStWwNz8f7NX/Pz88MMPP3AOIC0tDZ6enhAKhfD19UVOTk6b/cViMVasWAF3d3dYWlrCy8uLlnQmhBANcb5zVlFREYYNG6bSbmlpibq6Ok77OnjwIGJjY5GWlobRo0dj27ZtCAkJQWFhIfr27at2m2nTpuGPP/5Aeno6+vfvj3v37kEqlXJNgxBCTBLnou/p6Ylr167B3d1dqf3EiROKVTg1lZKSgsjISMVqnampqTh16hS2bNmC5ORklf4nT57EuXPncOvWLfTo0QMA4OHhwTUFQggxWZyLfkJCAhYuXIjGxkYwxnDp0iXs378fycnJ2LFjh8b7aWpqQn5+PpYuXarUHhwcjLy8PLXbfPHFF/Dz88PatWuxZ88e2NjYYNKkSXj33XdhZWWldhuxWAyxWKx4XFNTAwCQSCSQSCQax/toX4lEAgnPuNZkaMmRy/vSlRh7foDx50j5tb2dJjgX/YiICEilUiQmJqK+vh7Tp0+Hq6sr1q9fj1deeUXj/VRUVEAmk8HR0VGp3dHREeXl5Wq3uXXrFnJzcyEUCnH06FFUVFQgJiYG9+/fb3VcPzk5GatWrVJpz87OhrW1tcbxPurUqWxYGukFuSKRyNAh6JWx5wcYf46Un7L6+nqN+/IY034JsYqKCsjlcvTu3ZvztqWlpXB1dUVeXh78/f0V7e+//z727NmD//73vyrbBAcHIycnB+Xl5ejevTuA5qWcp0yZgrq6OrVH++qO9N3c3FBRUQE7OzuN45VIJPjqpAiJl5p/T/7n/8bBWsD5d2anJpFIIBKJEBQUpHTvBGNh7PkBxp8j5adeTU0NHBwcUF1d/di6xrlqrVq1Cq+99hq8vLzg4ODAdXMFBwcHmJubqxzV37t3T+Xov4WzszNcXV0VBR8ABg0aBMYY7t69iwEDBqhsY2lpqbgHwMP4fH67vmmatzeuot+ive9NZ2fs+QHGnyPlp9pfU5ynbB4+fBje3t4YNWoUNm3ahD///JPrLgAAAoEAvr6+Kn/GiEQiBAQEqN1m9OjRKC0txYMHDxRtv/zyC8zMzNCnTx+t4iCEEFPCuehfv34d169fx7hx45CSkgJXV1eEhoZi3759nMaVACA+Ph47duzAzp078dNPPyEuLg7FxcWIjo4GACxbtgyzZs1S9J8+fTp69uyJiIgIFBYW4vz580hISMDcuXNbPZFLCCHkf7RahuHJJ5/EmjVrcOvWLZw9exaenp6IjY2Fk5MTp/2Eh4cjNTUVq1evxtChQ3H+/HlkZWUppoOWlZWhuLhY0b9bt24QiUSoqqqCn58fZsyYgYkTJ2LDhg3apEEIISan3YPSNjY2sLKygkAgQG1tLeftY2JiEBMTo/a5zMxMlbaBAwca/Zl7QgjRF62O9IuKivD+++/Dx8cHfn5+uHr1KpKSklqdakkIIaRz4Hyk7+/vj0uXLuGpp55CRESEYp4+IYSQzo9z0X/++eexY8cOPPnkk/qIhxBCiB5xLvpr1qzRRxyEEEI6gEZFPz4+Hu+++y5sbGwQHx/fZt+UlBSdBEYIIUT3NCr6BQUFigV9CgoK9BoQIYQQ/dGo6J89e1bt/wkhhHQtnKdszp07V+18/Lq6OsydO1cnQXVGjDGs/9FIl9UkhJgMzkV/165daGhoUGlvaGjA7t27dRJUZ9QgkaGkngcA8HG2gxWffgEQQroejWfv1NTUgDEGxhhqa2shFAoVz8lkMmRlZWm1xHJX9Hm0P3g8nqHDIIQQzjQu+vb29uDxeODxePD29lZ5nsfjqb1ZiTGiek8I6ao0Lvpnz54FYwzjxo3D4cOHFfeoBZqXSXZ3d4eLi4tegiSEEKIbGhf9sWPHAmhed6dv3740vEEIIV2QRkX/+vXrGDx4MMzMzFBdXY0ffvih1b5DhgzRWXCEEEJ0S6OiP3ToUJSXl6N3794YOnQoeDwe1N1al8fjQSaT6TxIQgghuqFR0S8qKkKvXr0U/yeEENI1aVT0W+5k9ej/CSGEdC1aXZz19ddfKx4nJibC3t4eAQEBuH37tk6DI4QQoluci/6aNWsUNyG/ePEiNm3ahLVr18LBwQFxcXE6D5AQQojucF5P/86dO+jfvz8A4NixY5gyZQpef/11jB49Gs8995yu4yOEEKJDnI/0u3XrhsrKSgBAdnY2AgMDAQBCoVDtmjyEEEI6D85H+kFBQYiKisKwYcPwyy+/YMKECQCAGzduwMPDQ9fxEUII0SHOR/qbN2+Gv78//vzzTxw+fBg9e/YEAOTn5+PVV1/VeYCEEEJ0h/ORvr29PTZt2qTSbiqLrRFCSFfG+UgfAKqqqvDJJ58gKioK8+bNQ0pKCqqrq7UKIC0tDZ6enhAKhfD19UVOTo5G2124cAEWFhYYOnSoVq9LCCGmiHPRv3LlCry8vLBu3Trcv38fFRUVWLduHby8vHD16lVO+zp48CBiY2OxYsUKFBQUYMyYMQgJCUFxcXGb21VXV2PWrFl44YUXuIZPCCEmjXPRj4uLw6RJk/D777/jyJEjOHr0KIqKivDSSy8hNjaW075SUlIQGRmJqKgoDBo0CKmpqXBzc8OWLVva3G7+/PmYPn06/P39uYZPCCEmjfOY/pUrV/Dpp5/CwuJ/m1pYWCAxMRF+fn4a76epqQn5+flYunSpUntwcDDy8vJa3S4jIwO//fYb/v3vf+O999577OuIxWKIxWLF45qaGgCARCKBRCLROF6JRPrQ/yWQ8FQXnOvqWt4PLu9LV2Ls+QHGnyPl1/Z2muBc9O3s7FBcXIyBAwcqtd+5cwe2trYa76eiogIymQyOjo5K7Y6OjigvL1e7zc2bN7F06VLk5OQo/dJpS3JystqTzNnZ2bC2ttY4XrEMaHm7Tp3KhqUR3yJXJBIZOgS9Mvb8AOPPkfJTVl9fr3FfzkU/PDwckZGR+PjjjxEQEAAej4fc3FwkJCRoNWXz0ZuxMMbU3qBFJpNh+vTpWLVqldrbNbZm2bJliI+PVzyuqamBm5sbgoODYWdnp/F+qusagUvnAQDjxwfDWsD5rev0JBIJRCIRgoKCwOfzDR2Ozhl7foDx50j5qdcygqEJzpXr448/Bo/Hw6xZsyCVNg958Pl8LFiwAB988IHG+3FwcIC5ubnKUf29e/dUjv4BoLa2FleuXEFBQQEWLVoEAJDL5WCMwcLCAtnZ2Rg3bpzKdpaWlrC0tFRp5/P5nN5UPl/60P/54PONr+i34PredDXGnh9g/DlSfqr9NcW5cgkEAqxfvx7Jycn47bffwBhD//79OQ2VtOzH19cXIpEIYWFhinaRSITJkyer9Lezs1O5Y1daWhrOnDmDQ4cOwdPTk2sqhBBicjQu+vX19UhISMCxY8cgkUgQGBiIDRs2wMHBQesXj4+Px8yZM+Hn5wd/f39s374dxcXFiI6OBtA8NFNSUoLdu3fDzMwMgwcPVtq+d+/eEAqFKu2EEELU07jor1y5EpmZmZgxYwaEQiH279+PBQsW4PPPP9f6xcPDw1FZWYnVq1ejrKwMgwcPRlZWluJGLWVlZY+ds08IIURzGhf9I0eOID09Ha+88goA4LXXXsPo0aMhk8lgbq79VJaYmBjExMSofS4zM7PNbZOSkpCUlKT1axNCiKnR+OKsO3fuYMyYMYrHI0aMgIWFBUpLS/USGCGEEN3TuOjLZDIIBAKlNgsLC8UMHkIIIZ2fxsM7jDHMmTNHafpjY2MjoqOjYWNjo2g7cuSIbiMkhBCiMxoX/dmzZ6u0vfbaazoNhhBCiH5pXPQzMjL0GQchhJAOoNV6+oQQQromKvqEEGJCqOgTQogJoaJPCCEmhIo+IYSYEK2K/p49ezB69Gi4uLjg9u3bAIDU1FQcP35cp8ERQgjRLc5Ff8uWLYiPj0doaCiqqqogk8kAAPb29khNTdV1fIQQQnSIc9HfuHEjPv30U6xYsUJpoTU/Pz+V9e4JIYR0LpyLflFREYYNG6bSbmlpibq6Op0ERQghRD84F31PT09cu3ZNpf3EiRPw8fHRRUyEEEL0hPPtEhMSErBw4UI0NjaCMYZLly5h//79SE5Oxo4dO/QRIyGEEB3hXPQjIiIglUqRmJiI+vp6TJ8+Ha6urli/fr3iBiuEEEI6J85FHwDmzZuHefPmoaKiAnK5HL1799Z1XIQQQvRAq6Lfoj03RSeEENLxOBd9T09P8Hi8Vp+/detWuwIihBCiP5yLfmxsrNJjiUSCgoICnDx5EgkJCbqKixBCiB5wLvpLlixR275582ZcuXKl3QERQgjRH50tuBYSEoLDhw/raneEEEL0QGdF/9ChQ+jRo4eudkcIIUQPOBf9YcOGYfjw4YqvYcOGwdnZGcuXL8fy5cs5B5CWlgZPT08IhUL4+voiJyen1b5HjhxBUFAQevXqBTs7O/j7++PUqVOcX5MQQkwV5zH9f/zjH0qPzczM0KtXLzz33HMYOHAgp30dPHgQsbGxSEtLw+jRo7Ft2zaEhISgsLAQffv2Vel//vx5BAUFYc2aNbC3t0dGRgYmTpyI77//Xu16QIQQQpRxKvpSqRQeHh4YP348nJyc2v3iKSkpiIyMRFRUFIDmNflPnTqFLVu2IDk5WaX/o0s3r1mzBsePH8eXX35JRZ8QQjTAqehbWFhgwYIF+Omnn9r9wk1NTcjPz8fSpUuV2oODg5GXl6fRPuRyOWpra9s8lyAWiyEWixWPa2pqADRPNZVIJBrHK5FIH/q/BBIe03jbrqLl/eDyvnQlxp4fYPw5Un5tb6cJzsM7I0eOREFBAdzd3bluqqSiogIymQyOjo5K7Y6OjigvL9doH5988gnq6uowbdq0VvskJydj1apVKu3Z2dmwtrbWOF6xDGh5u06dyoaleZvduzSRSGToEPTK2PMDjD9Hyk9ZfX29xn05F/2YmBi8+eabuHv3Lnx9fWFjY6P0/JAhQzjt79GrexljbV7x22L//v1ISkrC8ePH21z7Z9myZYiPj1c8rqmpgZubG4KDg2FnZ6dxnNV1jcCl8wCA8eODYS1o1woWnZJEIoFIJEJQUBD4fL6hw9E5Y88PMP4cKT/1WkYwNKFx5Zo7dy5SU1MRHh4OAFi8eLHiOR6PpyjWLbdPfBwHBweYm5urHNXfu3dP5ej/UQcPHkRkZCQ+//xzBAYGttnX0tISlpaWKu18Pp/Tm8rnSx/6Px98vvEV/RZc35uuxtjzA4w/R8pPtb+mNK5cu3btwgcffICioiKNd94WgUAAX19fiEQihIWFKdpFIhEmT57c6nb79+/H3LlzsX//fkyYMEEnsRBCiKnQuOgz1nzisr1j+Q+Lj4/HzJkz4efnB39/f2zfvh3FxcWIjo4G0Dw0U1JSgt27dwNoLvizZs3C+vXrMWrUKMVfCVZWVujevbvO4iKEEGPFaYxCk7F2LsLDw1FZWYnVq1ejrKwMgwcPRlZWluIXS1lZGYqLixX9t23bBqlUioULF2LhwoWK9tmzZyMzM1OnsRFCiDHiVPS9vb0fW/jv37/PKYCYmBjExMSofe7RQv7tt99y2jchhBBlnIr+qlWraBiFEEK6ME5F/5VXXqFbIxJCSBem8YJruh7PJ4QQ0vE0Lvots3cIIYR0XRoP78jlcn3GQYjRY4xBKpVqfAGjNiQSCSwsLNDY2KjX1zEUU86Pz+fD3Lz9678Y72WlhHQiTU1NKCsr47RGijYYY3BycsKdO3eMckjWlPPj8Xjo06cPunXr1q7XoKJPiJ7J5XIUFRXB3NwcLi4uEAgEeitYcrkcDx48QLdu3WBmprMb43UappofYwx//vkn7t69iwEDBrTriJ+KPiF61tTUBLlcDjc3N04ru2pDLpejqakJQqHQaIuiqebXq1cv/P7775BIJO0q+sb3rhHSSRljkSIdR1d/HdJ3ISGEmBAq+oQQYkKo6BNCOJs5cybWrFlj6DCMyjPPPIMjR47o/XWo6BNCOLl+/Tq+/vprvPHGGyrP7du3D+bm5orl0R+WmZkJe3t7tfu0t7dXWWDx7NmzCA0NRc+ePWFtbQ0fHx+89dZbKC0t1UUaajHGkJSUBBcXF1hZWeG5557DjRs32txGIpFg9erV8PLyglAoxNNPP42TJ08q9fHw8ACPx1P5eni14P/7v//D8uXL9X5NFBV9QggnmzZtwtSpU2Fra6vy3M6dO5GYmIgDBw6065qEbdu2ITAwEE5OTjh8+DAKCwuxdetWVFdXY/Pmze0Jv01r165FSkoKNm3ahMuXL8PJyQlBQUGora1tdZu3334b27Ztw8aNG1FYWIjo6GiEhYWhoKBA0efy5csoKytTfLXcA3fq1KmKPhMmTEB1dTVOnz6tt/wAAMzEVFdXMwCsurqa03ZVD+qZ+7++Yu7/+orViSV6is6wmpqa2LFjx1hTU5OhQ9ELQ+XX0NDACgsLWUNDg6JNLpezOrFE51+1DWJW+kcFq20Qt9pHLpdrnYtMJmP29vbsq6++UnmuqKiIWVlZsaqqKjZy5Ei2a9cupeczMjJY9+7d1e63e/fuLCMjgzHG2J07d5hAIGCxsbFqX//3339nMplM6xxaI5fLmZOTE/vggw8UbY2Njax79+5s69atrW7n7OzMNm3apNQ2efJkNmPGjFa3WbJkCfPy8lL5LGbPns3Cw8PV5qfu+6gFl7pG8/QJMYAGiQw+75wyyGsXrh4Pa4F2P/rXr19HVVUV/Pz8VJ7buXMnJkyYgO7du+O1115Deno6Zs2axfk1Pv/8czQ1NSExMVHt820t7x4SEoKcnJw29//gwQO17UVFRSgvL0dwcLCizdLSEmPHjkVeXh7mz5+vdjuxWAyhUKjUZmVlhdzcXLX9m5qa8O9//xvx8fEq0zCfeeYZrF27ts3424uKPiFEY7///jvMzc1VlliXy+XIzMzExo0bATQvwx4fH49ff/0V/fv35/QaN2/ehJ2dHZydnTnHt2PHDjQ0NHDeDoDi9quOjo5K7Y6Ojrh9+3ar240fPx4pKSl49tln4eXlhdOnT+P48eOtrg107NgxVFVVYc6cOSrPubq64u7du5DL5Xq7roOKPiEGYMU3R+Hq8Trfr1wuR21NLWztbFstGlZ87a/mbGhogKWlpcoRanZ2Nurq6hASEgIAcHBwQHBwMHbu3Ml5lg9jTOsLkVxdXbXa7mGPvvbj4lm/fj3mzZuHgQMHgsfjwcvLCxEREcjIyFDbPz09HSEhIXBxcVF5zsrKCnK5HGKxGBYW+inPVPQJMQAej6f1EEtb5HI5pAJzWAss9HKk6ODggPr6ejQ1NUEgECjad+7cifv37ystMyGXy1FQUIB3330X5ubmsLOzw4MHDyCTyZSWEZDJZHjw4IFi2Mbb2xvV1dUoKyvjfLTfnuEdJycnAM1H/A+/7r1791SO/h/Wq1cvHDt2DI2NjaisrISLiwuWLl0KT09Plb63b9/GN9980+rUzJb30MrKqs0c2oNm7xBCNDZ06FAAQGFhoaKtsrISx48fx4EDB3Dt2jWlrwcPHuDEiRMAgIEDB0ImkynNagGAq1evQiaT4YknngAATJkyBQKBoNWx7erq6lbj27Fjh0oMj361xtPTE05OToqZNUDz+Pu5c+cQEBDQ5vsCAEKhEK6urpBKpTh8+DAmT56s0icjIwO9e/fGhAkT1O7jxo0bGDJkyGNfqz3oSF9DdA8ZQpqPaocPH47c3FzFL4A9e/agZ8+emDp1qspfFy+99BLS09Px0ksvwcfHByEhIZg7dy5SUlLg5eWF3377DfHx8QgJCYGPjw8AwM3NDevWrcOiRYtQU1ODWbNmwcPDA3fv3sWuXbsgEAiwYcMGtfG1Z3iHx+MhNjYWa9aswYABAzBgwACsWbMG1tbWmD59uqLfrFmz4OrqiuTkZADA999/j5KSEgwdOhQlJSVISkqCXC5XOREtl8uRkZGB2bNntzp0k5ubi3HjxmmdgyboSF8DjDG8uuOyocMgpFN4/fXXsXfvXsXjnTt3IiwsTO1w0ssvv4yvvvoKf/zxBwDgwIEDCAwMxIIFC+Dj44MFCxbghRdewP79+5W2i4mJQXZ2NkpKShAWFoaBAwciKioKdnZ2WLRokd5yS0xMRGxsLGJiYuDn54eSkhJkZ2crXZNQXFyMsrIyxePGxka8/fbb8PHxQVhYGFxdXZGbm6tyIdo333yD4uJizJ07V+1rl5SUIC8vT+kXjD7wGDOtY9iamhp0794d1dXVsLOz02ib+iapYnrdICdbZC0ZY5Q3cJBIJMjKykJoaCj4fL6hw9E5Q+XX2NiIoqIieHp6qkzt0zW5XI6amhrY2dnpbfZHY2MjnnjiCRw4cAD+/v56eY3WdER+hpKQkICqqip89NFHavNr6/uIS12j4R2O9kc9Y5QFnxBNCYVC7N69GxUVFYYOxaj07t0b8fHxen8dg/+qTEtLU/zm8vX1feyZ93PnzsHX1xdCoRD9+vXD1q1bOyjSZlTvCQHGjh2LiRMnGjoMo5KQkNDmLCFdMWjRP3jwIGJjY7FixQoUFBRgzJgxCAkJQXFxsdr+RUVFCA0NxZgxY1BQUIDly5dj8eLFOHz4cAdHTgghXZNBi35KSgoiIyMRFRWFQYMGITU1FW5ubtiyZYva/lu3bkXfvn2RmpqKQYMGISoqCnPnzsXHH3/cwZETQkjXZLAx/aamJuTn52Pp0qVK7cHBwcjLy1O7zcWLF5XWxQCaL4FOT0+HRCJRe3JOLBZDLBYrHtfU1ABoPqknkUg0ilUikSr9X9PtupqWvCg/3ZJKpWCMQSaT6X3Z3JZ5GYwxvb+WIZhyfjKZDIwxSKWqNYjL97TBin5FRQVkMpnadS5a1sB4VHl5udr+UqkUFRUVaq/eS05OxqpVq1Tas7OzNb5JtVgGtLxVZ86cgaX2V7F3CQ9fnGKMOjo/Ho8HZ2dn3L9/X+1yxPrQ1lLAxsAU86uvr0d9fT3Onj2r8guByzLWBp+9w3WdC3X91bW3WLZsmdIZ8ZqaGri5uSE4OFjjKZuMMYwbJ8aZM2cwYXyg0uXnxkQikUAkEiEoKMhop2waKr8//vgDNTU1EAqFsLa21tsMMMYY6urqYGNjY5SzzEw1P7lcjrq6OvTs2RNDhgxRyb1lBEMTBiv6Dg4OMDc3Vzmqb2udCycnJ7X9LSws0LNnT7XbWFpawtLSUqWdz+dz+sHvzuPB0hwQCARGWRAfxvW96WoMkZ+rqyvMzc31Ps2RMYaGhgZYWVkZbVE01fzMzMzg6uqq9qCTy/ezwYq+QCCAr68vRCIRwsLCFO0ikUjtmhUA4O/vjy+//FKpLTs7G35+fkZdpEjX1zLE07t3b72eU5BIJDh//jyeffZZo/yZMOX8BAKBTi5IM+jwTnx8PGbOnAk/Pz/4+/tj+/btKC4uVtxfc9myZSgpKcHu3bsBANHR0di0aRPi4+Mxb948XLx4Eenp6SqXcBPSWZmbmyutMKmP/UulUgiFQqMsipRf+xm06IeHh6OyshKrV69GWVkZBg8ejKysLLi7uwMAysrKlObse3p6IisrC3Fxcdi8eTNcXFywYcMGvPzyy4ZKgRBCuhSDn8iNiYlBTEyM2ucyMzNV2saOHYurV6/qOSpCCDFOBl+GgRBCSMcx+JF+R2uZ4sllihPQfIKlvr4eNTU1RjmWCBh/jsaeH2D8OVJ+6rXUM00WTTa5ot9y0YObm5uBIyGEEN2qra1V3HayNSa3nr5cLkdpaSlsbW05zfNtuajrzp07Gl/U1dUYe47Gnh9g/DlSfuoxxlBbWwsXF5fHTus0uSN9MzMz9OnTR+vt7ezsjPKb7WHGnqOx5wcYf46Un6rHHeG3oBO5hBBiQqjoE0KICaGiryFLS0usXLlS7To+xsLYczT2/ADjz5Hyaz+TO5FLCCGmjI70CSHEhFDRJ4QQE0JFnxBCTAgVfUIIMSFU9B+SlpYGT09PCIVC+Pr6Iicnp83+586dg6+vL4RCIfr164etW7d2UKTa45LjkSNHEBQUhF69esHOzg7+/v44depUB0bLHdfPsMWFCxdgYWGBoUOH6jfAduKan1gsxooVK+Du7g5LS0t4eXlh586dHRStdrjmuHfvXjz99NOwtraGs7MzIiIiUFlZ2UHRcnP+/HlMnDgRLi4u4PF4OHbs2GO30XmdYYQxxtiBAwcYn89nn376KSssLGRLlixhNjY27Pbt22r737p1i1lbW7MlS5awwsJC9umnnzI+n88OHTrUwZFrjmuOS5YsYR9++CG7dOkS++WXX9iyZcsYn89nV69e7eDINcM1vxZVVVWsX79+LDg4mD399NMdE6wWtMlv0qRJbOTIkUwkErGioiL2/fffswsXLnRg1NxwzTEnJ4eZmZmx9evXs1u3brGcnBz25JNPsn/84x8dHLlmsrKy2IoVK9jhw4cZAHb06NE2++ujzlDR//9GjBjBoqOjldoGDhzIli5dqrZ/YmIiGzhwoFLb/Pnz2ahRo/QWY3txzVEdHx8ftmrVKl2HphPa5hceHs7efvtttnLlyk5d9Lnmd+LECda9e3dWWVnZEeHpBNccP/roI9avXz+ltg0bNrA+ffroLUZd0aTo66PO0PAOgKamJuTn5yM4OFipPTg4GHl5eWq3uXjxokr/8ePH48qVK3q9B6q2tMnxUXK5HLW1tejRo4c+QmwXbfPLyMjAb7/9hpUrV+o7xHbRJr8vvvgCfn5+WLt2LVxdXeHt7Y233noLDQ0NHREyZ9rkGBAQgLt37yIrKwuMMfzxxx84dOgQJkyY0BEh650+6ozJLbimTkVFBWQyGRwdHZXaHR0dUV5ernab8vJytf2lUikqKirg7Oyst3i1oU2Oj/rkk09QV1eHadOm6SPEdtEmv5s3b2Lp0qXIycmBhUXn/lHQJr9bt24hNzcXQqEQR48eRUVFBWJiYnD//v1OOa6vTY4BAQHYu3cvwsPD0djYCKlUikmTJmHjxo0dEbLe6aPO0JH+Qx5dapkx1ubyy+r6q2vvTLjm2GL//v1ISkrCwYMH0bt3b32F126a5ieTyTB9+nSsWrUK3t7eHRVeu3H5/ORyOXg8Hvbu3YsRI0YgNDQUKSkpyMzM7LRH+wC3HAsLC7F48WK88847yM/Px8mTJ1FUVITo6OiOCLVD6LrOdO7Dmw7i4OAAc3NzlaOJe/fuqfyWbeHk5KS2v4WFBXr27Km3WLWlTY4tDh48iMjISHz++ecIDAzUZ5ha45pfbW0trly5goKCAixatAhAc5FkjMHCwgLZ2dkYN25ch8SuCW0+P2dnZ7i6uiotuTto0CAwxnD37l0MGDBArzFzpU2OycnJGD16NBISEgAAQ4YMgY2NDcaMGYP33nuv0/3FzZU+6gwd6QMQCATw9fWFSCRSaheJRAgICFC7jb+/v0r/7Oxs+Pn5dcrbuGmTI9B8hD9nzhzs27evU4+Tcs3Pzs4OP/zwA65du6b4io6OxhNPPIFr165h5MiRHRW6RrT5/EaPHo3S0lI8ePBA0fbLL7+0+54S+qJNjvX19So3DTE3Nweg2a0DOzu91BmtTwEbmZapYunp6aywsJDFxsYyGxsb9vvvvzPGGFu6dCmbOXOmon/LVKq4uDhWWFjI0tPTu8yUTU1z3LdvH7OwsGCbN29mZWVliq+qqipDpdAmrvk9qrPP3uGaX21tLevTpw+bMmUKu3HjBjt37hwbMGAAi4qKMlQKj8U1x4yMDGZhYcHS0tLYb7/9xnJzc5mfnx8bMWKEoVJoU21tLSsoKGAFBQUMAEtJSWEFBQWKKakdUWeo6D9k8+bNzN3dnQkEAjZ8+HB27tw5xXOzZ89mY8eOVer/7bffsmHDhjGBQMA8PDzYli1bOjhi7rjkOHbsWAZA5Wv27NkdH7iGuH6GD+vsRZ8x7vn99NNPLDAwkFlZWbE+ffqw+Ph4Vl9f38FRc8M1xw0bNjAfHx9mZWXFnJ2d2YwZM9jdu3c7OGrNnD17ts2fqY6oM7S0MiGEmBAa0yeEEBNCRZ8QQkwIFX1CCDEhVPQJIcSEUNEnhBATQkWfEEJMCBV9QggxIVT0CSHEhFDRJ51aZmYm7O3tDR2G1jw8PJCamtpmn6SkpE5/m0ZiPKjoE72bM2cOeDyeytevv/5q6NCQmZmpFJOzszOmTZuGoqIinez/8uXLeP311xWP1d0X9a233sLp06d18nqteTRPR0dHTJw4ETdu3OC8n678S5hQ0Scd5MUXX0RZWZnSl6enp6HDAtC84mZZWRlKS0uxb98+XLt2DZMmTYJMJmv3vnv16gVra+s2+3Tr1q1DluN+OM+vv/4adXV1mDBhApqamvT+2qTzoKJPOoSlpSWcnJyUvszNzZGSkoKnnnoKNjY2cHNzQ0xMjNJSwI/6z3/+g+effx62traws7ODr68vrly5ong+Ly8Pzz77LKysrODm5obFixejrq6uzdh4PB6cnJzg7OyM559/HitXrsSPP/6o+Etky5Yt8PLygkAgwBNPPIE9e/YobZ+UlIS+ffvC0tISLi4uWLx4seK5h4d3PDw8AABhYWHg8XiKxw8P75w6dQpCoRBVVVVKr7F48WKMHTtWZ3n6+fkhLi4Ot2/fxs8//6zo09bn8e233yIiIgLV1dWKvxiSkpIANN/qMDExEa6urrCxscHIkSPx7bffthkPMQwq+sSgzMzMsGHDBvz444/YtWsXzpw5g8TExFb7z5gxA3369MHly5eRn5+PpUuXKtYV/+GHHzB+/Hj885//xPXr13Hw4EHk5uYqbpKiKSsrKwCARCLB0aNHsWTJErz55pv48ccfMX/+fERERODs2bMAgEOHDmHdunXYtm0bbt68iWPHjuGpp55Su9/Lly8DaL4vb1lZmeLxwwIDA2Fvb4/Dhw8r2mQyGT777DPMmDFDZ3lWVVVh3759AKC0Lntbn0dAQABSU1MVfzGUlZXhrbfeAgBERETgwoULOHDgAK5fv46pU6fixRdfxM2bNzWOiXSQdq3RSYgGZs+ezczNzZmNjY3ia8qUKWr7fvbZZ6xnz56KxxkZGax79+6Kx7a2tiwzM1PttjNnzmSvv/66UltOTg4zMzNjDQ0Nard5dP937txho0aNYn369GFisZgFBASwefPmKW0zdepUFhoayhhj7JNPPmHe3t6sqalJ7f7d3d3ZunXrFI8BsKNHjyr1eXRJ58WLF7Nx48YpHp86dYoJBAJ2//79duUJgNnY2DBra2vFkr6TJk1S27/F4z4Pxhj79ddfGY/HYyUlJUrtL7zwAlu2bFmb+ycdj26XSDrE888/jy1btige29jYAADOnj2LNWvWoLCwEDU1NZBKpWhsbERdXZ2iz8Pi4+MRFRWFPXv2IDAwEFOnToWXlxcAID8/H7/++iv27t2r6M8Yg1wuR1FREQYNGqQ2turqanTr1g2MMdTX12P48OE4cuQIBAIBfvrpJ6UTsUDzHanWr18PAJg6dSpSU1PRr18/vPjiiwgNDcXEiRPbdaP1GTNmwN/fH6WlpXBxccHevXsRGhqKv/3tb+3K09bWFlevXoVUKsW5c+fw0UcfYevWrUp9uH4eAHD16lUwxlTuNSwWizvlrUNNHRV90iFsbGzQv39/pbbbt28jNDQU0dHRePfdd9GjRw/k5uYiMjISEolE7X6SkpIwffp0fP311zhx4gRWrlyJAwcOICwsDHK5HPPnz1caU2/Rt2/fVmNrKYZmZmZwdHRUKW5t3ajbzc0NP//8M0QiEb755hvExMTgo48+wrlz57S+nd2IESPg5eWFAwcOYMGCBTh69CgyMjIUz2ubp5mZmeIzGDhwIMrLyxEeHo7z588D0O7zaInH3Nwc+fn5ilsVtujWrRun3In+UdEnBnPlyhVIpVJ88sknivucfvbZZ4/dztvbG97e3oiLi8Orr76KjIwMhIWFYfjw4bhx44bKL5fHebgYPmrQoEHIzc3FrFmzFG15eXlKR9NWVlaYNGkSJk2ahIULF2LgwIH44YcfMHz4cJX98fl8jWYFTZ8+HXv37kWfPn1gZmamdH9ibfN8VFxcHFJSUnD06FGEhYVp9HkIBAKV+IcNGwaZTIZ79+5hzJgx7YqJ6B+dyCUG4+XlBalUio0bN+LWrVvYs2ePynDDwxoaGrBo0SJ8++23uH37Ni5cuIDLly8rCvC//vUvXLx4EQsXLsS1a9dw8+ZNfPHFF3jjjTe0jjEhIQGZmZnYunUrbt68iZSUFBw5ckRxAjMzMxPp6en48ccfFTlYWVnB3d1d7f48PDxw+vRplJeX46+//mr1dWfMmIGrV6/i/fffx5QpUyAUChXP6SpPOzs7REVFYeXKlWCMafR5eHh44MGDBzh9+jQqKipQX18Pb29vzJgxA7NmzcKRI0dQVFSEy5cv48MPP0RWVhanmEgHMOQJBWIaZs+ezSZPnqz2uZSUFObs7MysrKzY+PHj2e7duxkA9tdffzHGlE8cisVi9sorrzA3NzcmEAiYi4sLW7RokdLJy0uXLrGgoCDWrVs3ZmNjw4YMGcLef//9VmNTd2LyUWlpaaxfv36Mz+czb29vtnv3bsVzR48eZSNHjmR2dnbMxsaGjRo1in3zzTeK5x89kfvFF1+w/v37MwsLC+bu7s4Ya/3evM888wwDwM6cOaPynK7yvH37NrOwsGAHDx5kjD3+82CMsejoaNazZ08GgK1cuZIxxlhTUxN75513mIeHB+Pz+czJyYmFhYWx69evtxoTMQy6Ry4hhJgQGt4hhBATQkWfEEJMCBV9QggxIVT0CSHEhFDRJ4QQE0JFnxBCTAgVfUIIMSFU9AkhxIRQ0SeEEBNCRZ8QQkwIFX1CCDEh/w+xuYvO6SRo3QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 400x250 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "print(              blob_path + run_prefix + 'filtered_blob_stats_tagged.pkl')\n",
     "plot_roc_blob_stats(blob_path + run_prefix + 'filtered_blob_stats_tagged.pkl')\n",


### PR DESCRIPTION
I updated the PTP1B notebook to 
- take advantage of the numerical scaling (slight boost in peak heights)
- make other adjustments to the pipeline--in particular switching which phases are used for `/n/hekstra_lab/people/minhuan/projects/drug/minhuan_backup/pipeline/data/refined/`
- I updated the AUC calculation to take into account the dataset exclusions made by Keedy and Ginn in https://www.biorxiv.org/content/10.1101/2024.01.05.574428v1
- I fixed an error in referencing the reference MTZ in the file_list--after filtering the relevant dataframe index needed to be updated.