### PR TITLE
version attribute for valdo

### DIFF
--- a/valdo/__init__.py
+++ b/valdo/__init__.py
@@ -1,3 +1,10 @@
+def getVersionNumber():
+    import pkg_resources
+    version = pkg_resources.require("rs-valdo")[0].version
+    return version
+
+__version__ = getVersionNumber()
+
 # Top level API
 from .scaling import Scaler, Scaler_pool
 from .vae_networks import VAE


### PR DESCRIPTION
As a response to #21.  Now users can call

```
import valdo 

valdo.__version__
```