### PR TITLE
Tackle the dropnan issue and the copying rfree flag issue

### DIFF
--- a/notebooks/pipeline.ipynb
+++ b/notebooks/pipeline.ipynb
@@ -3260,7 +3260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "id": "61c46eda-4cdc-41a8-9999-fef2dc9dd207",
    "metadata": {
     "scrolled": true
@@ -3285,6 +3285,7 @@
    ],
    "source": [
     "%%time\n",
+    "rfree_in_label = None # e.g. 'R-free-flags' if you want to copy Rfree flags from the phasing mtz to the output mtz\n",
     "if ncpu > 1:\n",
     "    no_phases_files = valdo.helper.add_phases_pool(\n",
     "        file_list, \n",
@@ -3294,6 +3295,7 @@
     "        phase_2FOFC_col_in =phase_2FOFC_col_in,  phase_FOFC_col_in =phase_FOFC_col_in,\n",
     "        prefix=run_prefix, \n",
     "        parser=apo_phases_parser,\n",
+    "        rfree_label_in=rfree_in_label,\n",
     "        ncpu=ncpu)\n",
     "    print(\"Done. No phases found for \" + str(len(no_phases_files)) + \" starting MTZs.\")\n",
     "else:\n",
@@ -3303,7 +3305,8 @@
     "        vae_reconstructed_with_phases_path, \n",
     "        phase_2FOFC_col_out=phase_2FOFC_col_out, phase_FOFC_col_out=phase_FOFC_col_out,\n",
     "        phase_2FOFC_col_in =phase_2FOFC_col_in,  phase_FOFC_col_in =phase_FOFC_col_in,\n",
-    "        parser=apo_phases_parser\n",
+    "        parser=apo_phases_parser,\n",
+    "        rfree_label_in=rfree_in_label,\n",
     "    )\n",
     "    print(\"Done. No phases found for \" + str(len(no_phases_files)) + \" starting MTZs.\")"
    ]

--- a/notebooks/pipeline.ipynb
+++ b/notebooks/pipeline.ipynb
@@ -404,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "c2574860-1cb6-4935-b0d9-1433a20e8852",
    "metadata": {},
    "outputs": [
@@ -424,7 +424,8 @@
     "%%time\n",
     "new_mtzs=valdo.helper.standardize_input_mtzs(source_path=original_data_path, \n",
     "                       destination_path=input_mtz_path, \n",
-    "                       mtz_file_pattern=mtz_file_pattern, \n",
+    "                       mtz_file_pattern=mtz_file_pattern,\n",
+    "                       expcolumns=[amplitude_col, error_col], \n",
     "                       ncpu=ncpu)\n",
     "print(\"\\nCreated \" + str(len(new_mtzs)) + \" standardized MTZ files using the following pattern:\" + mtz_file_pattern + \".\")"
    ]

--- a/valdo/helper.py
+++ b/valdo/helper.py
@@ -123,7 +123,9 @@ def standardize_input_mtzs(source_path, destination_path, mtz_file_pattern, ncpu
     return result
  
 
-def add_phases(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, phase_2FOFC_col_out='PH2FOFCWT', phase_FOFC_col_out='PHFOFCWT',phase_2FOFC_col_in='PH2FOFCWT', phase_FOFC_col_in='PHFOFCWT',parser=None):
+def add_phases(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, 
+               phase_2FOFC_col_out='PH2FOFCWT', phase_FOFC_col_out='PHFOFCWT',phase_2FOFC_col_in='PH2FOFCWT', phase_FOFC_col_in='PHFOFCWT',
+               parser=None, rfree_label_in=None):
     """
     Add phases from apo models refined against the data (or otherwise) to the corresponding files in file_list and 
     write the resulting MTZ to vae_reconstructed_with_phases_path. Filenames in the file_list and the "apo" MTZs should match (e.g., ####.mtz)
@@ -138,6 +140,7 @@ def add_phases(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, pha
             phase_FOFC_col_in (str)  : *input* MTZ column name for  Fo-Fc phases
             parser (function name) : parser that maps input MTZs to names of MTZ files containing apo phases (default: None)
                                      see pipeline notebook for examples.
+            rfree_label_in (None or str)  : *input* MTZ column name for Rfree flags
 
         Returns:
             list of input files for which no matching file with phases could be found.
@@ -151,6 +154,13 @@ def add_phases(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, pha
         mtz, handler = find_phase_file(file, apo_mtzs_path, parser)
         if handler > 0:
             phases_df = rs.read_mtz(mtz)
+            
+            # add Rfree from phase mtz to reconstructed mtz, if not existing, generate rfree flags
+            try:
+                current = rs.utils.copy_rfree(current, phases_df, rfree_key=rfree_label_in)
+            except:
+                current = rs.utils.add_rfree(current)
+            
             try:    
                 current[phase_2FOFC_col_out] = phases_df[phase_2FOFC_col_in]
                 current[phase_FOFC_col_out]  = phases_df[phase_FOFC_col_in]
@@ -309,6 +319,7 @@ def add_phases_from_pool_map(file, additional_args):
     phase_2FOFC_col_in                 = additional_args[4]
     phase_FOFC_col_in                  = additional_args[5]
     parser                             = additional_args[6]
+    rfree_label_in                     = additional_args[7]
     
     current = rs.read_mtz(file)
     success=False
@@ -316,6 +327,13 @@ def add_phases_from_pool_map(file, additional_args):
     mtz, handler = find_phase_file(file, apo_mtzs_path, parser)
     if handler > 0:
         phases_df = rs.read_mtz(mtz)
+
+        # add Rfree from phase mtz to reconstructed mtz, if not existing, generate rfree flags
+        try:
+            current = rs.utils.copy_rfree(current, phases_df, rfree_key=rfree_label_in)
+        except:
+            current = rs.utils.add_rfree(current)
+            
         try:    
             current[phase_2FOFC_col_out] = phases_df[phase_2FOFC_col_in]
             current[phase_FOFC_col_out]  = phases_df[phase_FOFC_col_in]
@@ -334,7 +352,7 @@ def add_phases_from_pool_map(file, additional_args):
     return [file, success]
 
 
-def add_phases_pool(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, phase_2FOFC_col_out='PH2FOFCWT', phase_FOFC_col_out='PHFOFCWT',phase_2FOFC_col_in='PH2FOFCWT', phase_FOFC_col_in='PHFOFCWT',prefix=None, parser=None, ncpu=None):
+def add_phases_pool(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path, phase_2FOFC_col_out='PH2FOFCWT', phase_FOFC_col_out='PHFOFCWT',phase_2FOFC_col_in='PH2FOFCWT', phase_FOFC_col_in='PHFOFCWT', prefix=None, parser=None, ncpu=None, rfree_label_in=None):
     """
     Add phases from apo models refined against the data (or otherwise) to the corresponding files in file_list and 
     write the resulting MTZ to vae_reconstructed_with_phases_path. Filenames in the file_list and the "apo" MTZs should match (e.g., ####.mtz)
@@ -350,12 +368,13 @@ def add_phases_pool(file_list, apo_mtzs_path, vae_reconstructed_with_phases_path
             phase_FOFC_col_in (str)  : *input* MTZ column name for  Fo-Fc phases
             prefix (str) : prefix to add to pickle file report.
             ncpu (int) : Number of CPUs available
+            rfree_label_in (None or str)  : *input* MTZ column name for Rfree flags
 
         Returns:
             a dataframe reporting for each dataset whether phases were successfully added.
     """
 
-    additional_args=[apo_mtzs_path, vae_reconstructed_with_phases_path, phase_2FOFC_col_out, phase_FOFC_col_out,phase_2FOFC_col_in, phase_FOFC_col_in,parser]
+    additional_args=[apo_mtzs_path, vae_reconstructed_with_phases_path, phase_2FOFC_col_out, phase_FOFC_col_out, phase_2FOFC_col_in, phase_FOFC_col_in, parser, rfree_label_in]
     input_args = zip(file_list, repeat(additional_args))
     with Pool(ncpu) as pool:
         metrics = pool.starmap(add_phases_from_pool_map, tqdm(input_args, total=len(file_list)))


### PR DESCRIPTION
This pull request enhances the pipeline for processing MTZ files by improving how experimental columns and Rfree flags are handled during data standardization and phase addition. The changes make the workflow more robust and flexible, particularly for downstream crystallographic analysis.

**Enhancements to MTZ file processing:**

*Standardization improvements:*
- The `standardize_input_mtzs` function and its usage now accept an explicit `expcolumns` argument, ensuring that only rows with valid experimental data (e.g., amplitudes and errors) are retained, which helps avoid downstream issues with NaN values. (`valdo/helper.py`, `notebooks/pipeline.ipynb`) [[1]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917R68) [[2]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917L82-R95) [[3]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917L113-R113) [[4]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R428)

*Phase addition improvements:*
- The `add_phases`, `add_phases_pool`, and related functions now accept an optional `rfree_label_in` parameter, allowing the pipeline to copy Rfree flags from phase MTZ files to reconstructed MTZs. If Rfree flags are missing, they are generated automatically, improving compatibility with refinement software. (`valdo/helper.py`, `notebooks/pipeline.ipynb`) [[1]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917L126-R128) [[2]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917R143) [[3]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917R157-R163) [[4]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917R322-R336) [[5]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917L337-R355) [[6]](diffhunk://#diff-4fd166a66c7d4c9c4cdcec9087a3997fc5b46a5efce05fa8d2e4c4306bf7a917R371-R377) [[7]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R3288) [[8]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R3298) [[9]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9L3305-R3309)

*Notebook usability:*
- Updated the pipeline notebook to pass the new arguments for experimental columns and Rfree flags, aligning the example workflow with the improved helper functions. (`notebooks/pipeline.ipynb`) [[1]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R428) [[2]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R3288) [[3]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9R3298) [[4]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9L3305-R3309)

*General maintenance:*
- Cleared cell execution counts in the notebook to improve reproducibility and reduce confusion when sharing or re-running the notebook. (`notebooks/pipeline.ipynb`) [[1]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9L407-R407) [[2]](diffhunk://#diff-27a7475e422de80d24fbe954ebba70031d05cfd3affc97c9ee23b8389a99d5d9L3262-R3263)